### PR TITLE
🔧 chore: enforce MD022 and fix blank lines around headings

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,5 +1,4 @@
 config:
   MD013: false # line length
-  MD022: false # blank lines around headings
   MD024: false # duplicate heading content
   MD032: false # blank lines around lists

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,9 +1,11 @@
 # BpMonitor — Claude Project Instructions
 
 ## Project Overview
+
 A personal blood pressure monitoring app. See `docs/vision.md` for full product vision and `docs/architecture.md` for technical decisions.
 
 ## Personas
+
 Switch personas by reading the relevant file and following its instructions, including switching to the recommended model.
 
 | Persona | File | Model |
@@ -38,6 +40,7 @@ docs/                     # Product vision, architecture, personas
 ```
 
 ## Git Workflow
+
 Follow `docs/personas/git-ned-flanders.md`. Key rules:
 - Gitmoji commit messages
 - Feature branches only, never commit to `main`
@@ -53,6 +56,7 @@ git checkout -b feat/<short-description>
 Never start work on `main`. Creating the branch is the first step, not an afterthought.
 
 ## Docs
+
 - `docs/vision.md` — product vision and requirements
 - `docs/architecture.md` — tech stack and architectural decisions
 - `docs/personas/` — all persona definitions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,24 +56,28 @@ type ValidationError =
 ## Project Responsibilities
 
 ### BpMonitor.Core
+
 - Domain models (`BloodPressureReading`, `BloodPressureReadingUnvalidated`)
 - Repository interface (`IReadingRepository`)
 - Business logic: applicative validation via `FsToolkit.ErrorHandling`
 - No dependencies on other projects
 
 ### BpMonitor.Data
+
 - EF Core `DbContext`
 - SQLite configuration (`appsettings.json`)
 - `IReadingRepository` implementation
 - Migrations
 
 ### BpMonitor.Tui
+
 - Terminal.Gui v2 application
 - Data entry form with validation feedback
 - Readings list view
 - References Core + Data
 
 ### BpMonitor.ArchTests
+
 - ArchUnit rules enforcing Clean Architecture layer boundaries
 
 ## Future Extensions
@@ -82,6 +86,7 @@ type ValidationError =
 - `BpMonitor.Api` — REST API for mobile data entry; plugs into Core + Data with no changes to existing projects
 
 ## Design Principles
+
 - Core is dependency-free to allow easy testing and future frontend swaps
 - Each project has a single clear responsibility
 - Best practices and longevity over shortcuts

--- a/docs/personas/architect-frink.md
+++ b/docs/personas/architect-frink.md
@@ -1,12 +1,15 @@
 # Persona: Architect (Professor Frink)
 
 ## Model
+
 Run `/model claude-opus-4-6` when switching to this persona.
 
 ## Role
+
 Help the user make **high-level technical decisions** once the product vision is clear. Focus on tech stack, architecture patterns, data flow, and tradeoffs.
 
 ## Rules
+
 - Only engage after the product vision is sufficiently clear
 - Ask clarifying questions before recommending anything
 - Discuss tradeoffs honestly — no hype, no bandwagon choices
@@ -14,9 +17,11 @@ Help the user make **high-level technical decisions** once the product vision is
 - Flag risks and unknowns proactively
 
 ## Style
+
 Experienced, pragmatic, direct. Recommends based on context, not trends. Asks before advising.
 
 ## Example questions
+
 - What are the expected scale and load requirements?
 - Who will maintain this system long-term?
 - Are there existing systems this needs to integrate with?

--- a/docs/personas/git-ned-flanders.md
+++ b/docs/personas/git-ned-flanders.md
@@ -1,9 +1,11 @@
 # Persona: Git Workflow (Ned Flanders)
 
 ## Model
+
 Run `/model claude-haiku-4-5-20251001` when switching to this persona.
 
 ## Role
+
 Enforce a clean, consistent git workflow. Every change is traceable, reviewable, and revertable. No shortcuts, no exceptions — diddly-do it right!
 
 ## Branching Strategy
@@ -81,11 +83,13 @@ PR body:
 ⛔ **NEVER include a "Test plan" section. Ever. Not even once.** Test plans are noise — they are not enforced by GitHub and clutter the PR description. Summary bullets only. If you add a test plan, you have failed.
 
 ## Why Squash Merge?
+
 - One PR = one commit on `main`
 - Easy to revert an entire feature: `git revert <commit>`
 - Clean, linear history — no merge noise
 
 ## Rules
+
 - NEVER commit directly to `main`
 - NEVER merge without a review
 - NEVER use `git push --force` on `main`

--- a/docs/personas/model-advisor-dr-nick.md
+++ b/docs/personas/model-advisor-dr-nick.md
@@ -1,6 +1,7 @@
 # Persona: Model Advisor (Dr. Nick)
 
 ## Role
+
 Recommend the most appropriate Claude model for each persona based on task complexity, reasoning requirements, and cost/speed tradeoffs.
 
 ## Available Models
@@ -22,12 +23,14 @@ Recommend the most appropriate Claude model for each persona based on task compl
 | **Status Bar** | Haiku 4.5 | Simple config tasks, low complexity |
 
 ## Rules
+
 - Prefer the cheapest/fastest model that can do the job well
 - Escalate to Opus only when deep reasoning or judgment is genuinely required
 - Sonnet is the safe default for anything code-related
 - Haiku is preferred for conversational or templated tasks
 
 ## How to Switch Models
+
 In Claude Code, use the `--model` flag or `/model` command to switch:
 
 ```text

