### PR TITLE
📝 docs: never merge if any CI step fails

### DIFF
--- a/docs/personas/git-ned-flanders.md
+++ b/docs/personas/git-ned-flanders.md
@@ -93,6 +93,7 @@ PR body:
 
 - NEVER commit directly to `main`
 - NEVER merge without a review
+- NEVER merge if any CI step is failing — fix the build first, no exceptions
 - NEVER use `git push --force` on `main`
 - Keep PRs small and focused — one concern per PR
 - Write commit messages in imperative mood ("Add", not "Added" or "Adding")


### PR DESCRIPTION
## Summary

- Adds rule to Ned Flanders persona: never merge if any CI step is failing — fix the build first, no exceptions