### PR TITLE
✅ test: add parseMarkdown document-level properties

### DIFF
--- a/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
+++ b/code/BpMonitor.Import.Tests/BpMonitor.Import.Tests.fsproj
@@ -8,6 +8,7 @@
     <Compile Include="Generators.fs" />
     <Compile Include="MarkdownImportTests.fs" />
     <Compile Include="MarkdownParseLinePropertyTests.fs" />
+    <Compile Include="ParseMarkdownPropertyTests.fs" />
     <Compile Include="JsonImportTests.fs" />
     <Compile Include="JsonRoundTripPropertyTests.fs" />
     <Compile Include="ImportPropertyTests.fs" />

--- a/code/BpMonitor.Import.Tests/Generators.fs
+++ b/code/BpMonitor.Import.Tests/Generators.fs
@@ -131,3 +131,82 @@ let distinctValidUnvalidatedGen: Gen<BloodPressureReadingUnvalidated list> =
 /// A list of unvalidated readings mixing in-range and out-of-range measurements.
 let mixedUnvalidatedListGen: Gen<BloodPressureReadingUnvalidated list> =
   Gen.listOf mixedReadingGen |> Gen.map (List.map toUnvalidated)
+
+/// A single source line in a generated markdown document. Each item renders to
+/// exactly one line (no embedded newlines), so 1-based line numbers map to indices.
+type DocItem =
+  /// An ISO date header line, e.g. "2024-10-15".
+  | DateHeader of DateOnly
+  /// A date header followed by trailing text, e.g. "2024-10-18 day comment".
+  | DateHeaderWithText of DateOnly * string
+  /// A reading line, e.g. "- 08:30: 120/80 65 after coffee".
+  | ReadingRow of hour: int * minute: int * systolic: int * diastolic: int * heartRate: int * comment: string option
+  /// A line that is neither a date header nor a reading (headings, comments, blanks).
+  | NoiseRow of string
+
+let private renderDate (d: DateOnly) =
+  $"%04d{d.Year}-%02d{d.Month}-%02d{d.Day}"
+
+let renderDocLine (item: DocItem) : string =
+  match item with
+  | DateHeader d -> renderDate d
+  | DateHeaderWithText(d, t) -> renderDate d + " " + t
+  | ReadingRow(h, m, sys, dia, hr, comment) ->
+    let suffix =
+      match comment with
+      | Some s -> " " + s
+      | None -> ""
+
+    $"- %02d{h}:%02d{m}: %d{sys}/%d{dia} %d{hr}%s{suffix}"
+  | NoiseRow s -> s
+
+let private wordsGen: Gen<string> =
+  let wordGen =
+    Gen.elements [ 'a' .. 'z' ]
+    |> Gen.nonEmptyListOf
+    |> Gen.map (List.toArray >> String)
+
+  Gen.choose (1, 3)
+  |> Gen.bind (fun n -> Gen.listOfLength n wordGen)
+  |> Gen.map (String.concat " ")
+
+let private dateOnlyGen: Gen<DateOnly> =
+  gen {
+    let! y = Gen.choose (2000, 2030)
+    let! mo = Gen.choose (1, 12)
+    let! d = Gen.choose (1, 28)
+    return DateOnly(y, mo, d)
+  }
+
+let private dateHeaderItemGen: Gen<DocItem> =
+  gen {
+    let! d = dateOnlyGen
+    let! trailing = Gen.oneof [ Gen.constant None; wordsGen |> Gen.map Some ]
+
+    return
+      match trailing with
+      | Some t -> DateHeaderWithText(d, t)
+      | None -> DateHeader d
+  }
+
+let private readingItemGen: Gen<DocItem> =
+  gen {
+    let! h = Gen.choose (0, 23)
+    let! m = Gen.choose (0, 59)
+    let! sys = Gen.choose (1, 999)
+    let! dia = Gen.choose (1, 999)
+    let! hr = Gen.choose (1, 999)
+    let! comment = commentGen
+    return ReadingRow(h, m, sys, dia, hr, comment)
+  }
+
+/// Lines that match neither the date nor the reading pattern.
+let private noiseItemGen: Gen<DocItem> =
+  Gen.elements [ "# heading"; "<!-- ignore -->"; ""; "## section"; "notes here" ]
+  |> Gen.map NoiseRow
+
+/// A document as an ordered mix of date headers, reading lines, and noise,
+/// weighted towards reading lines.
+let docItemsGen: Gen<DocItem list> =
+  Gen.frequency [ 2, dateHeaderItemGen; 4, readingItemGen; 2, noiseItemGen ]
+  |> Gen.listOf

