### PR TITLE
📝 docs: add git branch and persona to status bar spec

### DIFF
--- a/docs/personas/status-bar-comic-book-guy.md
+++ b/docs/personas/status-bar-comic-book-guy.md
@@ -25,6 +25,8 @@ Passively display real-time AI session information in the Claude Code status bar
 | Output style | Only shown if not default |
 | Vim mode | Only shown when vim mode is active |
 | Agent name | Only shown when started with `--agent` flag |
+| Git branch | Current branch, prefixed with `*` if dirty — derived from `workspace.current_dir` |
+| Active persona | Read from `~/.claude/current-persona` (written by Claude when switching personas); always shown when the file exists |
 
 ## Example Output
 


### PR DESCRIPTION
## Summary

- Adds missing `Git branch` and `Active persona` rows to the Displayed Information table in `status-bar-comic-book-guy.md`
- Ensures the `statusline-setup` agent knows to include persona display (read from `~/.claude/current-persona`) when regenerating the status bar script
- Persona field is always shown when the file exists, matching actual script behaviour