### PR TITLE
🔧 chore: replace Dependabot with Renovate Bot for NuGet CPM support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: nuget
-    directory: "/"
-    schedule:
-      interval: weekly

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"],
+  "schedule": ["every weekend"],
+  "commitMessagePrefix": "⬆️ chore:"
 }


### PR DESCRIPTION
## Summary
- Remove `.github/dependabot.yml` — Dependabot does not support NuGet Central Package Management (CPM) and was never opening update PRs despite running on schedule
- Add `renovate.json` with `config:recommended`, weekly schedule, and gitmoji commit prefix — Renovate has first-class CPM support and will update `Directory.Packages.props` directly

Closes #87