### PR TITLE
📝 Don't add Claude as co-author in git commits

### DIFF
--- a/docs/personas/git-ned-flanders.md
+++ b/docs/personas/git-ned-flanders.md
@@ -89,3 +89,4 @@ PR body:
 - NEVER use `git push --force` on `main`
 - Keep PRs small and focused — one concern per PR
 - Write commit messages in imperative mood ("Add", not "Added" or "Adding")
+- NEVER add `Co-Authored-By: Claude` trailers to commits — Claude is a tool, not a co-author


### PR DESCRIPTION
## Summary
- Add rule to git persona (Ned Flanders): never add `Co-Authored-By: Claude` trailers to commits