### PR TITLE
✨ feat(import): add JSON importer

### DIFF
--- a/code/BpMonitor.ArchTests/ArchitectureTests.fs
+++ b/code/BpMonitor.ArchTests/ArchitectureTests.fs
@@ -74,6 +74,11 @@ let ``Import should not depend on Charts`` () =
   ArchRuleAssert.CheckRule(architecture, rule)
 
 [<Fact>]
+let ``Import should not depend on Export`` () =
+  let rule = importTypes.Should().NotDependOnAny(exportTypes)
+  ArchRuleAssert.CheckRule(architecture, rule)
+
+[<Fact>]
 let ``Charts should not depend on Data`` () =
   let rule = chartsTypes.Should().NotDependOnAny(dataTypes)
   ArchRuleAssert.CheckRule(architecture, rule)

--- a/code/BpMonitor.Export.Tests/JsonExportTests.fs
+++ b/code/BpMonitor.Export.Tests/JsonExportTests.fs
@@ -6,6 +6,7 @@ open System.Text.Json
 open System.Threading.Tasks
 open BpMonitor.Core
 open BpMonitor.Export.JsonExport
+
 open Swensen.Unquote
 open VerifyXunit
 open Xunit
@@ -58,42 +59,3 @@ let ``tryWriteToFile returns Error when path is invalid`` () =
   let result = tryWriteToFile "/invalid/path/that/does/not/exist/file.json" []
 
   test <@ result <> Ok() @>
-
-[<Fact>]
-let ``tryReadFromFile returns Ok with readings when file contains valid JSON`` () =
-  let reading =
-    { Id = 1
-      Systolic = 120
-      Diastolic = 80
-      HeartRate = 70
-      Timestamp = DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero)
-      Comments = Some "morning"
-      CreatedAt = DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero)
-      ModifiedAt = DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero) }
-
-  let path = Path.GetTempFileName()
-  tryWriteToFile path [ reading ] |> ignore
-
-  let result = tryReadFromFile path
-  test <@ result = Ok [ reading ] @>
-
-[<Fact>]
-let ``tryReadFromFile returns Ok with empty list when file contains empty array`` () =
-  let path = Path.GetTempFileName()
-  File.WriteAllText(path, "[]")
-
-  let result = tryReadFromFile path
-  test <@ result = Ok [] @>
-
-[<Fact>]
-let ``tryReadFromFile returns Error when file does not exist`` () =
-  let result = tryReadFromFile "/nonexistent/path/file.json"
-  test <@ result <> Ok [] @>
-
-[<Fact>]
-let ``tryReadFromFile returns Error when file contains invalid JSON`` () =
-  let path = Path.GetTempFileName()
-  File.WriteAllText(path, "not valid json")
-
-  let result = tryReadFromFile path
-  test <@ result <> Ok [] @>

--- a/code/BpMonitor.Export/JsonExport.fs
+++ b/code/BpMonitor.Export/JsonExport.fs
@@ -14,9 +14,6 @@ let private options =
 let serialize (readings: BloodPressureReading list) : string =
   JsonSerializer.Serialize(readings, options)
 
-let deserialize (json: string) : BloodPressureReading list =
-  JsonSerializer.Deserialize<BloodPressureReading list>(json, options)
-
 let tryWriteToFile (path: string) (readings: BloodPressureReading list) : Result<unit, string> =
   try
     File.WriteAllText(path, serialize readings)
@@ -24,12 +21,3 @@ let tryWriteToFile (path: string) (readings: BloodPressureReading list) : Result
   with
   | :? IOException as ex -> Error ex.Message
   | :? UnauthorizedAccessException as ex -> Error ex.Message
-
-let tryReadFromFile (path: string) : Result<BloodPressureReading list, string> =
-  try
-    let json = File.ReadAllText(path)
-    Ok(deserialize json)
-  with
-  | :? IOException as ex -> Error ex.Message
-  | :? UnauthorizedAccessException as ex -> Error ex.Message
-  | :? Text.Json.JsonException as ex -> Error ex.Message