--- a/code/BpMonitor.Import.Tests/ParseMarkdownPropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/ParseMarkdownPropertyTests.fs
@@ -1,0 +1,52 @@
+module BpMonitor.Import.Tests.ParseMarkdownPropertyTests
+
+open FsCheck.FSharp
+open FsCheck.Xunit
+open BpMonitor.Core
+open BpMonitor.Import.MarkdownImport
+open BpMonitor.Import.Tests.Generators
+
+let private render (items: DocItem list) =
+  items |> List.map renderDocLine |> String.concat "\n"
+
+/// A clean re-implementation of parseMarkdown's date-carry-forward and filtering,
+/// used as an oracle. Lines are joined with '\n', so each item's 1-based line
+/// number is its index + 1.
+let private expected (items: DocItem list) =
+  let folder (currentDate, acc) (i, item) =
+    match item with
+    | DateHeader d -> (Some d, acc)
+    | DateHeaderWithText(d, _) -> (Some d, acc)
+    | NoiseRow _ -> (currentDate, acc)
+    | ReadingRow(h, m, sys, dia, hr, comment) ->
+      match currentDate with
+      | None -> (currentDate, acc)
+      | Some d ->
+        let reading: BloodPressureReadingUnvalidated =
+          { Systolic = sys
+            Diastolic = dia
+            HeartRate = hr
+            Timestamp = Timestamp.local d.Year d.Month d.Day h m 0
+            Comments = comment }
+
+        (currentDate, (i + 1, renderDocLine item, reading) :: acc)
+
+  items |> List.indexed |> List.fold folder (None, []) |> snd |> List.rev
+
+[<Property>]
+let ``parseMarkdown matches the date-carry-forward model`` () =
+  Prop.forAll (Arb.fromGen docItemsGen) (fun items -> parseMarkdown (render items) = expected items)
+
+[<Property>]
+let ``parseMarkdown emits strictly increasing line numbers`` () =
+  Prop.forAll (Arb.fromGen docItemsGen) (fun items ->
+    let lineNumbers = parseMarkdown (render items) |> List.map (fun (n, _, _) -> n)
+    lineNumbers = List.sort lineNumbers && List.distinct lineNumbers = lineNumbers)
+
+[<Property>]
+let ``parseMarkdown triples reference their source line`` () =
+  Prop.forAll (Arb.fromGen docItemsGen) (fun items ->
+    let lines = items |> List.map renderDocLine
+
+    parseMarkdown (String.concat "\n" lines)
+    |> List.forall (fun (n, line, _) -> n >= 1 && n <= lines.Length && lines.[n - 1] = line))


### PR DESCRIPTION
## Summary

Third property-based testing iteration (follow-up to #123, #124), covering `MarkdownImport.parseMarkdown` at the document level.

A document generator produces an ordered mix of date headers (some with trailing text), reading lines, and noise lines (`DocItem` DU + `renderDocLine` + `docItemsGen` in `Generators.fs`). Three properties in `ParseMarkdownPropertyTests.fs`:

- **Date carry-forward model** — `parseMarkdown` equals a clean oracle that re-implements the date-context carry-forward and filtering. Captures order preservation, carry-forward to the most recent date header, dropping of readings before any header, and line-number/original-line fidelity, all at once.
- **Strictly increasing line numbers** in the output.
- **Source-line fidelity** — each emitted triple's original line equals the actual line at its reported line number.

## Verification

- Full suite green (123 tests).
- `dotnet fantomas --check .` clean.
- Confirmed the model property catches bugs: breaking the date carry-forward (resetting context after each reading) falsified it, then reverted.