### PR TITLE
✨ feat: show line number and original line for import failures

### DIFF
--- a/code/BpMonitor.Import.Tests/MarkdownImportTests.fs
+++ b/code/BpMonitor.Import.Tests/MarkdownImportTests.fs
@@ -59,7 +59,7 @@ let ``parse markdown - multiple dates and readings`` () =
 2024-10-16
 - 09.30: 118/74 70"""
 
-  let result = parseMarkdown markdown
+  let result = parseMarkdown markdown |> List.map (fun (_, _, r) -> r)
 
   let expected =
     [ { Systolic = 131
@@ -94,7 +94,7 @@ let ``parse markdown - full sample from issue`` () =
 - 9:45: 123/89 98 morning
 - 19:15: 123/89 98 evening"""
 
-  let result = parseMarkdown markdown
+  let result = parseMarkdown markdown |> List.map (fun (_, _, r) -> r)
 
   let expected =
     [ { Systolic = 108
@@ -127,7 +127,7 @@ let ``parse markdown - trailing date line without readings is ignored`` () =
 - 11.00: 131/80 80
 2024-10-16"""
 
-  let result = parseMarkdown markdown
+  let result = parseMarkdown markdown |> List.map (fun (_, _, r) -> r)
 
   let expected =
     [ { Systolic = 131
@@ -145,7 +145,7 @@ let ``parse markdown - reading without preceding date is ignored`` () =
 2024-10-15
 - 12.00: 125/76 75"""
 
-  let result = parseMarkdown markdown
+  let result = parseMarkdown markdown |> List.map (fun (_, _, r) -> r)
 
   let expected =
     [ { Systolic = 125
@@ -189,6 +189,16 @@ let ``parse reading line - single-digit hour with dot separator`` () =
   test <@ result = expected @>
 
 [<Fact>]
+let ``parseMarkdown includes line number and original line for each reading`` () =
+  let markdown = "2024-10-15\n- 11.00: 131/80 80"
+  let result = parseMarkdown markdown
+
+  let (lineNumber, originalLine, _) = List.head result
+
+  test <@ lineNumber = 2 @>
+  test <@ originalLine = "- 11.00: 131/80 80" @>
+
+[<Fact>]
 let ``parse markdown - empty input returns empty list`` () =
   let result = parseMarkdown ""
   test <@ result = [] @>
@@ -215,7 +225,8 @@ let ``import - new valid reading is added to repository`` () =
       Timestamp = DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero)
       Comments = None }
 
-  let result = import repo ReadingRanges.defaults [ reading ]
+  let result =
+    import repo ReadingRanges.defaults [ (1, "- 09:00: 120/80 70", reading) ]
 
   test <@ result.Added = 1 @>
   test <@ result.Updated = 0 @>
@@ -242,7 +253,8 @@ let ``import - existing reading with same timestamp is updated`` () =
       Timestamp = DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero)
       Comments = None }
 
-  let result = import repo ReadingRanges.defaults [ updated ]
+  let result =
+    import repo ReadingRanges.defaults [ (1, "- 09:00: 120/80 70", updated) ]
 
   test <@ result.Added = 0 @>
   test <@ result.Updated = 1 @>
