### PR TITLE
🔧 chore: bump docker actions to Node 24 majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/draptik/bpmonitor-web
           # {{version}} strips the leading "v"; latest=auto adds :latest only
@@ -96,7 +96,7 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: code
           file: code/BpMonitor.Web/Containerfile


### PR DESCRIPTION
## What

Bumps the container-publish actions in `release.yml` to their Node 24 major releases:

- `docker/login-action` v3 → **v4**
- `docker/metadata-action` v5 → **v6**
- `docker/build-push-action` v6 → **v7**

## Why

The `v0.1.12` release run flagged these as Node 20 actions, which GitHub will force off the runners after 2026-09-16. The new majors run on Node 24. The inputs we use (registry/credentials; `images`/`tags`; `context`/`file`/`push`/`tags`/`labels`) are unchanged across these majors, so it's a drop-in bump.

The `publish-image` job only runs on `v*` tags, so this is first exercised on the next tagged release.