--- a/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
+++ b/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
@@ -21,7 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="..\BpMonitor.Import\BpMonitor.Import.fsproj" />
     <ProjectReference Include="..\BpMonitor.Data\BpMonitor.Data.fsproj" />
-    <ProjectReference Include="..\BpMonitor.Export\BpMonitor.Export.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
+++ b/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <Compile Include="MarkdownImportTests.fs" />
+    <Compile Include="JsonImportTests.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BpMonitor.Import\BpMonitor.Import.fsproj" />
     <ProjectReference Include="..\BpMonitor.Data\BpMonitor.Data.fsproj" />
+    <ProjectReference Include="..\BpMonitor.Export\BpMonitor.Export.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/code/BpMonitor.Import.Tests/JsonImportTests.fs
+++ b/code/BpMonitor.Import.Tests/JsonImportTests.fs
@@ -1,0 +1,74 @@
+module BpMonitor.Import.Tests.JsonImportTests
+
+open System
+open BpMonitor.Data
+open BpMonitor.Export
+open BpMonitor.Core
+open BpMonitor.Import.JsonImport
+open Swensen.Unquote
+open Xunit
+
+let private makeReading id systolic diastolic heartRate (ts: DateTimeOffset) comments =
+  { Id = id
+    Systolic = systolic
+    Diastolic = diastolic
+    HeartRate = heartRate
+    Timestamp = ts
+    Comments = comments
+    CreatedAt = DateTimeOffset.MinValue
+    ModifiedAt = DateTimeOffset.MinValue }
+
+[<Fact>]
+let ``parse - valid JSON returns reading list`` () =
+  let reading =
+    makeReading 1 120 80 70 (DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero)) None
+
+  let json = JsonExport.serialize [ reading ]
+  let result = parse json
+  test <@ result = Ok [ reading ] @>
+
+[<Fact>]
+let ``parse - empty array returns empty list`` () =
+  let result = parse "[]"
+  test <@ result = Ok [] @>
+
+[<Fact>]
+let ``parse - invalid JSON returns Error`` () =
+  let result = parse "not valid json"
+
+  test
+    <@
+      match result with
+      | Error _ -> true
+      | _ -> false
+    @>
+
+[<Fact>]
+let ``import - new reading is added to repository`` () =
+  let repo = InMemoryReadingRepository(Some []) :> IReadingRepository
+
+  let reading =
+    makeReading 99 120 80 70 (DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero)) None
+
+  let result = import repo [ reading ]
+  test <@ result.Added = 1 @>
+  test <@ result.Updated = 0 @>
+
+[<Fact>]
+let ``import - existing reading with same timestamp is updated`` () =
+  let ts = DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero)
+  let existing = makeReading 1 110 70 60 ts None
+  let repo = InMemoryReadingRepository(Some [ existing ]) :> IReadingRepository
+  let updated = makeReading 99 120 80 70 ts None
+  let result = import repo [ updated ]
+  test <@ result.Added = 0 @>
+  test <@ result.Updated = 1 @>
+  test <@ repo.GetAll().[0].Systolic = 120 @>
+  test <@ repo.GetAll().[0].Id = 1 @>
+
+[<Fact>]
+let ``import - empty list returns zero counts`` () =
+  let repo = InMemoryReadingRepository(Some []) :> IReadingRepository
+  let result = import repo []
+  test <@ result.Added = 0 @>
+  test <@ result.Updated = 0 @>

--- a/code/BpMonitor.Import.Tests/JsonImportTests.fs
+++ b/code/BpMonitor.Import.Tests/JsonImportTests.fs
@@ -1,8 +1,8 @@
 module BpMonitor.Import.Tests.JsonImportTests
 
 open System
+open System.IO
 open BpMonitor.Data
-open BpMonitor.Export
 open BpMonitor.Core
 open BpMonitor.Import.JsonImport
 open Swensen.Unquote
@@ -20,12 +20,15 @@ let private makeReading id systolic diastolic heartRate (ts: DateTimeOffset) com
 
 [<Fact>]
 let ``parse - valid JSON returns reading list`` () =
