### PR TITLE
🐛 fix: include appsettings.json in release assets and install script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: code/publish/bpmonitor
+          files: |
+            code/publish/bpmonitor
+            code/publish/appsettings.json
           generate_release_notes: true

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,12 @@ INSTALL_PATH="${INSTALL_PATH:-$HOME/.local/bin/$BINARY_NAME}"
 LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep tag_name | cut -d'"' -f4)
 DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST/$BINARY_NAME"
 
-mkdir -p "$(dirname "$INSTALL_PATH")"
+INSTALL_DIR="$(dirname "$INSTALL_PATH")"
+mkdir -p "$INSTALL_DIR"
+
 curl -fsSL "$DOWNLOAD_URL" -o "$INSTALL_PATH"
 chmod +x "$INSTALL_PATH"
+
+curl -fsSL "https://github.com/$REPO/releases/download/$LATEST/appsettings.json" -o "$INSTALL_DIR/appsettings.json"
+
 echo "Installed $BINARY_NAME $LATEST to $INSTALL_PATH"


### PR DESCRIPTION
## Summary
- Upload `appsettings.json` alongside the binary as a release asset — dotnet publish already writes it to the output directory
- Update `install.sh` to download `appsettings.json` into the same directory as the binary so the app can find it at runtime