### PR TITLE
✅ test: introduce property-based testing with FsCheck

### DIFF
--- a/code/BpMonitor.Core.Tests/BloodPressureReadingPropertyTests.fs
+++ b/code/BpMonitor.Core.Tests/BloodPressureReadingPropertyTests.fs
@@ -1,0 +1,88 @@
+module BpMonitor.Core.Tests.BloodPressureReadingPropertyTests
+
+open System
+open FsCheck.FSharp
+open FsCheck.Xunit
+open BpMonitor.Core
+open BpMonitor.Core.Tests.Generators
+
+let private inRange lo hi v = v >= lo && v <= hi
+
+[<Property>]
+let ``valid input parses to Ok preserving all fields`` () =
+  Prop.forAll (Arb.fromGen validUnvalidatedGen) (fun input ->
+    match BloodPressureReading.parse ranges input with
+    | Ok r ->
+      r.Systolic = input.Systolic
+      && r.Diastolic = input.Diastolic
+      && r.HeartRate = input.HeartRate
+      && r.Timestamp = input.Timestamp
+      && r.Comments = input.Comments
+    | Error _ -> false)
+
+[<Property>]
+let ``valid input always has Id 0 and MinValue audit timestamps`` () =
+  Prop.forAll (Arb.fromGen validUnvalidatedGen) (fun input ->
+    match BloodPressureReading.parse ranges input with
+    | Ok r ->
+      r.Id = 0
+      && r.CreatedAt = DateTimeOffset.MinValue
+      && r.ModifiedAt = DateTimeOffset.MinValue
+    | Error _ -> false)
+
+[<Property>]
+let ``systolic out of range yields exactly SystolicOutOfRange`` () =
+  let arb =
+    Arb.fromGen (Gen.zip validUnvalidatedGen (outOfRangeGen ranges.SystolicMin ranges.SystolicMax))
+
+  Prop.forAll arb (fun (baseInput, badSys) ->
+    let input = { baseInput with Systolic = badSys }
+
+    match BloodPressureReading.parse ranges input with
+    | Error errs -> errs = [ SystolicOutOfRange badSys ]
+    | Ok _ -> false)
+
+[<Property>]
+let ``diastolic out of range yields exactly DiastolicOutOfRange`` () =
+  let arb =
+    Arb.fromGen (Gen.zip validUnvalidatedGen (outOfRangeGen ranges.DiastolicMin ranges.DiastolicMax))
+
+  Prop.forAll arb (fun (baseInput, badDia) ->
+    let input = { baseInput with Diastolic = badDia }
+
+    match BloodPressureReading.parse ranges input with
+    | Error errs -> errs = [ DiastolicOutOfRange badDia ]
+    | Ok _ -> false)
+
+[<Property>]
+let ``heart rate out of range yields exactly HeartRateOutOfRange`` () =
+  let arb =
+    Arb.fromGen (Gen.zip validUnvalidatedGen (outOfRangeGen ranges.HeartRateMin ranges.HeartRateMax))
+
+  Prop.forAll arb (fun (baseInput, badHr) ->
+    let input = { baseInput with HeartRate = badHr }
+
+    match BloodPressureReading.parse ranges input with
+    | Error errs -> errs = [ HeartRateOutOfRange badHr ]
+    | Ok _ -> false)
+
+[<Property>]
+let ``error count equals number of out-of-range fields`` () =
+  Prop.forAll (Arb.fromGen mixedUnvalidatedGen) (fun input ->
+    let expected =
+      (if inRange ranges.SystolicMin ranges.SystolicMax input.Systolic then
+         0
+       else
+         1)
+      + (if inRange ranges.DiastolicMin ranges.DiastolicMax input.Diastolic then
+           0
+         else
+           1)
+      + (if inRange ranges.HeartRateMin ranges.HeartRateMax input.HeartRate then
+           0
+         else
+           1)
+
+    match BloodPressureReading.parse ranges input with
+    | Ok _ -> expected = 0
+    | Error errs -> List.length errs = expected)

--- a/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
+++ b/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
@@ -5,7 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Generators.fs" />
     <Compile Include="BloodPressureReadingTests.fs" />
+    <Compile Include="BloodPressureReadingPropertyTests.fs" />
     <Compile Include="ReadingRepositoryContractTests.fs" />
   </ItemGroup>
 
