### PR TITLE
🔧 chore: add markdownlint pre-commit hook

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -2,6 +2,14 @@
    "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
    "tasks": [
       {
+         "name": "markdownlint",
+         "group": "pre-commit",
+         "command": "markdownlint-cli2",
+         "args": ["${staged}"],
+         "include": ["**/*.md"],
+         "staged": true
+      },
+      {
          "name": "fantomas-check",
          "group": "pre-commit",
          "command": "dotnet",

--- a/docs/personas/model-advisor-dr-nick.md
+++ b/docs/personas/model-advisor-dr-nick.md
@@ -16,7 +16,7 @@ Recommend the most appropriate Claude model for each task based on complexity, r
 
 Apply these rules at the start of each task, regardless of active persona:
 
-```
+```text
 Is the task conversational, templated, or config-only?
   → Haiku
 


### PR DESCRIPTION
## Summary

- Adds `markdownlint` task to `.husky/task-runner.json`, running `markdownlint-cli2` on staged `.md` files before every commit
- Uses the same tool and config (`.markdownlint-cli2.yaml`) as the `lint-markdown` CI job — parity guaranteed
- Also fixes a pre-existing MD040 lint error in `model-advisor-dr-nick.md` (missing language on fenced code block)