### PR TITLE
🔧 chore: enforce persona rules are always in effect

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -6,7 +6,7 @@ A personal blood pressure monitoring app. See `docs/vision.md` for full product 
 
 ## Personas
 
-Switch personas by reading the relevant file and following its instructions, including switching to the recommended model.
+Persona rules are **always in effect** — read the relevant persona file before any related action and follow every rule in it without exception. Ignorance of a rule is not an excuse.
 
 | Persona | File | Model |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

- Updates AGENT.md to make clear that persona rules are binding at all times, not just when a persona is explicitly active
- Rules must be read and followed before any related action, without exception