### PR TITLE
♻️ refactor: apply F# style conventions (shorthand lambdas, indexer syntax)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,13 @@ git checkout -b feat/<short-description>
 
 Never start work on `main`. Creating the branch is the first step, not an afterthought.
 
+## F# Style Conventions
+
+- Use shorthand lambda syntax where the argument is only used for a single member access chain: `_.Property` instead of `fun x -> x.Property`
+- Do not use `.[n]` indexer syntax outside of Unquote quotation expressions (`<@ ... @>`); use `[n]` instead
+- Inside Unquote quotation expressions, `[n]` only works on simple local variables — use `.[n]` when indexing the result of a method call (e.g. `repo.GetAll().[0]`)
+- `new` is required for any type implementing `IDisposable` — the compiler enforces this via FS0760
+
 ## Docs
 
 - `docs/vision.md` — product vision and requirements

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -13,7 +13,7 @@ module BpChart =
     let diastolic = readings |> List.map _.Diastolic
     let heartRate = readings |> List.map _.HeartRate
 
-    let commented = readings |> List.filter (fun r -> r.Comments.IsSome)
+    let commented = readings |> List.filter _.Comments.IsSome
 
     let commentTraces =
       if commented.IsEmpty then
@@ -32,4 +32,4 @@ module BpChart =
     |> Chart.combine
     |> Chart.withTitle "Blood Pressure History"
     |> GenericChart.toEmbeddedHTML
-    |> fun html -> html.Replace("\"width\":600,", "")
+    |> _.Replace("\"width\":600,", "")

--- a/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
@@ -90,7 +90,7 @@ let ``Add sets CreatedAt and ModifiedAt to current time`` () =
   use ctx = createContext ()
   let repo = EfReadingRepository(ctx, timeProvider) :> IReadingRepository
   repo.Add(sample)
-  let result = repo.GetAll().[0]
+  let result = repo.GetAll()[0]
   test <@ result.CreatedAt = now @>
   test <@ result.ModifiedAt = now @>
 
@@ -121,10 +121,10 @@ let ``AddMany sets CreatedAt and ModifiedAt to current time`` () =
 
   repo.AddMany([ sample; second ])
   let readings = repo.GetAll()
-  test <@ readings.[0].CreatedAt = now @>
-  test <@ readings.[0].ModifiedAt = now @>
-  test <@ readings.[1].CreatedAt = now @>
-  test <@ readings.[1].ModifiedAt = now @>
+  test <@ readings[0].CreatedAt = now @>
+  test <@ readings[0].ModifiedAt = now @>
+  test <@ readings[1].CreatedAt = now @>
+  test <@ readings[1].ModifiedAt = now @>
 
 [<Fact>]
 let ``Update preserves CreatedAt and sets ModifiedAt to current time`` () =
@@ -134,9 +134,9 @@ let ``Update preserves CreatedAt and sets ModifiedAt to current time`` () =
   use ctx = createContext ()
   let repo = EfReadingRepository(ctx, timeProvider) :> IReadingRepository
   repo.Add(sample)
-  let added = repo.GetAll().[0]
+  let added = repo.GetAll()[0]
   timeProvider.SetUtcNow(updatedAt)
   repo.Update({ added with Systolic = 130 })
-  let result = repo.GetAll().[0]
+  let result = repo.GetAll()[0]
   test <@ result.CreatedAt = createdAt @>
   test <@ result.ModifiedAt = updatedAt @>

--- a/code/BpMonitor.Data.Tests/InMemoryReadingRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/InMemoryReadingRepositoryTests.fs
@@ -33,8 +33,8 @@ let ``Add assigns sequential Ids starting at 1`` () =
   repo.Add(sample)
   repo.Add(sample)
   let readings = repo.GetAll()
-  test <@ readings.[0].Id = 1 @>
-  test <@ readings.[1].Id = 2 @>
+  test <@ readings[0].Id = 1 @>
+  test <@ readings[1].Id = 2 @>
 
 [<Fact>]
 let ``AddMany persists all readings`` () =
@@ -57,5 +57,5 @@ let ``AddMany assigns sequential Ids`` () =
 
   repo.AddMany([ sample; second ])
   let readings = repo.GetAll()
-  test <@ readings.[0].Id = 1 @>
-  test <@ readings.[1].Id = 2 @>
+  test <@ readings[0].Id = 1 @>
+  test <@ readings[1].Id = 2 @>

--- a/code/BpMonitor.Data/InMemoryReadingRepository.fs
+++ b/code/BpMonitor.Data/InMemoryReadingRepository.fs
@@ -48,7 +48,7 @@ type InMemoryReadingRepository(initialReadings: BloodPressureReading list option
     if initial.IsEmpty then
       1
     else
-      (initial |> List.map (fun r -> r.Id) |> List.max) + 1
+      (initial |> List.map _.Id |> List.max) + 1
 
   interface IReadingRepository with
     member _.GetAll() = readings |> Seq.toList

--- a/code/BpMonitor.Tui/Program.fs
+++ b/code/BpMonitor.Tui/Program.fs
@@ -59,7 +59,7 @@ let private readRanges (config: IConfiguration) =
   let d = ReadingRanges.defaults
 
   let getInt key fallback =
-    match s.[key] with
+    match s[key] with
     | null -> fallback
     | v ->
       match Int32.TryParse(v) with
@@ -191,7 +191,7 @@ let main _ =
       match tryReadFromFile exportJsonPath with
       | Error msg -> Some msg
       | Ok jsonReadings ->
-        let existingIds = repository.GetAll() |> List.map (fun r -> r.Id) |> Set.ofList
+        let existingIds = repository.GetAll() |> List.map _.Id |> Set.ofList
 
         let newReadings =
           jsonReadings |> List.filter (fun r -> not (existingIds.Contains(r.Id)))

--- a/code/BpMonitor.Tui/ReadingsWindow.fs
+++ b/code/BpMonitor.Tui/ReadingsWindow.fs
@@ -23,7 +23,7 @@ type ReadingsWindow
   inherit Window()
 
   let sortedReadings () =
-    repository.GetAll() |> List.sortByDescending (fun r -> r.Timestamp)
+    repository.GetAll() |> List.sortByDescending _.Timestamp
 
   let makeTableSource () =
     EnumerableTableSource<BloodPressureReading>(


### PR DESCRIPTION
## Summary
- Replace `fun x -> x.Property` lambdas with `_.Property` shorthand where the argument is used for a single member access
- Replace `.[n]` indexer syntax with `[n]` outside Unquote quotation expressions
- Document F# style conventions in AGENTS.md (including the Unquote nuance: `.[n]` is still required when indexing method call results inside `<@ ... @>`)