### PR TITLE
🔧 chore: add CI job to publish single self-contained linux executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,33 @@ jobs:
       - name: Test
         run: dotnet test --no-build --configuration Release --verbosity normal
         working-directory: code
+
+  publish-single-executable:
+    name: Publish Single Executable
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Publish single executable
+        run: >
+          dotnet publish BpMonitor.Tui/BpMonitor.Tui.fsproj
+          --configuration Release
+          --runtime linux-x64
+          --self-contained true
+          -p:PublishSingleFile=true
+          --output ./publish
+        working-directory: code
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bpmonitor-linux-x64
+          path: code/publish/BpMonitor.Tui


### PR DESCRIPTION
## Summary

- Add `publish-single-executable` CI job that builds a self-contained single-file binary for `linux-x64`
- Only runs on pushes to `main` (skipped on PRs)
- Requires `build-and-test` to pass first
- Uploads the binary as a GitHub Actions artifact (`bpmonitor-linux-x64`)

Closes #32