-  let reading =
+  let json =
+    """[{"id":1,"systolic":120,"diastolic":80,"heartRate":70,"timestamp":"2024-10-15T09:00:00+00:00","comments":null,"createdAt":"0001-01-01T00:00:00+00:00","modifiedAt":"0001-01-01T00:00:00+00:00"}]"""
+
+  let result = parse json
+
+  let expected =
     makeReading 1 120 80 70 (DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero)) None
 
-  let json = JsonExport.serialize [ reading ]
-  let result = parse json
-  test <@ result = Ok [ reading ] @>
+  test <@ result = Ok [ expected ] @>
 
 [<Fact>]
 let ``parse - empty array returns empty list`` () =
@@ -42,6 +45,41 @@ let ``parse - invalid JSON returns Error`` () =
       | Error _ -> true
       | _ -> false
     @>
+
+[<Fact>]
+let ``tryReadFromFile returns Ok with readings when file contains valid JSON`` () =
+  let path = Path.GetTempFileName()
+
+  File.WriteAllText(
+    path,
+    """[{"id":1,"systolic":120,"diastolic":80,"heartRate":70,"timestamp":"2024-10-15T09:00:00+00:00","comments":"morning","createdAt":"0001-01-01T00:00:00+00:00","modifiedAt":"0001-01-01T00:00:00+00:00"}]"""
+  )
+
+  let result = tryReadFromFile path
+
+  let expected =
+    makeReading 1 120 80 70 (DateTimeOffset(2024, 10, 15, 9, 0, 0, TimeSpan.Zero)) (Some "morning")
+
+  test <@ result = Ok [ expected ] @>
+
+[<Fact>]
+let ``tryReadFromFile returns Ok with empty list when file contains empty array`` () =
+  let path = Path.GetTempFileName()
+  File.WriteAllText(path, "[]")
+  let result = tryReadFromFile path
+  test <@ result = Ok [] @>
+
+[<Fact>]
+let ``tryReadFromFile returns Error when file does not exist`` () =
+  let result = tryReadFromFile "/nonexistent/path/file.json"
+  test <@ result <> Ok [] @>
+
+[<Fact>]
+let ``tryReadFromFile returns Error when file contains invalid JSON`` () =
+  let path = Path.GetTempFileName()
+  File.WriteAllText(path, "not valid json")
+  let result = tryReadFromFile path
+  test <@ result <> Ok [] @>
 
 [<Fact>]
 let ``import - new reading is added to repository`` () =

--- a/code/BpMonitor.Import/BpMonitor.Import.fsproj
+++ b/code/BpMonitor.Import/BpMonitor.Import.fsproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="FSharp.SystemTextJson" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\BpMonitor.Core\BpMonitor.Core.fsproj" />
-    <ProjectReference Include="..\BpMonitor.Export\BpMonitor.Export.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/code/BpMonitor.Import/BpMonitor.Import.fsproj
+++ b/code/BpMonitor.Import/BpMonitor.Import.fsproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <Compile Include="MarkdownImport.fs" />
+    <Compile Include="JsonImport.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -10,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BpMonitor.Core\BpMonitor.Core.fsproj" />
+    <ProjectReference Include="..\BpMonitor.Export\BpMonitor.Export.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/code/BpMonitor.Import/JsonImport.fs
+++ b/code/BpMonitor.Import/JsonImport.fs
@@ -1,0 +1,28 @@
+module BpMonitor.Import.JsonImport
+
+open System.Text.Json
+open BpMonitor.Core
+open BpMonitor.Export
+
+type JsonImportSummary = { Added: int; Updated: int }
+
+let parse (json: string) : Result<BloodPressureReading list, string> =
+  try
+    Ok(JsonExport.deserialize json)
+  with :? JsonException as ex ->
+    Error ex.Message
+
+let import (repository: IReadingRepository) (readings: BloodPressureReading list) : JsonImportSummary =
+  let existing = repository.GetAll()
+
+  let folder (added, updated) (reading: BloodPressureReading) =
+    match existing |> List.tryFind (fun r -> r.Timestamp = reading.Timestamp) with
+    | None ->
+      repository.Add(reading)
+      (added + 1, updated)
+    | Some existingReading ->
+      repository.Update({ reading with Id = existingReading.Id })
+      (added, updated + 1)
+
+  let (added, updated) = readings |> List.fold folder (0, 0)
+  { Added = added; Updated = updated }

