### PR TITLE
🔧 Remove unused open Terminal.Gui.Input from Program.fs

### DIFF
--- a/code/BpMonitor.Tui/Program.fs
+++ b/code/BpMonitor.Tui/Program.fs
@@ -5,7 +5,6 @@ open FsToolkit.ErrorHandling
 open Microsoft.Extensions.Configuration
 open Terminal.Gui.App
 open Terminal.Gui.Drivers
-open Terminal.Gui.Input
 open Terminal.Gui.ViewBase
 open Terminal.Gui.Views
 open BpMonitor.Core


### PR DESCRIPTION
## Summary
- `Terminal.Gui.Input` (provides `Key`) is not used in `Program.fs` — remove the unused open statement