@@ -267,9 +279,10 @@ let ``import - invalid reading is captured in Failed, valid ones still imported`
       Timestamp = DateTimeOffset(2024, 10, 15, 10, 0, 0, TimeSpan.Zero)
       Comments = None }
 
-  let result = import repo ReadingRanges.defaults [ invalid; valid ]
+  let result =
+    import repo ReadingRanges.defaults [ (1, "- 09:00: 0/80 70", invalid); (2, "- 10:00: 120/80 70", valid) ]
 
   test <@ result.Added = 1 @>
   test <@ result.Updated = 0 @>
   test <@ result.Failed.Length = 1 @>
-  test <@ result.Failed.[0] |> fst = invalid @>
+  test <@ result.Failed.[0] |> (fun (_, _, r, _) -> r) = invalid @>

--- a/code/BpMonitor.Import/MarkdownImport.fs
+++ b/code/BpMonitor.Import/MarkdownImport.fs
@@ -5,7 +5,7 @@ open BpMonitor.Core
 type ImportSummary =
   { Added: int
     Updated: int
-    Failed: (BloodPressureReadingUnvalidated * ValidationError list) list }
+    Failed: (int * string * BloodPressureReadingUnvalidated * ValidationError list) list }
 
 open System
 open BpMonitor.Core
@@ -38,16 +38,16 @@ let parseLine (date: DateOnly) (line: string) : BloodPressureReadingUnvalidated 
   else
     None
 
-/// Parses a full markdown document into a list of unvalidated readings.
+/// Parses a full markdown document into a list of (1-based line number, original line, unvalidated reading) triples.
 /// Scans lines sequentially: a line matching an ISO date header (e.g. "2024-03-01") sets the current date context;
 /// every subsequent non-date line is attempted as a reading using that date, and silently skipped if it does not match.
 /// The date context carries forward until the next date header.
-let parseMarkdown (markdown: string) : BloodPressureReadingUnvalidated list =
+let parseMarkdown (markdown: string) : (int * string * BloodPressureReadingUnvalidated) list =
   let datePattern = System.Text.RegularExpressions.Regex(@"^(\d{4}-\d{2}-\d{2})")
 
   let lines = markdown.Split([| '\n'; '\r' |], StringSplitOptions.None)
 
-  let folder (currentDate, readings) (line: string) =
+  let folder (currentDate, readings) (lineIndex: int, line: string) =
     let dm = datePattern.Match(line)
 
     if dm.Success then
@@ -59,22 +59,22 @@ let parseMarkdown (markdown: string) : BloodPressureReadingUnvalidated list =
       | Some date ->
         match parseLine date line with
         | None -> (currentDate, readings)
-        | Some reading -> (currentDate, reading :: readings)
+        | Some reading -> (currentDate, (lineIndex + 1, line, reading) :: readings)
 
-  lines |> Array.fold folder (None, []) |> snd |> List.rev
+  lines |> Array.indexed |> Array.fold folder (None, []) |> snd |> List.rev
 
 let import
   (repository: IReadingRepository)
   (ranges: ReadingRanges)
-  (unvalidated: BloodPressureReadingUnvalidated list)
+  (unvalidated: (int * string * BloodPressureReadingUnvalidated) list)
   : ImportSummary =
   let existing = repository.GetAll()
 
-  let folder acc reading =
+  let folder acc (lineNumber, line, reading) =
     let (added, updated, failed) = acc
 
     match BloodPressureReading.parse ranges reading with
-    | Error errors -> (added, updated, (reading, errors) :: failed)
+    | Error errors -> (added, updated, (lineNumber, line, reading, errors) :: failed)
     | Ok validated ->
       match existing |> List.tryFind (fun r -> r.Timestamp = validated.Timestamp) with
       | None ->

--- a/code/BpMonitor.Tui/ReadingsWindow.fs
+++ b/code/BpMonitor.Tui/ReadingsWindow.fs
@@ -111,8 +111,16 @@ type ReadingsWindow
       | Some summary ->
         tableView.Table <- makeTableSource ()
 
+        let failureLines =
+          summary.Failed
+          |> List.map (fun (lineNumber, line, _, _) -> $"  Line {lineNumber}: {line}")
+          |> String.concat "\n"
+
         let msg =
-          $"Added: {summary.Added}\nUpdated: {summary.Updated}\nFailed: {summary.Failed.Length}"
+          if summary.Failed.IsEmpty then
+            $"Added: {summary.Added}\nUpdated: {summary.Updated}\nFailed: 0"
+          else
+            $"Added: {summary.Added}\nUpdated: {summary.Updated}\nFailed: {summary.Failed.Length}\n\n{failureLines}"
 
         MessageBox.Query(app, "Import Complete", msg, "OK") |> ignore)
 


### PR DESCRIPTION
## Summary
- `parseMarkdown` now returns `(lineNumber * originalLine * reading)` triples instead of bare readings, so line provenance is preserved through the pipeline
- `ImportSummary.Failed` extended to `(int * string * BloodPressureReadingUnvalidated * ValidationError list)` — each failure carries its 1-based line number and original line text
- Import result modal now lists each failed entry as `Line {n}: {originalLine}` below the summary counts