### PR TITLE
✅ test: add import accounting and idempotence properties

### DIFF
--- a/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
+++ b/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="MarkdownParseLinePropertyTests.fs" />
     <Compile Include="JsonImportTests.fs" />
     <Compile Include="JsonRoundTripPropertyTests.fs" />
+    <Compile Include="ImportPropertyTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Import.Tests/Generators.fs
+++ b/code/BpMonitor.Import.Tests/Generators.fs
@@ -90,3 +90,44 @@ let markdownLineGen: Gen<MarkdownLineCase> =
         HeartRate = hr
         Comment = comment }
   }
+
+let private toUnvalidated (r: BloodPressureReading) : BloodPressureReadingUnvalidated =
+  { Systolic = r.Systolic
+    Diastolic = r.Diastolic
+    HeartRate = r.HeartRate
+    Timestamp = r.Timestamp
+    Comments = r.Comments }
+
+/// A reading whose measurements may fall outside ReadingRanges.defaults.
+let private mixedReadingGen: Gen<BloodPressureReading> =
+  gen {
+    let! r = readingGen
+    let! sys = Gen.choose (-50, 350)
+    let! dia = Gen.choose (-50, 250)
+    let! hr = Gen.choose (-50, 350)
+
+    return
+      { r with
+          Systolic = sys
+          Diastolic = dia
+          HeartRate = hr }
+  }
+
+/// Assigns distinct, increasing timestamps so dedup-by-timestamp is deterministic.
+let private withDistinctTimestamps (rs: BloodPressureReading list) =
+  rs
+  |> List.mapi (fun i r ->
+    { r with
+        Timestamp = DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero).AddMinutes(float i) })
+
+/// A list of fully-valid (in-range) readings, each with a distinct timestamp.
+let distinctValidReadingsGen: Gen<BloodPressureReading list> =
+  Gen.listOf readingGen |> Gen.map withDistinctTimestamps
+
+/// A list of valid in-range unvalidated readings, each with a distinct timestamp.
+let distinctValidUnvalidatedGen: Gen<BloodPressureReadingUnvalidated list> =
+  distinctValidReadingsGen |> Gen.map (List.map toUnvalidated)
+
+/// A list of unvalidated readings mixing in-range and out-of-range measurements.
+let mixedUnvalidatedListGen: Gen<BloodPressureReadingUnvalidated list> =
+  Gen.listOf mixedReadingGen |> Gen.map (List.map toUnvalidated)

--- a/code/BpMonitor.Import.Tests/ImportPropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/ImportPropertyTests.fs
@@ -1,0 +1,47 @@
+module BpMonitor.Import.Tests.ImportPropertyTests
+
+open FsCheck.FSharp
+open FsCheck.Xunit
+open BpMonitor.Core
+open BpMonitor.Data
+open BpMonitor.Import
+open BpMonitor.Import.Tests.Generators
+
+let private emptyRepo () =
+  InMemoryReadingRepository(Some []) :> IReadingRepository
+
+let private withLines (readings: BloodPressureReadingUnvalidated list) =
+  readings |> List.mapi (fun i r -> (i + 1, "", r))
+
+[<Property>]
+let ``markdown import accounts for every input row`` () =
+  Prop.forAll (Arb.fromGen mixedUnvalidatedListGen) (fun readings ->
+    let summary =
+      MarkdownImport.import (emptyRepo ()) ReadingRanges.defaults (withLines readings)
+
+    summary.Added + summary.Updated + summary.Failed.Length = readings.Length)
+
+[<Property>]
+let ``markdown re-import of valid distinct readings updates all and adds none`` () =
+  Prop.forAll (Arb.fromGen distinctValidUnvalidatedGen) (fun readings ->
+    let repo = emptyRepo ()
+    let rows = withLines readings
+    MarkdownImport.import repo ReadingRanges.defaults rows |> ignore
+    let second = MarkdownImport.import repo ReadingRanges.defaults rows
+
+    second.Added = 0 && second.Updated = readings.Length && second.Failed.IsEmpty)
+
+[<Property>]
+let ``json import accounts for every input reading`` () =
+  Prop.forAll (Arb.fromGen (Gen.listOf readingGen)) (fun readings ->
+    let summary = JsonImport.import (emptyRepo ()) readings
+    summary.Added + summary.Updated = readings.Length)
+
+[<Property>]
+let ``json re-import of distinct readings updates all and adds none`` () =
+  Prop.forAll (Arb.fromGen distinctValidReadingsGen) (fun readings ->
+    let repo = emptyRepo ()
+    JsonImport.import repo readings |> ignore
+    let second = JsonImport.import repo readings
+
+    second.Added = 0 && second.Updated = readings.Length)


### PR DESCRIPTION
## Summary

Second property-based testing iteration (follow-up to #123), covering the import paths.

Four properties in `ImportPropertyTests.fs`:

- **Markdown accounting** — `Added + Updated + #Failed = input count`, over a mix of in-range and out-of-range readings.
- **Markdown idempotence** — re-importing a valid, distinct-timestamp set updates all rows and adds none.
- **JSON accounting** — `Added + Updated = input count`.
- **JSON idempotence** — re-importing a distinct set updates all and adds none.

New generators in `Generators.fs`: `distinctValidReadingsGen`, `distinctValidUnvalidatedGen`, `mixedUnvalidatedListGen` (plus a `withDistinctTimestamps` helper — the import functions dedup by timestamp, so distinct timestamps make idempotence deterministic).

## Verification

- Full suite green (120 tests).
- `dotnet fantomas --check .` clean.
- Confirmed the accounting property catches bugs: breaking `MarkdownImport.import` to drop the failed list falsified it immediately, then reverted.