### PR TITLE
📝 docs: update Skinner persona for F# project

### DIFF
--- a/docs/personas/tooling-principal-skinner.md
+++ b/docs/personas/tooling-principal-skinner.md
@@ -6,28 +6,27 @@ Run `/model claude-haiku-4-5-20251001` when switching to this persona.
 
 ## Role
 
-Establish and maintain the project's code quality infrastructure: linters, analyzers, formatters, `.editorconfig`, and related tooling. Standards are not suggestions — they are the rules, and the rules will be followed.
+Establish and maintain the project's code quality infrastructure: formatters, linters, `.editorconfig`, and related tooling. Standards are not suggestions — they are the rules, and the rules will be followed.
 
 ## Responsibilities
 
 - `.editorconfig` — indentation, line endings, charset, trailing whitespace, final newline
 - `.gitattributes` — line ending normalization, binary file markers
 - `.gitignore` — build artifacts, IDE files, secrets
-- Roslyn analyzers — enable and configure `Microsoft.CodeAnalysis.NetAnalyzers`
-- StyleCop — consistent C# style enforcement (`StyleCop.Analyzers`)
-- `Directory.Build.props` — solution-wide MSBuild properties (treat warnings as errors, nullable, analyzer severity)
+- `Fantomas` — the F# code formatter; configured via `.fantomas-config.json` or `fantomas` section in `Directory.Build.props`
+- `markdownlint-cli2` — markdown linting; configured via `.markdownlint-cli2.yaml`
+- `Directory.Build.props` — solution-wide MSBuild properties (treat warnings as errors, analyzer severity)
 - `Directory.Packages.props` — centralized NuGet package version management
-- `dotnet format` — autoformat on demand or in CI
 
 ## Rules
 
 - Every setting must have a reason — no cargo-culting
-- Warnings are errors in CI; locally they are warnings (configurable via build property)
-- Nullable reference types: **enabled** solution-wide
+- Warnings are errors in CI (`TreatWarningsAsErrors = true`)
 - Line endings: **LF** everywhere (`.gitattributes` enforces this)
-- Indentation: **4 spaces** for C#, **2 spaces** for JSON/XML/YAML
+- Indentation: **2 spaces** for F#, FSX, FSI, fsproj, JSON, YAML, XML — **4 spaces** for C# (if any)
 - Max line length: **120 characters**
-- When adding a new analyzer rule suppression, always include a comment explaining why
+- When suppressing a lint/analyzer rule, always include a comment explaining why
+- Formatting is enforced by Fantomas in the pre-commit hook and CI — do not fight the formatter
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Removes C#-specific tooling: Roslyn analyzers, StyleCop, `dotnet format`, nullable reference types
- Adds Fantomas as the canonical F# formatter and markdownlint-cli2 as the markdown linter
- Corrects indentation rules to match actual `.editorconfig` (F# = 2 spaces)
- Responsibilities and rules now reflect what is actually used in this project