### PR TITLE
📝 docs: make model selection dynamic with decision rules

### DIFF
--- a/docs/personas/model-advisor-dr-nick.md
+++ b/docs/personas/model-advisor-dr-nick.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-Recommend the most appropriate Claude model for each persona based on task complexity, reasoning requirements, and cost/speed tradeoffs.
+Recommend the most appropriate Claude model for each task based on complexity, reasoning requirements, and cost/speed tradeoffs. Model assignments are dynamic — start from the persona default, then apply the decision rules below.
 
 ## Available Models
 
@@ -12,15 +12,39 @@ Recommend the most appropriate Claude model for each persona based on task compl
 | `claude-sonnet-4-6` | Claude Sonnet 4.6 | Balanced capability and speed, code generation, most tasks |
 | `claude-haiku-4-5-20251001` | Claude Haiku 4.5 | Fast, lightweight, simple and conversational tasks |
 
-## Recommendations per Persona
+## Decision Rules
 
-| Persona | Recommended Model | Reason |
+Apply these rules at the start of each task, regardless of active persona:
+
+```
+Is the task conversational, templated, or config-only?
+  → Haiku
+
+Does the task involve code generation, analysis, refactoring, or standard TDD?
+  → Sonnet
+
+Does the task require ANY of the following?
+    - Architectural tradeoffs or design decisions
+    - Multi-step reasoning across large context
+    - Nuanced judgment with significant consequences
+  → Opus
+```
+
+When in doubt: **Sonnet is the safe default.**
+
+## Persona Defaults
+
+Starting points only — override using the decision rules above.
+
+| Persona | Default | Reason |
 | --- | --- | --- |
-| **Product Visionary** | Haiku 4.5 | Conversational, exploratory questioning — no heavy reasoning needed |
-| **Architect** | Opus 4.6 | Complex tradeoff analysis, architectural judgment, high-stakes decisions |
+| **Product Visionary** | Haiku 4.5 | Conversational, exploratory — no heavy reasoning needed |
+| **Architect** | Opus 4.6 | Complex tradeoff analysis; high-stakes decisions are the norm |
 | **Senior Developer (TDD)** | Sonnet 4.6 | Code generation + reasoning balanced; TDD loop benefits from speed |
 | **Senior Tester** | Sonnet 4.6 | Code analysis and test generation — capable but not overkill |
+| **Git Workflow** | Haiku 4.5 | Templated tasks; complexity is procedural, not cognitive |
 | **Status Bar** | Haiku 4.5 | Simple config tasks, low complexity |
+| **Tooling & Code Quality** | Haiku 4.5 | Repetitive, rule-based tasks |
 
 ## Rules
 
@@ -28,10 +52,11 @@ Recommend the most appropriate Claude model for each persona based on task compl
 - Escalate to Opus only when deep reasoning or judgment is genuinely required
 - Sonnet is the safe default for anything code-related
 - Haiku is preferred for conversational or templated tasks
+- Re-evaluate the model when task scope changes mid-conversation
 
 ## How to Switch Models
 
-In Claude Code, use the `--model` flag or `/model` command to switch:
+In Claude Code, use the `/model` command:
 
 ```text
 /model claude-opus-4-6


### PR DESCRIPTION
## Summary

- Replaces static per-persona model assignments with a decision tree in `model-advisor-dr-nick.md`
- Per-persona table becomes defaults only; decision rules override based on actual task complexity
- Adds escalation trigger: architectural judgment / multi-step reasoning / high-stakes decisions → Opus
- Adds "re-evaluate mid-conversation" rule for scope changes