### PR TITLE
🚀 chore: add GitHub release workflow and install docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Publish single executable
+        run: >
+          dotnet publish BpMonitor.Tui/BpMonitor.Tui.fsproj
+          --configuration Release
+          --runtime linux-x64
+          --self-contained true
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          -p:DebugType=none
+          --output ./publish
+        working-directory: code
+
+      - name: Rename binary
+        run: mv code/publish/BpMonitor.Tui code/publish/bpmonitor
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: code/publish/bpmonitor
+          generate_release_notes: true

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,28 @@
+# Installing BpMonitor on Arch Linux
+
+BpMonitor is distributed as a self-contained single executable — no .NET runtime required.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
+```
+
+This downloads the latest release and installs it to `~/.local/bin/bpmonitor`.
+
+## Custom install path
+
+```bash
+INSTALL_PATH=/usr/local/bin/bpmonitor curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
+```
+
+## Creating a new release
+
+Push a version tag on `main` to trigger the release workflow:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The workflow builds the executable and publishes a GitHub Release with auto-generated release notes.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="draptik/BpMonitor"
+BINARY_NAME="bpmonitor"
+INSTALL_PATH="${INSTALL_PATH:-$HOME/.local/bin/$BINARY_NAME}"
+
+LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep tag_name | cut -d'"' -f4)
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST/$BINARY_NAME"
+
+mkdir -p "$(dirname "$INSTALL_PATH")"
+curl -fsSL "$DOWNLOAD_URL" -o "$INSTALL_PATH"
+chmod +x "$INSTALL_PATH"
+echo "Installed $BINARY_NAME $LATEST to $INSTALL_PATH"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` triggered on `v*` tag pushes: builds a self-contained `linux-x64` single-file executable and publishes it as a GitHub Release with auto-generated release notes
- Add `install.sh` at repo root: fetches the latest release via the GitHub API and installs to `~/.local/bin/bpmonitor` (overridable via `INSTALL_PATH`)
- Add `docs/install.md` with a one-liner install command and custom path instructions