### PR TITLE
📝 docs: update install docs and add helper scripts

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -8,13 +8,54 @@ BpMonitor is distributed as a self-contained single executable — no .NET runti
 curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
 ```
 
-This downloads the latest release and installs it to `~/.local/bin/bpmonitor`.
+This downloads the latest release and installs it to `~/.local/bin/bp/bpmonitor`.
 
-## Custom install path
+## Custom install location
+
+Use flags to override defaults:
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `-b PATH` | `~/.local/bin` | Base directory |
+| `-d NAME` | `bp` | Subdirectory under base path |
+| `-n NAME` | `bpmonitor` | Executable name |
 
 ```bash
-INSTALL_PATH=/usr/local/bin/bpmonitor curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -b /usr/local/bin -d bp -n bpmonitor
 ```
+
+Or via environment variables:
+
+```bash
+BASE_PATH=/usr/local/bin INSTALL_DIR_NAME=bp BINARY_NAME=bpmonitor \
+  curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
+```
+
+Run with `-h` for full usage:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -h
+```
+
+## Helper scripts
+
+`docs/scripts/` contains convenience scripts for managing a local installation.
+
+### Install and configure
+
+```bash
+IMPORT_FILE_LOCATION=~/documents/health bash docs/scripts/install.sh
+```
+
+Runs `install.sh` and patches `appsettings.json` to set `MarkdownDirectory` to the given path. Defaults to `.` if `IMPORT_FILE_LOCATION` is not set.
+
+### Remove local installation
+
+```bash
+bash docs/scripts/clean.sh
+```
+
+Removes the `~/.local/bin/bp/` directory.
 
 ## Creating a new release
 

--- a/docs/scripts/clean.sh
+++ b/docs/scripts/clean.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rm -rf ./bp

--- a/docs/scripts/install.sh
+++ b/docs/scripts/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMPORT_FILE_LOCATION="${IMPORT_FILE_LOCATION:-.}"
+INSTALL_DIR="${HOME}/.local/bin/bp"
+
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
+
+sed -i "s|\"MarkdownDirectory\": \".\"|\"MarkdownDirectory\": \"${IMPORT_FILE_LOCATION}\"|" "${INSTALL_DIR}/appsettings.json"


### PR DESCRIPTION
## Summary
- Update `docs/install.md` to reflect new default install path (`~/.local/bin/bp/bpmonitor`), document CLI flags and env vars, and add helper scripts section
- Add `docs/scripts/install.sh`: installs and patches `appsettings.json` with configurable `IMPORT_FILE_LOCATION`
- Add `docs/scripts/clean.sh`: removes the local `~/.local/bin/bp/` installation
- Both scripts pass shellcheck and follow project shell conventions