--- a/code/BpMonitor.Import/JsonImport.fs
+++ b/code/BpMonitor.Import/JsonImport.fs
@@ -21,12 +21,11 @@ let parse (json: string) : Result<BloodPressureReading list, string> =
 
 let tryReadFromFile (path: string) : Result<BloodPressureReading list, string> =
   try
-    let json = File.ReadAllText(path)
-    Ok(JsonSerializer.Deserialize<BloodPressureReading list>(json, options))
+    Ok(File.ReadAllText(path))
   with
   | :? IOException as ex -> Error ex.Message
   | :? UnauthorizedAccessException as ex -> Error ex.Message
-  | :? JsonException as ex -> Error ex.Message
+  |> Result.bind parse
 
 let import (repository: IReadingRepository) (readings: BloodPressureReading list) : JsonImportSummary =
   let existing = repository.GetAll()

--- a/code/BpMonitor.Import/JsonImport.fs
+++ b/code/BpMonitor.Import/JsonImport.fs
@@ -1,16 +1,32 @@
 module BpMonitor.Import.JsonImport
 
+open System
+open System.IO
 open System.Text.Json
+open System.Text.Json.Serialization
 open BpMonitor.Core
-open BpMonitor.Export
+
+let private options =
+  let o = JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
+  o.Converters.Add(JsonFSharpConverter())
+  o
 
 type JsonImportSummary = { Added: int; Updated: int }
 
 let parse (json: string) : Result<BloodPressureReading list, string> =
   try
-    Ok(JsonExport.deserialize json)
+    Ok(JsonSerializer.Deserialize<BloodPressureReading list>(json, options))
   with :? JsonException as ex ->
     Error ex.Message
+
+let tryReadFromFile (path: string) : Result<BloodPressureReading list, string> =
+  try
+    let json = File.ReadAllText(path)
+    Ok(JsonSerializer.Deserialize<BloodPressureReading list>(json, options))
+  with
+  | :? IOException as ex -> Error ex.Message
+  | :? UnauthorizedAccessException as ex -> Error ex.Message
+  | :? JsonException as ex -> Error ex.Message
 
 let import (repository: IReadingRepository) (readings: BloodPressureReading list) : JsonImportSummary =
   let existing = repository.GetAll()

--- a/code/BpMonitor.Tui/Program.fs
+++ b/code/BpMonitor.Tui/Program.fs
@@ -13,6 +13,7 @@ open BpMonitor.Charts
 open BpMonitor.Core
 open BpMonitor.Data
 open BpMonitor.Export.JsonExport
+open BpMonitor.Import.JsonImport
 open BpMonitor.Import.MarkdownImport
 
 let private makeField (y: int) (width: Dim) =

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ code/
 ├── BpMonitor.Core.Tests     # Unit tests for Core
 ├── BpMonitor.Data           # EF Core + SQLite, repository implementations
 ├── BpMonitor.Data.Tests     # Integration tests for Data
-├── BpMonitor.Import         # Markdown parser and import logic
+├── BpMonitor.Import         # Markdown and JSON importers
 ├── BpMonitor.Import.Tests   # Unit tests for Import
 ├── BpMonitor.Charts         # Plotly.NET chart generation
 ├── BpMonitor.Charts.Tests   # Snapshot tests for Charts

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,6 @@ graph TD
 
     Data --> Core
     Import --> Core
-    Import --> Export
     Charts --> Core
     Export --> Core
     Tui --> Core
@@ -105,8 +104,8 @@ graph TD
 
 - Parses blood pressure readings from Markdown files (`parseMarkdown`, `parseLine`)
 - Upsert import logic with summary (`ImportSummary`: added, updated, failed counts)
