### PR TITLE
⬆️ chore: update NuGet packages and centralise coverlet.collector in Directory.Build.props

### DIFF
--- a/code/BpMonitor.ArchTests/BpMonitor.ArchTests.fsproj
+++ b/code/BpMonitor.ArchTests/BpMonitor.ArchTests.fsproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Charts.Tests/BpMonitor.Charts.Tests.fsproj
+++ b/code/BpMonitor.Charts.Tests/BpMonitor.Charts.Tests.fsproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Unquote" />
     <PackageReference Include="Verify.XunitV3" />

--- a/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
+++ b/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Data.Tests/BpMonitor.Data.Tests.fsproj
+++ b/code/BpMonitor.Data.Tests/BpMonitor.Data.Tests.fsproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Export.Tests/BpMonitor.Export.Tests.fsproj
+++ b/code/BpMonitor.Export.Tests/BpMonitor.Export.Tests.fsproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
+++ b/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Tui.Tests/BpMonitor.Tui.Tests.fsproj
+++ b/code/BpMonitor.Tui.Tests/BpMonitor.Tui.Tests.fsproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Terminal.Gui" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/Directory.Build.props
+++ b/code/Directory.Build.props
@@ -3,4 +3,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <ItemGroup Condition="'$(IsPackable)' == 'false' and $(MSBuildProjectName.Contains('Tests'))">
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -2,45 +2,36 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup Label="Tui">
     <PackageVersion Include="Terminal.Gui" Version="2.0.0-develop.5100" />
   </ItemGroup>
-
   <ItemGroup Label="Charts">
     <PackageVersion Include="Plotly.NET" Version="5.1.0" />
   </ItemGroup>
-
   <ItemGroup Label="Test - Verify">
-    <PackageVersion Include="Verify.XunitV3" Version="31.13.2" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.15.0" />
   </ItemGroup>
-
-
   <ItemGroup Label="FSharp">
-    <PackageVersion Include="FSharp.Core" Version="10.0.103" />
+    <PackageVersion Include="FSharp.Core" Version="10.1.201" />
     <PackageVersion Include="FsToolkit.ErrorHandling" Version="5.2.0" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.4.36" />
   </ItemGroup>
-
   <ItemGroup Label="Data">
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
   </ItemGroup>
-
   <ItemGroup Label="Configuration">
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
   </ItemGroup>
-
   <ItemGroup Label="Test">
     <PackageVersion Include="Unquote" Version="7.0.1" />
     <PackageVersion Include="TngTech.ArchUnitNET.xUnit" Version="0.13.3" />
   </ItemGroup>
-
   <ItemGroup Label="Test - xunit">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Update NuGet package versions (`FSharp.Core`, `Verify.XunitV3`, `Microsoft.NET.Test.Sdk`, `coverlet.collector`)
- Extract `coverlet.collector` `PackageReference` metadata into `Directory.Build.props` with condition `IsPackable == false and MSBuildProjectName.Contains('Tests')`, removing the duplicated block from all 7 test projects