### PR TITLE
✨ feat: publish web container image and add web install paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,39 @@ jobs:
           # prereleases so the /releases/latest API keeps pointing at the last
           # stable release that install.sh and the docs depend on.
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+  publish-image:
+    name: Publish container image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/draptik/bpmonitor-web
+          # {{version}} strips the leading "v"; latest=auto adds :latest only
+          # for stable (non-pre-release) semver tags.
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: code
+          file: code/BpMonitor.Web/Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/code/.dockerignore
+++ b/code/.dockerignore
@@ -1,0 +1,11 @@
+# Keep host build artifacts out of the image build context. Without this,
+# `COPY . .` drags in each project's bin/obj — which may have been restored by a
+# different SDK on the host — and breaks the in-container `dotnet publish`.
+**/bin/
+**/obj/
+**/publish/
+**/publish-web/
+**/*.tar.gz
+**/TestResults/
+**/.vs/
+**/.idea/

--- a/code/BpMonitor.Web/Containerfile
+++ b/code/BpMonitor.Web/Containerfile
@@ -11,6 +11,9 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 COPY --from=build /app .
 
+# Links the published GHCR package to its source repository.
+LABEL org.opencontainers.image.source="https://github.com/draptik/BpMonitor"
+
 # Bind on all interfaces (reachable on the homelab LAN, incl. phones) and keep
 # the SQLite database on a mounted volume so it survives redeploys.
 ENV ASPNETCORE_URLS=http://0.0.0.0:5000

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,32 @@
+# Example Docker Compose for running BpMonitor.Web in a container.
+#
+# Pulls the prebuilt image published to GitHub Container Registry on each
+# release (see .github/workflows/release.yml). Run it from anywhere:
+#
+#   docker compose -f deploy/docker-compose.yml up -d
+#
+# The web UI is then reachable on http://localhost:5000 (and on the LAN, since
+# the app binds 0.0.0.0). The SQLite database lives on a named volume so it
+# survives container recreation. Pin a specific version by replacing :latest
+# with a release tag, e.g. ghcr.io/draptik/bpmonitor-web:0.1.11.
+#
+# Podman users: `podman compose -f deploy/docker-compose.yml up -d` works too,
+# or use the systemd Quadlet units in this directory instead.
+
+services:
+  bpmonitor-web:
+    image: ghcr.io/draptik/bpmonitor-web:latest
+    container_name: bpmonitor-web
+    ports:
+      - "5000:5000"
+    volumes:
+      - bpmonitor-data:/data
+    # The image already sets these defaults; listed here so they are easy to
+    # override (e.g. point at a different database path).
+    environment:
+      - ASPNETCORE_URLS=http://0.0.0.0:5000
+      - ConnectionStrings__DefaultConnection=Data Source=/data/bpmonitor.db
+    restart: unless-stopped
+
+volumes:
+  bpmonitor-data:

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,11 +43,17 @@ The web frontend ships as a self-contained bundle on the same release. It needs
 no .NET runtime; the single-file executable carries its own `wwwroot/` static
 assets and `appsettings.json`.
 
