### PR TITLE
🔧 chore: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@v19
-        with:
-          globs: "**/*.md"
+        run: npx markdownlint-cli2 "**/*.md"
 
   lint-fsharp:
     name: Lint F#
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -44,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -70,10 +68,10 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -90,7 +88,7 @@ jobs:
         working-directory: code
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bpmonitor-linux-x64
           path: code/publish/


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from `v4` to `v6`
- Upgrade `actions/setup-dotnet` from `v4` to `v5`
- Upgrade `actions/upload-artifact` from `v4` to `v7`
- Replace `DavidAnson/markdownlint-cli2-action` with `npx markdownlint-cli2` directly — maintainer has not yet released a Node.js 24 compatible version