### PR TITLE
✨ feat: publish web target in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,31 @@ jobs:
       - name: Rename binary
         run: mv code/publish/BpMonitor.Tui code/publish/bpmonitor
 
+      - name: Publish web single executable
+        run: >
+          dotnet publish BpMonitor.Web/BpMonitor.Web.fsproj
+          --configuration Release
+          --runtime linux-x64
+          --self-contained true
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          -p:DebugType=none
+          --output ./publish-web
+        working-directory: code
+
+      - name: Rename web binary
+        run: mv code/publish-web/BpMonitor.Web code/publish-web/bpmonitor-web
+
+      - name: Package web bundle
+        run: >
+          tar -czf code/bpmonitor-web-linux-x64.tar.gz
+          -C code/publish-web bpmonitor-web appsettings.json wwwroot
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
           files: |
             code/publish/bpmonitor
             code/publish/appsettings.json
+            code/bpmonitor-web-linux-x64.tar.gz
           generate_release_notes: true

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,6 +37,31 @@ Run with `-h` for full usage:
 curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -h
 ```
 
+## Web UI
+
+The web frontend ships as a self-contained bundle on the same release. It needs
+no .NET runtime; the single-file executable carries its own `wwwroot/` static
+assets and `appsettings.json`.
+
+```bash
+LATEST=$(curl -fsSL https://api.github.com/repos/draptik/BpMonitor/releases/latest | grep tag_name | cut -d'"' -f4)
+curl -fsSL "https://github.com/draptik/BpMonitor/releases/download/$LATEST/bpmonitor-web-linux-x64.tar.gz" -o bpmonitor-web.tar.gz
+mkdir -p ~/.local/bin/bpweb && tar -xzf bpmonitor-web.tar.gz -C ~/.local/bin/bpweb
+~/.local/bin/bpweb/bpmonitor-web
+```
+
+The server binds `http://0.0.0.0:5000` (configured via the bundled
+`appsettings.json`). Override the database location with the
+`ConnectionStrings__DefaultConnection` environment variable:
+
+```bash
+ConnectionStrings__DefaultConnection="Data Source=$HOME/.local/share/bpmonitor/bpmonitor.db" \
+  ~/.local/bin/bpweb/bpmonitor-web
+```
+
+For a containerized deployment instead, see the Podman `Containerfile` and the
+systemd Quadlet units under `deploy/`.
+
 ## Helper scripts
 
 `docs/scripts/` contains convenience scripts for managing a local installation.


### PR DESCRIPTION
## What

Adds a self-contained single-file `linux-x64` `BpMonitor.Web` build to the tag-triggered release (`release.yml`), **alongside** the existing TUI artifact (TUI stays for now — it's only slated for deprecation later).

Pushing a `v*` tag now produces a GitHub Release containing:
- `bpmonitor` + `appsettings.json` (TUI, unchanged)
- `bpmonitor-web-linux-x64.tar.gz` (new)

## Why a tarball, not a loose binary

Two constraints make a bare single-file binary unworkable for the web target:

1. **Static assets aren't embedded.** `Program.fs` uses `app.UseStaticFiles()` to serve `wwwroot/app.css` and `wwwroot/htmx.min.js`. Under `PublishSingleFile=true` these are emitted as a loose `wwwroot/` folder next to the exe — a bare binary would render unstyled and htmx-less.
2. **`appsettings.json` basename collision.** The TUI and Web ship *different* `appsettings.json` files. The release already attaches the TUI's as a loose asset; attaching the web's loosely too would collide.

The tarball bundles the single-file exe + `wwwroot/` + `appsettings.json`, keeping the sidecar files together and namespaced. The web `appsettings.json` already sets `Urls: http://0.0.0.0:5000`, so the extracted binary binds correctly with no env setup.

## Also

- `docs/install.md`: documents downloading/extracting/running the web bundle, plus a pointer to the Podman/Quadlet container path in `deploy/`.

## Verification

Reproduced the workflow locally and ran from a clean extraction:
- Single-file publish — no loose framework DLLs.
- `GET /` → 200 (dashboard references both assets); `/app.css` → 200 `text/css`; `/htmx.min.js` → 200 `text/javascript`.
- Server binds `0.0.0.0:5000`; `bpmonitor.db` created on startup.