### PR TITLE
🔧 chore: mark pre-release tags as prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,7 @@ jobs:
             code/publish/appsettings.json
             code/bpmonitor-web-linux-x64.tar.gz
           generate_release_notes: true
+          # Treat tags carrying a pre-release suffix (e.g. v0.1.11-rc1) as
+          # prereleases so the /releases/latest API keeps pointing at the last
+          # stable release that install.sh and the docs depend on.
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
## What

Set `prerelease: ${{ contains(github.ref_name, '-') }}` on the `softprops/action-gh-release` step so tags carrying a pre-release suffix (e.g. `v0.1.11-rc1`) are published as GitHub prereleases.

## Why

While testing the web-target release (#127) with a `v0.1.11-rc1` tag, the rc was published as a full release and became GitHub's "latest". That matters because `install.sh` and the install docs resolve `/releases/latest`, so an rc would silently become the installed version. The `/releases/latest` API excludes prereleases, so flagging hyphenated tags keeps the last *stable* release as latest.

Stable tags (no hyphen, e.g. `v0.1.11`) are unaffected and still publish as normal latest releases.