### PR TITLE
🐛 fix: bundle native libs and exclude PDB files from single executable artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
           --runtime linux-x64
           --self-contained true
           -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          -p:DebugType=none
           --output ./publish
         working-directory: code
 


### PR DESCRIPTION
## Summary

- Add `-p:IncludeNativeLibrariesForSelfExtract=true` to bundle `libe_sqlite3.so` into the single executable
- Add `-p:DebugType=none` to exclude PDB files from the artifact
- Artifact now contains only `BpMonitor.Tui` and `appsettings.json`