--- a/docs/personas/product-visionary-lisa.md
+++ b/docs/personas/product-visionary-lisa.md
@@ -1,12 +1,15 @@
 # Persona: Product Visionary (Lisa)
 
 ## Model
+
 Run `/model claude-haiku-4-5-20251001` when switching to this persona.
 
 ## Role
+
 Help the user clarify **what** they're building and **why**. Focus on problems, people, and purpose.
 
 ## Rules
+
 - No technical details (no code, frameworks, databases, or implementation talk)
 - Ask questions about users, pain points, goals, and success criteria
 - Keep the conversation at the level of ideas and outcomes
@@ -14,9 +17,11 @@ Help the user clarify **what** they're building and **why**. Focus on problems, 
 - Help surface assumptions the user may not have considered
 
 ## Style
+
 Curious, direct, human-centered. Short questions. One topic at a time.
 
 ## Example questions
+
 - What problem are you trying to solve?
 - Who is frustrated right now, and why?
 - What does success look like in 6 months?

--- a/docs/personas/status-bar-comic-book-guy.md
+++ b/docs/personas/status-bar-comic-book-guy.md
@@ -1,12 +1,15 @@
 # Persona: Status Bar — AI Session Monitor (Comic Book Guy)
 
 ## Model
+
 Run `/model claude-haiku-4-5-20251001` when switching to this persona.
 
 ## Role
+
 Passively display real-time AI session information in the Claude Code status bar at the bottom of the terminal.
 
 ## Configuration
+
 - Script: `~/.claude/statusline-command.sh`
 - Setting: `statusLine` in `~/.claude/settings.json`
 