-- Imports `BloodPressureReading` lists from JSON (`JsonImport.parse`, `JsonImport.import`)
-- Depends on Core and Export (delegates JSON deserialisation to `JsonExport.deserialize`)
+- Imports `BloodPressureReading` lists from JSON (`JsonImport.parse`, `JsonImport.tryReadFromFile`, `JsonImport.import`)
+- Depends on Core only
 
 ### BpMonitor.Charts
 
@@ -116,8 +115,7 @@ graph TD
 
 ### BpMonitor.Export
 
-- JSON serialisation of `BloodPressureReading` lists (`serialize`, `deserialize`)
-- File-level helpers `tryWriteToFile` / `tryReadFromFile` returning `Result<_, string>`
+- JSON serialisation of `BloodPressureReading` lists (`serialize`, `tryWriteToFile`)
 - Depends on Core only
 
 ### BpMonitor.Tui
@@ -132,7 +130,7 @@ graph TD
 - ArchUnit rules enforcing Clean Architecture layer boundaries
 - Core must not depend on Data, Tui
 - Data must not depend on Tui
-- Import must not depend on Data, Tui, Charts (may depend on Export)
+- Import must not depend on Data, Tui, Charts, Export
 - Charts must not depend on Data, Tui
 - Export must not depend on Data, Tui, Charts, Import
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ code/
 ├── BpMonitor.Import.Tests   # Unit tests for Import
 ├── BpMonitor.Charts         # Plotly.NET chart generation
 ├── BpMonitor.Charts.Tests   # Snapshot tests for Charts
-├── BpMonitor.Export         # JSON serialisation and file export/import
+├── BpMonitor.Export         # JSON serialisation and file write
 ├── BpMonitor.Export.Tests   # Tests for Export
 ├── BpMonitor.Tui            # Terminal.Gui v2 app (data entry + list view + import)
 ├── BpMonitor.Tui.Tests      # Tests for TUI layer
@@ -69,6 +69,7 @@ graph TD
     Core[BpMonitor.Core]
     Data[BpMonitor.Data]
     Import[BpMonitor.Import]
+    Export[BpMonitor.Export]
     Charts[BpMonitor.Charts]
     Tui[BpMonitor.Tui]
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,7 @@ graph TD
 
     Data --> Core
     Import --> Core
+    Import --> Export
     Charts --> Core
     Export --> Core
     Tui --> Core
@@ -104,7 +105,8 @@ graph TD
 
 - Parses blood pressure readings from Markdown files (`parseMarkdown`, `parseLine`)
 - Upsert import logic with summary (`ImportSummary`: added, updated, failed counts)
-- Depends on Core only
+- Imports `BloodPressureReading` lists from JSON (`JsonImport.parse`, `JsonImport.import`)
+- Depends on Core and Export (delegates JSON deserialisation to `JsonExport.deserialize`)
 
 ### BpMonitor.Charts
 
@@ -130,7 +132,7 @@ graph TD
 - ArchUnit rules enforcing Clean Architecture layer boundaries
 - Core must not depend on Data, Tui
 - Data must not depend on Tui
-- Import must not depend on Data, Tui, Charts
+- Import must not depend on Data, Tui, Charts (may depend on Export)
 - Charts must not depend on Data, Tui
 - Export must not depend on Data, Tui, Charts, Import
 


### PR DESCRIPTION
## Summary

- Add `BpMonitor.Import.JsonImport` module with `parse`, `tryReadFromFile`, and `import` functions
- Deduplicate by `Timestamp`, consistent with `MarkdownImport`
- `JsonImport` owns its own JSON deserialisation — no dependency on `JsonExport`
- `JsonExport` becomes write-only: `serialize` + `tryWriteToFile`
- `tryReadFromFile` composes with `parse` via `Result.bind`
- Add arch rule: `Import should not depend on Export`
- Move `tryReadFromFile` tests from `JsonExportTests` to `JsonImportTests`
- Update architecture docs