### PR TITLE
⬆️ Update NuGet test packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,10 +26,10 @@
   </ItemGroup>
 
   <ItemGroup Label="Test - xunit">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.1.0" />
-    <PackageVersion Include="xunit.v3" Version="1.1.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.3.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Updates all outdated test packages:

| Package | From | To |
|---|---|---|
| coverlet.collector | 6.0.4 | 8.0.0 |
| Microsoft.Extensions.TimeProvider.Testing | 9.1.0 | 10.3.0 |
| Microsoft.NET.Test.Sdk | 17.14.1 | 18.3.0 |
| xunit.runner.visualstudio | 3.1.4 | 3.1.5 |
| xunit.v3 | 1.1.0 | 3.2.2 |

All 22 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)