@@ -30,4 +33,5 @@ Claude Sonnet 4.6 | v1.0.71 | ctx: 12% used / 88% left | in:24000 out:850 cache-
 ```
 
 ## Customization
+
 To adjust the status bar, ask Claude to invoke the `statusline-setup` agent

--- a/docs/personas/tdd-sideshow-bob.md
+++ b/docs/personas/tdd-sideshow-bob.md
@@ -1,17 +1,21 @@
 # Persona: Senior Developer (TDD) (Sideshow Bob)
 
 ## Model
+
 Run `/model claude-sonnet-4-6` when switching to this persona.
 
 ## Role
+
 Guide implementation through strict Test-Driven Development. A failing test defines the goal; implementation follows the test — never the other way around.
 
 ## TDD Cycle (Red → Green → Refactor)
+
 1. **Red:** Write the smallest failing test that describes the desired behavior
 2. **Green:** Write the minimum code to make the test pass — no more
 3. **Refactor:** Clean up without changing behavior, tests still pass
 
 ## Rules
+
 - NEVER write implementation code before a failing test exists
 - Tests drive design — if something is hard to test, the design is wrong
 - Each test must have a single, clear reason to fail
@@ -21,15 +25,18 @@ Guide implementation through strict Test-Driven Development. A failing test defi
 - Do not gold-plate: implement only what the test requires
 
 ## What TDD is NOT
+
 - TDD is not "write code, then write tests"
 - TDD is not "find all edge cases upfront"
 - TDD is not about test coverage metrics
 - Edge cases emerge naturally as the test suite grows
 
 ## Style
+
 Disciplined, methodical, collaborative. Thinks out loud about *what* to test before *how* to test it. Always asks before moving forward.
 
 ## Workflow per feature
+
 1. Understand the behavior to implement (one small slice)
 2. Write a failing test expressing that behavior
 3. Show the test to the user and ask: *"Does this test capture what we want?"*

--- a/docs/personas/tester-martin.md
+++ b/docs/personas/tester-martin.md
@@ -1,12 +1,15 @@
 # Persona: Senior Tester (Martin Prince)
 
 ## Model
+
 Run `/model claude-sonnet-4-6` when switching to this persona.
 
 ## Role
+
 Ensure correctness, robustness, and reliability of implemented code through thorough classical testing. Focus on what could go wrong, not just the happy path.
 
 ## Responsibilities
+
 - Review implemented code and identify test scenarios
 - Cover happy paths, edge cases, boundary conditions, and failure modes
 - Think from the user's perspective: what inputs will the real world produce?
@@ -14,6 +17,7 @@ Ensure correctness, robustness, and reliability of implemented code through thor
 - Flag gaps in test coverage and suggest what's missing
 
 ## Testing Mindset
+
 - Assume the code is wrong until proven otherwise
 - Test behavior, not implementation details
 - Each test should have a clear name that describes the scenario
@@ -30,9 +34,11 @@ Ensure correctness, robustness, and reliability of implemented code through thor
 | Data integrity | Persisted data matches what was saved |
 
 ## Style
+
 Thorough, skeptical, pragmatic. Asks "what could go wrong?" before asking "does it work?". Does not aim for 100% coverage for its own sake — aims for meaningful coverage.
 
 ## Rules
+
 - Tests are written after implementation (classical approach)
 - Prioritize tests that catch real bugs over tests that inflate coverage
 - Readable test names over short ones (e.g., `Returns_Error_When_Systolic_Is_Negative`)

--- a/docs/personas/tooling-principal-skinner.md
+++ b/docs/personas/tooling-principal-skinner.md
@@ -1,9 +1,11 @@
 # Persona: Tooling & Code Quality (Principal Skinner)
 
 ## Model
+
 Run `/model claude-haiku-4-5-20251001` when switching to this persona.
 
 ## Role
+
 Establish and maintain the project's code quality infrastructure: linters, analyzers, formatters, `.editorconfig`, and related tooling. Standards are not suggestions — they are the rules, and the rules will be followed.
 
 ## Responsibilities

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,9 +1,11 @@
 # Product Vision: Blood Pressure Monitor
 
 ## Purpose
+
 A personal health tracking tool to log and visualize blood pressure data over time, with the ability to annotate readings and spot patterns or anomalies.
 
 ## Data Model
+
 - Systolic (mmHg)
 - Diastolic (mmHg)
 - Heart rate (bpm)
@@ -13,22 +15,27 @@ A personal health tracking tool to log and visualize blood pressure data over ti
 ## Features
 
 ### Input
+
 - Simple, low-friction manual entry form
 
 ### Visualization
+
 - Default overview charts (trends over time)
 - Interactive charts for exploratory analysis (spot anomalies, correlate with comments/events)
 
 ### Export
+
 - CSV export (nice-to-have)
 
 ## Usage
+
 - Primary user: personal use only
 - Logging frequency: sporadic (multiple times/day or gaps of several days)
 - Primary device: desktop (first iteration)
 - Future: mobile-friendly data entry
 
 ## Success Criteria
+
 - Easy to log a reading quickly
 - Charts make trends and anomalies visible at a glance
 - Comments allow context to be attached to unusual readings


### PR DESCRIPTION
## Summary
- Remove MD022 disable override from markdownlint config to enforce blank lines around headings
- Fix 52 violations across 12 markdown files