@@ -16,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FsCheck.Xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Core.Tests/Generators.fs
+++ b/code/BpMonitor.Core.Tests/Generators.fs
@@ -1,0 +1,65 @@
+module BpMonitor.Core.Tests.Generators
+
+open System
+open FsCheck
+open FsCheck.FSharp
+open BpMonitor.Core
+
+let ranges = ReadingRanges.defaults
+
+/// None, or Some non-empty alphabetic string (never null).
+let commentGen: Gen<string option> =
+  let someComment =
+    Gen.elements [ 'a' .. 'z' ]
+    |> Gen.nonEmptyListOf
+    |> Gen.map (fun cs -> Some(String(List.toArray cs)))
+
+  Gen.oneof [ Gen.constant None; someComment ]
+
+let timestampGen: Gen<DateTimeOffset> =
+  gen {
+    let! y = Gen.choose (2000, 2030)
+    let! mo = Gen.choose (1, 12)
+    let! d = Gen.choose (1, 28)
+    let! h = Gen.choose (0, 23)
+    let! mi = Gen.choose (0, 59)
+    return DateTimeOffset(y, mo, d, h, mi, 0, TimeSpan.Zero)
+  }
+
+/// All three measurements within their valid ranges.
+let validUnvalidatedGen: Gen<BloodPressureReadingUnvalidated> =
+  gen {
+    let! sys = Gen.choose (ranges.SystolicMin, ranges.SystolicMax)
+    let! dia = Gen.choose (ranges.DiastolicMin, ranges.DiastolicMax)
+    let! hr = Gen.choose (ranges.HeartRateMin, ranges.HeartRateMax)
+    let! ts = timestampGen
+    let! comments = commentGen
+
+    return
+      { Systolic = sys
+        Diastolic = dia
+        HeartRate = hr
+        Timestamp = ts
+        Comments = comments }
+  }
+
+/// Measurements straddling the range boundaries (each field may be in or out of range).
+let mixedUnvalidatedGen: Gen<BloodPressureReadingUnvalidated> =
+  gen {
+    let! sys = Gen.choose (ranges.SystolicMin - 50, ranges.SystolicMax + 50)
+    let! dia = Gen.choose (ranges.DiastolicMin - 50, ranges.DiastolicMax + 50)
+    let! hr = Gen.choose (ranges.HeartRateMin - 50, ranges.HeartRateMax + 50)
+    let! ts = timestampGen
+    let! comments = commentGen
+
+    return
+      { Systolic = sys
+        Diastolic = dia
+        HeartRate = hr
+        Timestamp = ts
+        Comments = comments }
+  }
+
+/// An int strictly below the minimum or strictly above the maximum.
+let outOfRangeGen (lo: int) (hi: int) : Gen<int> =
+  Gen.oneof [ Gen.choose (lo - 1000, lo - 1); Gen.choose (hi + 1, hi + 1000) ]

--- a/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
+++ b/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
@@ -5,8 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Generators.fs" />
     <Compile Include="MarkdownImportTests.fs" />
+    <Compile Include="MarkdownParseLinePropertyTests.fs" />
     <Compile Include="JsonImportTests.fs" />
+    <Compile Include="JsonRoundTripPropertyTests.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,10 +18,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FsCheck.Xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\BpMonitor.Import\BpMonitor.Import.fsproj" />
+    <ProjectReference Include="..\BpMonitor.Export\BpMonitor.Export.fsproj" />
     <ProjectReference Include="..\BpMonitor.Data\BpMonitor.Data.fsproj" />
   </ItemGroup>
 

--- a/code/BpMonitor.Import.Tests/Generators.fs
+++ b/code/BpMonitor.Import.Tests/Generators.fs
@@ -1,0 +1,92 @@
+module BpMonitor.Import.Tests.Generators
+
+open System
+open FsCheck
+open FsCheck.FSharp
+open BpMonitor.Core
+
+/// None, or Some string of one to three lowercase words joined by single spaces.
+/// Such a comment has no newlines, is non-empty, and equals its own Trim(),
+/// so it survives MarkdownImport.parseLine's `(.*)$` + Trim() round-trip.
+let commentGen: Gen<string option> =
+  let wordGen =
+    Gen.elements [ 'a' .. 'z' ]
+    |> Gen.nonEmptyListOf
+    |> Gen.map (List.toArray >> String)
+
+  let someComment =
+    Gen.choose (1, 3)
+    |> Gen.bind (fun n -> Gen.listOfLength n wordGen)
+    |> Gen.map (fun ws -> Some(String.concat " " ws))
+
+  Gen.oneof [ Gen.constant None; someComment ]
+
+/// A DateTimeOffset with a whole-second time and an hour-aligned offset, which
+/// round-trips exactly through System.Text.Json.
+let timestampGen: Gen<DateTimeOffset> =
+  gen {
+    let! y = Gen.choose (2000, 2030)
+    let! mo = Gen.choose (1, 12)
+    let! d = Gen.choose (1, 28)
+    let! h = Gen.choose (0, 23)
+    let! mi = Gen.choose (0, 59)
+    let! s = Gen.choose (0, 59)
+    let! offsetHours = Gen.choose (-12, 12)
+    return DateTimeOffset(y, mo, d, h, mi, s, TimeSpan.FromHours(float offsetHours))
+  }
+
+/// A fully-populated, validated reading for JSON round-trip testing.
+/// Comments are never `Some null` (which FSharp.SystemTextJson would collapse to None).
+let readingGen: Gen<BloodPressureReading> =
+  gen {
+    let! id = Gen.choose (0, 100000)
+    let! sys = Gen.choose (1, 300)
+    let! dia = Gen.choose (1, 200)
+    let! hr = Gen.choose (1, 300)
+    let! ts = timestampGen
+    let! comments = commentGen
+    let! created = timestampGen
+    let! modified = timestampGen
+
+    return
+      { Id = id
+        Systolic = sys
+        Diastolic = dia
+        HeartRate = hr
+        Timestamp = ts
+        Comments = comments
+        CreatedAt = created
+        ModifiedAt = modified }
+  }
+
+/// The raw ingredients of a single markdown reading line.
+type MarkdownLineCase =
+  { Date: DateOnly
+    Hour: int
+    Minute: int
+    Systolic: int
+    Diastolic: int
+    HeartRate: int
+    Comment: string option }
+
+let markdownLineGen: Gen<MarkdownLineCase> =
+  gen {
+    let! y = Gen.choose (2000, 2030)
+    let! mo = Gen.choose (1, 12)
+    let! d = Gen.choose (1, 28)
+    let! h = Gen.choose (0, 23)
+    let! mi = Gen.choose (0, 59)
+    let! sys = Gen.choose (1, 999)
+    let! dia = Gen.choose (1, 999)
+    let! hr = Gen.choose (1, 999)
+    let! comment = commentGen
+
+    return
+      { Date = DateOnly(y, mo, d)
+        Hour = h
+        Minute = mi
+        Systolic = sys
+        Diastolic = dia
+        HeartRate = hr
+        Comment = comment }
+  }

