### PR TITLE
🐛 fix: create bpmonitor.json if missing on startup

### DIFF
--- a/code/BpMonitor.Import.Tests/JsonImportTests.fs
+++ b/code/BpMonitor.Import.Tests/JsonImportTests.fs
@@ -81,6 +81,30 @@ let ``tryReadFromFile returns Error when file contains invalid JSON`` () =
   test <@ result <> Ok [] @>
 
 [<Fact>]
+let ``ensureFileExists - creates file with empty array when file does not exist`` () =
+  let path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+
+  try
+    ensureFileExists path
+
+    test <@ File.Exists(path) @>
+    test <@ File.ReadAllText(path) = "[]" @>
+  finally
+    File.Delete(path)
+
+[<Fact>]
+let ``ensureFileExists - does not overwrite existing file`` () =
+  let path = Path.GetTempFileName()
+
+  try
+    File.WriteAllText(path, "existing content")
+    ensureFileExists path
+
+    test <@ File.ReadAllText(path) = "existing content" @>
+  finally
+    File.Delete(path)
+
+[<Fact>]
 let ``import - new reading is added to repository`` () =
   let repo = InMemoryReadingRepository(Some []) :> IReadingRepository
 

--- a/code/BpMonitor.Import/JsonImport.fs
+++ b/code/BpMonitor.Import/JsonImport.fs
@@ -19,6 +19,10 @@ let parse (json: string) : Result<BloodPressureReading list, string> =
   with :? JsonException as ex ->
     Error ex.Message
 
+let ensureFileExists (path: string) : unit =
+  if not (File.Exists(path)) then
+    File.WriteAllText(path, "[]")
+
 let tryReadFromFile (path: string) : Result<BloodPressureReading list, string> =
   try
     Ok(File.ReadAllText(path))

--- a/code/BpMonitor.Tui/Program.fs
+++ b/code/BpMonitor.Tui/Program.fs
@@ -184,6 +184,9 @@ let main _ =
   app.Init() |> ignore
   let repository = ReadingRepository.create connectionString
 
+  if not (String.IsNullOrEmpty(exportJsonPath)) then
+    ensureFileExists exportJsonPath
+
   let jsonImportWarning =
     if String.IsNullOrEmpty(exportJsonPath) then
       None


### PR DESCRIPTION
## Summary
- Extract `ensureFileExists` into `BpMonitor.Import.JsonImport` — creates an empty `[]` file at the given path if it does not exist
- Call it from `Program.fs` on startup so `bpmonitor.json` is silently created rather than triggering a warning dialog
- Add two tests: file is created with `[]` when missing; existing file is not overwritten