### PR TITLE
✨ feat: add Import:MarkdownDirectory config to appsettings with default "."

### DIFF
--- a/code/BpMonitor.Tui/Program.fs
+++ b/code/BpMonitor.Tui/Program.fs
@@ -179,6 +179,7 @@ let main _ =
   let connectionString = config.GetConnectionString("DefaultConnection")
   let ranges = readRanges config
   let exportJsonPath = config["Export:JsonPath"]
+  let importMarkdownDirectory = config["Import:MarkdownDirectory"]
 
   use app = Application.Create()
   app.Init() |> ignore
@@ -217,6 +218,9 @@ let main _ =
   let showImportDialog () =
     let dialog =
       new OpenDialog(Title = "Import from Markdown", AllowsMultipleSelection = false)
+
+    if not (String.IsNullOrEmpty(importMarkdownDirectory)) then
+      dialog.Path <- importMarkdownDirectory
 
     app.Run(dialog) |> ignore
 

--- a/code/BpMonitor.Tui/appsettings.json
+++ b/code/BpMonitor.Tui/appsettings.json
@@ -5,6 +5,9 @@
   "Export": {
     "JsonPath": "bpmonitor.json"
   },
+  "Import": {
+    "MarkdownDirectory": "."
+  },
   "ReadingRanges": {
     "SystolicMin": 1,
     "SystolicMax": 300,


### PR DESCRIPTION
## Summary
- Add `Import:MarkdownDirectory` key to `appsettings.json` defaulting to `"."` (current working directory)
- Read the value in `Program.fs` and pre-populate `OpenDialog.Path` so the markdown import dialog opens in the configured directory