### PR TITLE
🔧 Add markdownlint-cli2 config

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,3 @@
+config:
+  MD022: false
+  MD032: false


### PR DESCRIPTION
## Summary
- Add `.markdownlint-cli2.yaml` to root
- Disables MD022 (headings surrounded by blank lines) and MD032 (lists surrounded by blank lines)

## Test plan
- [ ] Verify markdownlint-cli2 runs without MD022/MD032 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)