### PR TITLE
Add persona display to status bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,11 @@ Switch personas by reading the relevant file and following its instructions, inc
 
 To switch: *"Switch to the Architect persona"* or reference the file directly.
 
+When switching to a persona, write the character name to `~/.claude/current-persona` so the status bar reflects it. Example:
+```
+echo "Professor Frink" > ~/.claude/current-persona
+```
+
 ## Project Structure
 ```
 BpMonitor.slnx

--- a/docs/personas/status-bar-comic-book-guy.md
+++ b/docs/personas/status-bar-comic-book-guy.md
@@ -29,4 +29,4 @@ Claude Sonnet 4.6 | v1.0.71 | ctx: 12% used / 88% left | in:24000 out:850 cache-
 ```
 
 ## Customization
-To adjust the status bar, ask Claude to invoke the `statusline-setup` agent.
+To adjust the status bar, ask Claude to invoke the `statusline-setup` agent


### PR DESCRIPTION
## Summary
- Status bar now shows the active persona (from `~/.claude/current-persona`) in magenta
- Document persona switching convention in `CLAUDE.md`: write persona name to `~/.claude/current-persona` on switch

## Test plan
- [ ] Switch persona and verify status bar updates accordingly
- [ ] Verify status bar shows nothing when `~/.claude/current-persona` is absent or empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)