### PR TITLE
🐛 fix: sort readings by timestamp before charting

### DIFF
--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -53,6 +53,14 @@ let private readings =
 
 type ChartTests() =
   [<Fact>]
+  member _.``toHtml renders timestamps in ascending order regardless of input order``() =
+    let reversed = List.rev readings
+    let html = BpChart.toHtml reversed
+    let pos1 = html.IndexOf("2026-01-01")
+    let pos30 = html.IndexOf("2026-01-30")
+    Assert.True(pos1 < pos30, "First timestamp should appear before last in chart data")
+
+  [<Fact>]
   member _.``toHtml matches snapshot``() : Task =
     let html = BpChart.toHtml readings
     let settings = VerifyTests.VerifySettings()

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -5,6 +5,7 @@ open BpMonitor.Core
 
 module BpChart =
   let toHtml (readings: BloodPressureReading list) : string =
+    let readings = readings |> List.sortBy _.Timestamp
     let timestamps = readings |> List.map _.Timestamp.ToString("yyyy-MM-dd HH:mm")
     let systolic = readings |> List.map _.Systolic
     let diastolic = readings |> List.map _.Diastolic


### PR DESCRIPTION
## Summary

- Readings are now sorted by timestamp before being passed to Plotly
- Prevents line series jumping backwards when readings are stored out of chronological order

## Root cause

`Chart.Line` connects points in the order they are given. If the reading list is unsorted, lines connect across the full time range producing visual artefacts.