### PR TITLE
⬆️ chore: bump softprops/action-gh-release from v2 to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: mv code/publish/BpMonitor.Tui code/publish/bpmonitor
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             code/publish/bpmonitor


### PR DESCRIPTION
## Summary
- Bumps `softprops/action-gh-release` from `v2` to `v3`
- v3 moves the action runtime from Node 20 to Node 24, resolving the deprecation warning seen in the v0.1.7 release run