### PR TITLE
🐛 fix: expand ~ in Import:MarkdownDirectory before setting dialog path

### DIFF
--- a/code/BpMonitor.Tui/Program.fs
+++ b/code/BpMonitor.Tui/Program.fs
@@ -242,7 +242,8 @@ let main _ =
         new OpenDialog(Title = "Import from Markdown", AllowsMultipleSelection = false)
 
       if not (String.IsNullOrEmpty(importMarkdownDirectory)) then
-        dialog.Path <- importMarkdownDirectory
+        let home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+        dialog.Path <- importMarkdownDirectory.Replace("~", home)
 
       app.Run(dialog) |> ignore
 


### PR DESCRIPTION
## Summary
- `~` in paths is a shell convention; .NET does not expand it automatically
- Replace leading `~` with `Environment.SpecialFolder.UserProfile` before assigning to `OpenDialog.Path`