--- a/code/BpMonitor.Import.Tests/JsonRoundTripPropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/JsonRoundTripPropertyTests.fs
@@ -1,0 +1,12 @@
+module BpMonitor.Import.Tests.JsonRoundTripPropertyTests
+
+open FsCheck.FSharp
+open FsCheck.Xunit
+open BpMonitor.Export
+open BpMonitor.Import
+open BpMonitor.Import.Tests.Generators
+
+[<Property>]
+let ``serialize then parse round-trips a reading list`` () =
+  Prop.forAll (Arb.fromGen (Gen.listOf readingGen)) (fun readings ->
+    JsonImport.parse (JsonExport.serialize readings) = Ok readings)

--- a/code/BpMonitor.Import.Tests/MarkdownParseLinePropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/MarkdownParseLinePropertyTests.fs
@@ -1,0 +1,29 @@
+module BpMonitor.Import.Tests.MarkdownParseLinePropertyTests
+
+open FsCheck.FSharp
+open FsCheck.Xunit
+open BpMonitor.Core
+open BpMonitor.Import.MarkdownImport
+open BpMonitor.Import.Tests.Generators
+
+let private renderLine (c: MarkdownLineCase) =
+  let suffix =
+    match c.Comment with
+    | Some s -> " " + s
+    | None -> ""
+
+  $"- %02d{c.Hour}:%02d{c.Minute}: %d{c.Systolic}/%d{c.Diastolic} %d{c.HeartRate}%s{suffix}"
+
+[<Property>]
+let ``parseLine round-trips a rendered reading line`` () =
+  Prop.forAll (Arb.fromGen markdownLineGen) (fun c ->
+    let line = renderLine c
+
+    let expected: BloodPressureReadingUnvalidated =
+      { Systolic = c.Systolic
+        Diastolic = c.Diastolic
+        HeartRate = c.HeartRate
+        Timestamp = Timestamp.local c.Date.Year c.Date.Month c.Date.Day c.Hour c.Minute 0
+        Comments = c.Comment }
+
+    parseLine c.Date line = Some expected)

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -36,4 +36,8 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
+  <ItemGroup Label="Test - PBT">
+    <PackageVersion Include="FsCheck" Version="3.3.2" />
+    <PackageVersion Include="FsCheck.Xunit.v3" Version="3.3.2" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

First iteration of property-based testing (PBT) for the domain logic, using **FsCheck** integrated with xUnit v3 via **`FsCheck.Xunit.v3`** (`[<Property>]`).

Three high-value properties:

1. **JSON round-trip** — `JsonImport.parse (JsonExport.serialize xs) = Ok xs`
2. **Validation invariants** (`BloodPressureReading.parse`) — field preservation on success; `Id=0` and `MinValue` audit timestamps; each field out of range yields exactly the matching `ValidationError`; error count equals the number of out-of-range fields.
3. **Markdown round-trip** — a canonical reading line built from generated values parses back via `MarkdownImport.parseLine`.

Each test project gets a small `Generators.fs` with constrained generators. Two edge cases worth calling out (both encoded in the generators):

- `FSharp.SystemTextJson` collapses `Comments = Some null` → JSON `null` → `None`, which breaks the round-trip — the reading generator never produces `Some null`.
- Markdown comments are generated as trimmed, newline-free strings so they survive the `(.*)$` + `Trim()` parse.

## Scope

Deferred to a later iteration: import accounting/idempotence and chart properties.

## Verification

- Full suite green (116 tests across all projects).
- `dotnet fantomas --check .` clean.
- Confirmed the round-trip property catches real bugs: temporarily breaking `JsonExport.serialize` made it fail with a shrunk counterexample, then reverted.