### PR TITLE
🔧 chore: make install.sh configurable with CLI args and add shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,16 @@ jobs:
       - name: Run markdownlint-cli2
         run: npx markdownlint-cli2 "**/*.md"
 
+  lint-shell:
+    name: Lint Shell
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run shellcheck
+        run: find . -name "*.sh" -not -path "./.husky/_/*" | xargs shellcheck
+
   lint-fsharp:
     name: Lint F#
     runs-on: ubuntu-latest

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -2,6 +2,15 @@
    "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
    "tasks": [
       {
+         "name": "shellcheck",
+         "group": "pre-commit",
+         "command": "shellcheck",
+         "args": ["${staged}"],
+         "include": ["**/*.sh"],
+         "exclude": [".husky/_/*.sh"],
+         "staged": true
+      },
+      {
          "name": "markdownlint",
          "group": "pre-commit",
          "command": "markdownlint-cli2",

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,52 @@
 #!/usr/bin/env bash
+# install.sh — Download and install the latest BpMonitor release from GitHub.
+#
+# Usage:
+#   ./install.sh [OPTIONS]
+#
+# Options:
+#   -b PATH   Base directory for installation  (default: ~/.local/bin)
+#   -d NAME   Subdirectory under base path     (default: bp)
+#   -n NAME   Name of the installed executable (default: bpmonitor)
+#   -h        Show this help message
+#
+# Options take precedence over environment variables of the same meaning.
+# The binary is installed to: BASE_PATH/INSTALL_DIR_NAME/BINARY_NAME
+# An appsettings.json is placed alongside the binary.
+#
+# Examples:
+#   ./install.sh
+#   ./install.sh -b /opt/local/bin
+#   ./install.sh -d bpmon -n bp
 set -euo pipefail
 
 REPO="draptik/BpMonitor"
-BINARY_NAME="bpmonitor"
-INSTALL_PATH="${INSTALL_PATH:-$HOME/.local/bin/$BINARY_NAME}"
+ARTIFACT_NAME="bpmonitor"
+BASE_PATH="${BASE_PATH:-$HOME/.local/bin}"
+INSTALL_DIR_NAME="${INSTALL_DIR_NAME:-bp}"
+BINARY_NAME="${BINARY_NAME:-$ARTIFACT_NAME}"
+
+usage() {
+  sed -n '/^# install\.sh/,/^[^#]/{ /^[^#]/d; s/^# \?//; p }' "$0"
+  exit 0
+}
+
+while getopts ":b:d:n:h" opt; do
+  case $opt in
+    b) BASE_PATH="$OPTARG" ;;
+    d) INSTALL_DIR_NAME="$OPTARG" ;;
+    n) BINARY_NAME="$OPTARG" ;;
+    h) usage ;;
+    :) echo "Option -$OPTARG requires an argument." >&2; exit 1 ;;
+    \?) echo "Unknown option: -$OPTARG" >&2; exit 1 ;;
+  esac
+done
+INSTALL_DIR="$BASE_PATH/$INSTALL_DIR_NAME"
+INSTALL_PATH="$INSTALL_DIR/$BINARY_NAME"
 
 LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep tag_name | cut -d'"' -f4)
-DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST/$BINARY_NAME"
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST/$ARTIFACT_NAME"
 
-INSTALL_DIR="$(dirname "$INSTALL_PATH")"
 mkdir -p "$INSTALL_DIR"
 
 curl -fsSL "$DOWNLOAD_URL" -o "$INSTALL_PATH"


### PR DESCRIPTION
## Summary
- `install.sh` now accepts CLI flags (`-b`, `-d`, `-n`, `-h`) to configure base path, install subdirectory, and binary name; env vars still work as fallback
- Default install path changed from `~/.local/bin/bpmonitor` to `~/.local/bin/bp/bpmonitor`
- Separated `ARTIFACT_NAME` (fixed GitHub release artifact) from `BINARY_NAME` (installed name) to prevent broken download URLs when renaming
- Added shell documentation and `-h` usage output
- Added `shellcheck` to CI (`lint-shell` job) and pre-commit hook, excluding the generated `.husky/_/husky.sh`