+Install it with the same script, passing `-t web`:
+
 ```bash
-LATEST=$(curl -fsSL https://api.github.com/repos/draptik/BpMonitor/releases/latest | grep tag_name | cut -d'"' -f4)
-curl -fsSL "https://github.com/draptik/BpMonitor/releases/download/$LATEST/bpmonitor-web-linux-x64.tar.gz" -o bpmonitor-web.tar.gz
-mkdir -p ~/.local/bin/bpweb && tar -xzf bpmonitor-web.tar.gz -C ~/.local/bin/bpweb
-~/.local/bin/bpweb/bpmonitor-web
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -t web
+```
+
+This installs to `~/.local/bin/bpweb/bpmonitor-web`. Run it **from its install
+directory** so the bundled `wwwroot/` static assets resolve:
+
+```bash
+cd ~/.local/bin/bpweb && ./bpmonitor-web
 ```
 
 The server binds `http://0.0.0.0:5000` (configured via the bundled
@@ -55,12 +61,27 @@ The server binds `http://0.0.0.0:5000` (configured via the bundled
 `ConnectionStrings__DefaultConnection` environment variable:
 
 ```bash
-ConnectionStrings__DefaultConnection="Data Source=$HOME/.local/share/bpmonitor/bpmonitor.db" \
-  ~/.local/bin/bpweb/bpmonitor-web
+cd ~/.local/bin/bpweb && \
+  ConnectionStrings__DefaultConnection="Data Source=$HOME/.local/share/bpmonitor/bpmonitor.db" \
+  ./bpmonitor-web
 ```
 
-For a containerized deployment instead, see the Podman `Containerfile` and the
-systemd Quadlet units under `deploy/`.
+### Docker Compose
+
+To run the web app in a container instead, use the example Compose file at
+`deploy/docker-compose.yml`. It pulls the prebuilt image published to GitHub
+Container Registry (`ghcr.io/draptik/bpmonitor-web`) on each release and
+persists the database on a named volume:
+
+```bash
+docker compose -f deploy/docker-compose.yml up -d
+```
+
+The UI is then served on `http://localhost:5000`. Pin a specific version by
+replacing `:latest` with a release tag (e.g.
+`ghcr.io/draptik/bpmonitor-web:0.1.11`). Podman users can substitute
+`podman compose`, or use the systemd Quadlet units (`deploy/*.container`,
+`deploy/*.volume`).
 
 ## Helper scripts
 

--- a/install.sh
+++ b/install.sh
@@ -5,34 +5,44 @@
 #   ./install.sh [OPTIONS]
 #
 # Options:
-#   -b PATH   Base directory for installation  (default: ~/.local/bin)
-#   -d NAME   Subdirectory under base path     (default: bp)
-#   -n NAME   Name of the installed executable (default: bpmonitor)
+#   -t TARGET Which app to install: tui or web    (default: tui)
+#   -b PATH   Base directory for installation      (default: ~/.local/bin)
+#   -d NAME   Subdirectory under base path         (default: bp for tui, bpweb for web)
+#   -n NAME   Name of the installed executable     (default: bpmonitor / bpmonitor-web)
 #   -h        Show this help message
 #
 # Options take precedence over environment variables of the same meaning.
 # The binary is installed to: BASE_PATH/INSTALL_DIR_NAME/BINARY_NAME
 # An appsettings.json is placed alongside the binary.
 #
+# The web target is distributed as a tarball bundling the single-file binary,
+# its wwwroot/ static assets, and appsettings.json. Run it from its install
+# directory so the static assets are found, e.g.:
+#   cd ~/.local/bin/bpweb && ./bpmonitor-web
+#
 # Examples:
 #   ./install.sh
+#   ./install.sh -t web
 #   ./install.sh -b /opt/local/bin
 #   ./install.sh -d bpmon -n bp
 set -euo pipefail
 
 REPO="draptik/BpMonitor"
-ARTIFACT_NAME="bpmonitor"
+TARGET="${TARGET:-tui}"
 BASE_PATH="${BASE_PATH:-$HOME/.local/bin}"
-INSTALL_DIR_NAME="${INSTALL_DIR_NAME:-bp}"
-BINARY_NAME="${BINARY_NAME:-$ARTIFACT_NAME}"
+# Left empty so target-specific defaults below only apply when the user
+# did not override them via an option or environment variable.
+INSTALL_DIR_NAME="${INSTALL_DIR_NAME:-}"
+BINARY_NAME="${BINARY_NAME:-}"
 
 usage() {
   sed -n '/^# install\.sh/,/^[^#]/{ /^[^#]/d; s/^# \?//; p }' "$0"
   exit 0
 }
 
-while getopts ":b:d:n:h" opt; do
+while getopts ":t:b:d:n:h" opt; do
   case $opt in
+    t) TARGET="$OPTARG" ;;
     b) BASE_PATH="$OPTARG" ;;
     d) INSTALL_DIR_NAME="$OPTARG" ;;
     n) BINARY_NAME="$OPTARG" ;;
@@ -41,6 +51,24 @@ while getopts ":b:d:n:h" opt; do
     \?) echo "Unknown option: -$OPTARG" >&2; exit 1 ;;
   esac
 done
