### PR TITLE
🐛 fix: include appsettings.json in single executable artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,4 +91,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bpmonitor-linux-x64
-          path: code/publish/BpMonitor.Tui
+          path: code/publish/


### PR DESCRIPTION
## Summary

- Upload the entire `publish/` directory as artifact instead of just the binary
- Ensures `appsettings.json` is included, making the executable usable