### PR TITLE
📝 docs: add comments to parseLine and parseMarkdown

### DIFF
--- a/code/BpMonitor.Import/MarkdownImport.fs
+++ b/code/BpMonitor.Import/MarkdownImport.fs
@@ -10,6 +10,8 @@ type ImportSummary =
 open System
 open BpMonitor.Core
 
+/// Parses a single markdown list item (e.g. "- 08:30: 120/80 65 comment") into an unvalidated reading.
+/// Returns None if the line does not match the expected format.
 let parseLine (date: DateOnly) (line: string) : BloodPressureReadingUnvalidated option =
   let readingPattern =
     System.Text.RegularExpressions.Regex(@"^- (\d{1,2})[.:](\d{2}): (\d+)/(\d+) (\d+)(.*)$")
@@ -36,6 +38,10 @@ let parseLine (date: DateOnly) (line: string) : BloodPressureReadingUnvalidated 
   else
     None
 
+/// Parses a full markdown document into a list of unvalidated readings.
+/// Scans lines sequentially: a line matching an ISO date header (e.g. "2024-03-01") sets the current date context;
+/// every subsequent non-date line is attempted as a reading using that date, and silently skipped if it does not match.
+/// The date context carries forward until the next date header.
 let parseMarkdown (markdown: string) : BloodPressureReadingUnvalidated list =
   let datePattern = System.Text.RegularExpressions.Regex(@"^(\d{4}-\d{2}-\d{2})")
 


### PR DESCRIPTION
## Summary

- Adds `///` doc comments to `parseLine` and `parseMarkdown` in `MarkdownImport.fs`
- Documents expected input format, return behaviour, and the date-context carry-forward scanning strategy