+
+case "$TARGET" in
+  tui)
+    ARTIFACT_NAME="bpmonitor"
+    INSTALL_DIR_NAME="${INSTALL_DIR_NAME:-bp}"
+    BINARY_NAME="${BINARY_NAME:-bpmonitor}"
+    ;;
+  web)
+    ARTIFACT_NAME="bpmonitor-web-linux-x64.tar.gz"
+    INSTALL_DIR_NAME="${INSTALL_DIR_NAME:-bpweb}"
+    BINARY_NAME="${BINARY_NAME:-bpmonitor-web}"
+    ;;
+  *)
+    echo "Unknown target: $TARGET (expected 'tui' or 'web')" >&2
+    exit 1
+    ;;
+esac
+
 INSTALL_DIR="$BASE_PATH/$INSTALL_DIR_NAME"
 INSTALL_PATH="$INSTALL_DIR/$BINARY_NAME"
 
@@ -49,9 +77,28 @@ DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST/$ARTIFACT_NAME"
 
 mkdir -p "$INSTALL_DIR"
 
-curl -fsSL "$DOWNLOAD_URL" -o "$INSTALL_PATH"
-chmod +x "$INSTALL_PATH"
-
-curl -fsSL "https://github.com/$REPO/releases/download/$LATEST/appsettings.json" -o "$INSTALL_DIR/appsettings.json"
+case "$TARGET" in
+  tui)
+    curl -fsSL "$DOWNLOAD_URL" -o "$INSTALL_PATH"
+    chmod +x "$INSTALL_PATH"
+    curl -fsSL "https://github.com/$REPO/releases/download/$LATEST/appsettings.json" -o "$INSTALL_DIR/appsettings.json"
+    ;;
+  web)
+    tarball=$(mktemp)
+    curl -fsSL "$DOWNLOAD_URL" -o "$tarball"
+    # Tarball contains: bpmonitor-web, appsettings.json, wwwroot/
+    tar -xzf "$tarball" -C "$INSTALL_DIR"
+    rm -f "$tarball"
+    # Honour a custom binary name by renaming the extracted executable.
+    if [ "$BINARY_NAME" != "bpmonitor-web" ]; then
+      mv "$INSTALL_DIR/bpmonitor-web" "$INSTALL_PATH"
+    fi
+    chmod +x "$INSTALL_PATH"
+    ;;
+esac
 
 echo "Installed $BINARY_NAME $LATEST to $INSTALL_PATH"
+if [ "$TARGET" = "web" ]; then
+  echo "Run it from its install directory so static assets resolve:"
+  echo "  cd $INSTALL_DIR && ./$BINARY_NAME"
+fi


### PR DESCRIPTION
## What

Extends web-app distribution beyond the release tarball with two more paths:

- **`install.sh -t web`** — downloads and extracts the `bpmonitor-web` bundle (single-file binary + `wwwroot/` + `appsettings.json`) to `~/.local/bin/bpweb/`. The `tui` target is unchanged and remains the default, so the existing `curl | bash` one-liner still installs the TUI.
- **Container image on GHCR** — `release.yml` gains a `publish-image` job that builds `code/BpMonitor.Web/Containerfile` and pushes to `ghcr.io/draptik/bpmonitor-web` on every `v*` tag. Tags: the version (e.g. `0.1.11`) always, plus `:latest` for stable releases only (`-rc` prereleases don't move `:latest`). Auth uses the built-in `GITHUB_TOKEN` — no extra secrets.
- **`deploy/docker-compose.yml`** — pulls the published image (`ghcr.io/draptik/bpmonitor-web:latest`) instead of building from source; persists the DB on a named volume.

`docs/install.md` documents both the `-t web` install and the Compose deployment (including version pinning).

## ⚠️ One-time manual step

GHCR packages are created **private** on first push. After the first release publishes the image, set the `bpmonitor-web` package visibility to **Public** in the GitHub package settings so `docker compose` can pull it anonymously.

## Verification

- `install.sh -t web` and the default `tui` path both live-tested against the `v0.1.11` release; web app booted and served `/`, `/app.css`, `/htmx.min.js` (all 200).
- `install.sh` passes shellcheck; `docs/install.md` passes markdownlint.
- `docker compose -f deploy/docker-compose.yml config` resolves to the GHCR image (no build context).
- Workflow YAML validated; `publish-image` job has `packages: write`.