### PR TITLE
🔧 chore: update model references to Opus 4.8

### DIFF
--- a/.claude/skills/model-advisor/SKILL.md
+++ b/.claude/skills/model-advisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-advisor
-description: Reference for selecting the right Claude model (Opus 4.6, Sonnet 4.6, Haiku 4.5) based on task complexity, reasoning depth, and cost/speed tradeoffs. Auto-loaded when model selection is relevant.
+description: Reference for selecting the right Claude model (Opus 4.8, Sonnet 4.6, Haiku 4.5) based on task complexity, reasoning depth, and cost/speed tradeoffs. Auto-loaded when model selection is relevant.
 user-invocable: false
 ---
 
@@ -12,7 +12,7 @@ Recommend the most appropriate Claude model for each task based on complexity, r
 
 | Model ID | Name | Strengths |
 | --- | --- | --- |
-| `claude-opus-4-6` | Claude Opus 4.6 | Deep reasoning, complex decisions, nuanced judgment |
+| `claude-opus-4-8` | Claude Opus 4.8 | Deep reasoning, complex decisions, nuanced judgment |
 | `claude-sonnet-4-6` | Claude Sonnet 4.6 | Balanced capability and speed, code generation, most tasks |
 | `claude-haiku-4-5-20251001` | Claude Haiku 4.5 | Fast, lightweight, simple and conversational tasks |
 
@@ -39,7 +39,7 @@ When in doubt: **Sonnet is the safe default.**
 | Persona | Default Model | Reason |
 | --- | --- | --- |
 | Product Visionary (Lisa) | Haiku 4.5 | Conversational, exploratory |
-| Architect (Professor Frink) | Opus 4.6 | Complex tradeoff analysis |
+| Architect (Professor Frink) | Opus 4.8 | Complex tradeoff analysis |
 | Senior Developer / TDD (Sideshow Bob) | Sonnet 4.6 | Code generation + reasoning |
 | Senior Tester (Martin Prince) | Sonnet 4.6 | Code analysis and test generation |
 
@@ -54,7 +54,7 @@ When in doubt: **Sonnet is the safe default.**
 ## How to Switch Models
 
 ```text
-/model claude-opus-4-6
+/model claude-opus-4-8
 /model claude-sonnet-4-6
 /model claude-haiku-4-5-20251001
 ```

--- a/.claude/skills/model-advisor/SKILL.md
+++ b/.claude/skills/model-advisor/SKILL.md
@@ -41,7 +41,6 @@ When in doubt: **Sonnet is the safe default.**
 | Product Visionary (Lisa) | Haiku 4.5 | Conversational, exploratory |
 | Architect (Professor Frink) | Opus 4.8 | Complex tradeoff analysis |
 | Senior Developer / TDD (Sideshow Bob) | Sonnet 4.6 | Code generation + reasoning |
-| Senior Tester (Martin Prince) | Sonnet 4.6 | Code analysis and test generation |
 
 ## Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ All persona rules are **always in effect** — read the relevant persona file be
 | Persona | File | Model |
 | --- | --- | --- |
 | Product Visionary (Lisa) | `docs/personas/product-visionary-lisa.md` | Haiku 4.5 |
-| Architect (Professor Frink) | `docs/personas/architect-frink.md` | Opus 4.6 |
+| Architect (Professor Frink) | `docs/personas/architect-frink.md` | Opus 4.8 |
 | Senior Developer / TDD (Sideshow Bob) | `docs/personas/tdd-sideshow-bob.md` | Sonnet 4.6 |
 
 To switch: *"Switch to the Architect persona"* or reference the file directly.

--- a/docs/personas/architect-frink.md
+++ b/docs/personas/architect-frink.md
@@ -2,7 +2,7 @@
 
 ## Model
 
-Run `/model claude-opus-4-6` when switching to this persona.
+Run `/model claude-opus-4-8` when switching to this persona.
 
 ## Role
 


### PR DESCRIPTION
## Summary

Housekeeping pass on model references across project docs and skills.

- Bump the Architect (Professor Frink) persona from Opus 4.6 → **Opus 4.8** (`claude-opus-4-8`) in `AGENTS.md`, `docs/personas/architect-frink.md`, and `.claude/skills/model-advisor/SKILL.md`.
- Drop the stale **Senior Tester (Martin Prince)** row from `model-advisor` — that persona has no entry in `AGENTS.md` and no `docs/personas/` file.

Sonnet 4.6 and Haiku 4.5 references were left unchanged since they're still the latest in their tiers.