### PR TITLE
♻️ refactor: ship tui and web as parallel named tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Publish single executable
+      - name: Publish TUI single executable
         run: >
           dotnet publish BpMonitor.Tui/BpMonitor.Tui.fsproj
           --configuration Release
@@ -32,8 +32,13 @@ jobs:
           --output ./publish
         working-directory: code
 
-      - name: Rename binary
-        run: mv code/publish/BpMonitor.Tui code/publish/bpmonitor
+      - name: Rename TUI binary
+        run: mv code/publish/BpMonitor.Tui code/publish/bpmonitor-tui
+
+      - name: Package TUI bundle
+        run: >
+          tar -czf code/bpmonitor-tui-linux-x64.tar.gz
+          -C code/publish bpmonitor-tui appsettings.json
 
       - name: Publish web single executable
         run: >
@@ -59,8 +64,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            code/publish/bpmonitor
-            code/publish/appsettings.json
+            code/bpmonitor-tui-linux-x64.tar.gz
             code/bpmonitor-web-linux-x64.tar.gz
           generate_release_notes: true
           # Treat tags carrying a pre-release suffix (e.g. v0.1.11-rc1) as

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,14 +1,17 @@
 # Installing BpMonitor on Arch Linux
 
-BpMonitor is distributed as a self-contained single executable — no .NET runtime required.
+BpMonitor ships two apps — a terminal UI (TUI) and a web UI — each published as a
+self-contained tarball (`bpmonitor-tui-linux-x64.tar.gz` and
+`bpmonitor-web-linux-x64.tar.gz`). No .NET runtime required.
 
-## Install
+## TUI
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
 ```
 
-This downloads the latest release and installs it to `~/.local/bin/bp/bpmonitor`.
+This downloads the latest release and installs the TUI (the default target) to
+`~/.local/bin/bp/bpmonitor-tui`.
 
 ## Custom install location
 
@@ -16,18 +19,19 @@ Use flags to override defaults:
 
 | Flag | Default | Description |
 | ---- | ------- | ----------- |
+| `-t TARGET` | `tui` | Which app to install (`tui` or `web`) |
 | `-b PATH` | `~/.local/bin` | Base directory |
-| `-d NAME` | `bp` | Subdirectory under base path |
-| `-n NAME` | `bpmonitor` | Executable name |
+| `-d NAME` | `bp` (tui), `bpweb` (web) | Subdirectory under base path |
+| `-n NAME` | `bpmonitor-tui` / `bpmonitor-web` | Executable name |
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -b /usr/local/bin -d bp -n bpmonitor
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -b /usr/local/bin -d bp -n bpmonitor-tui
 ```
 
 Or via environment variables:
 
 ```bash
-BASE_PATH=/usr/local/bin INSTALL_DIR_NAME=bp BINARY_NAME=bpmonitor \
+BASE_PATH=/usr/local/bin INSTALL_DIR_NAME=bp BINARY_NAME=bpmonitor-tui \
   curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -8,16 +8,16 @@
 #   -t TARGET Which app to install: tui or web    (default: tui)
 #   -b PATH   Base directory for installation      (default: ~/.local/bin)
 #   -d NAME   Subdirectory under base path         (default: bp for tui, bpweb for web)
-#   -n NAME   Name of the installed executable     (default: bpmonitor / bpmonitor-web)
+#   -n NAME   Name of the installed executable     (default: bpmonitor-tui / bpmonitor-web)
 #   -h        Show this help message
 #
 # Options take precedence over environment variables of the same meaning.
 # The binary is installed to: BASE_PATH/INSTALL_DIR_NAME/BINARY_NAME
-# An appsettings.json is placed alongside the binary.
 #
-# The web target is distributed as a tarball bundling the single-file binary,
-# its wwwroot/ static assets, and appsettings.json. Run it from its install
-# directory so the static assets are found, e.g.:
+# Each target is distributed as a self-contained tarball
+# (bpmonitor-<target>-linux-x64.tar.gz) bundling the single-file binary and its
+# appsettings.json — the web bundle additionally carries its wwwroot/ static
+# assets, so run the web binary from its install directory, e.g.:
 #   cd ~/.local/bin/bpweb && ./bpmonitor-web
 #
 # Examples:
@@ -54,14 +54,12 @@ done
 
 case "$TARGET" in
   tui)
-    ARTIFACT_NAME="bpmonitor"
+    DEFAULT_BINARY="bpmonitor-tui"
     INSTALL_DIR_NAME="${INSTALL_DIR_NAME:-bp}"
-    BINARY_NAME="${BINARY_NAME:-bpmonitor}"
     ;;
   web)
-    ARTIFACT_NAME="bpmonitor-web-linux-x64.tar.gz"
+    DEFAULT_BINARY="bpmonitor-web"
     INSTALL_DIR_NAME="${INSTALL_DIR_NAME:-bpweb}"
-    BINARY_NAME="${BINARY_NAME:-bpmonitor-web}"
     ;;
   *)
     echo "Unknown target: $TARGET (expected 'tui' or 'web')" >&2
@@ -69,6 +67,8 @@ case "$TARGET" in
     ;;
 esac
 
+ARTIFACT_NAME="$DEFAULT_BINARY-linux-x64.tar.gz"
+BINARY_NAME="${BINARY_NAME:-$DEFAULT_BINARY}"
 INSTALL_DIR="$BASE_PATH/$INSTALL_DIR_NAME"
 INSTALL_PATH="$INSTALL_DIR/$BINARY_NAME"
 
@@ -77,25 +77,17 @@ DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST/$ARTIFACT_NAME"
 
 mkdir -p "$INSTALL_DIR"
 
-case "$TARGET" in
-  tui)
-    curl -fsSL "$DOWNLOAD_URL" -o "$INSTALL_PATH"
-    chmod +x "$INSTALL_PATH"
-    curl -fsSL "https://github.com/$REPO/releases/download/$LATEST/appsettings.json" -o "$INSTALL_DIR/appsettings.json"
-    ;;
-  web)
-    tarball=$(mktemp)
-    curl -fsSL "$DOWNLOAD_URL" -o "$tarball"
-    # Tarball contains: bpmonitor-web, appsettings.json, wwwroot/
-    tar -xzf "$tarball" -C "$INSTALL_DIR"
-    rm -f "$tarball"
-    # Honour a custom binary name by renaming the extracted executable.
-    if [ "$BINARY_NAME" != "bpmonitor-web" ]; then
-      mv "$INSTALL_DIR/bpmonitor-web" "$INSTALL_PATH"
-    fi
-    chmod +x "$INSTALL_PATH"
-    ;;
-esac
+# Both targets ship as tarballs (binary + appsettings.json [+ wwwroot/]).
+tarball=$(mktemp)
+curl -fsSL "$DOWNLOAD_URL" -o "$tarball"
+tar -xzf "$tarball" -C "$INSTALL_DIR"
+rm -f "$tarball"
+
+# Honour a custom binary name by renaming the extracted executable.
+if [ "$BINARY_NAME" != "$DEFAULT_BINARY" ]; then
+  mv "$INSTALL_DIR/$DEFAULT_BINARY" "$INSTALL_PATH"
+fi
+chmod +x "$INSTALL_PATH"
 
 echo "Installed $BINARY_NAME $LATEST to $INSTALL_PATH"
 if [ "$TARGET" = "web" ]; then


### PR DESCRIPTION
## What

Makes release artifacts self-documenting about which app they belong to.

**Before** (ambiguous — the loose files give no hint they're the TUI):
```
appsettings.json
bpmonitor
bpmonitor-web-linux-x64.tar.gz
```

**After** (symmetric, clearly named):
```
bpmonitor-tui-linux-x64.tar.gz   (bpmonitor-tui + appsettings.json)
bpmonitor-web-linux-x64.tar.gz   (bpmonitor-web + wwwroot/ + appsettings.json)
```

The only package, the GHCR image `bpmonitor-web`, is already unambiguous.

## Changes

- **`release.yml`** — TUI binary renamed to `bpmonitor-tui`, packaged as `bpmonitor-tui-linux-x64.tar.gz`; loose `bpmonitor`/`appsettings.json` assets dropped; steps renamed to parallel the web steps.
- **`install.sh`** — unified so both `-t tui` and `-t web` download + extract a tarball; TUI default binary is now `bpmonitor-tui` (installs to `~/.local/bin/bp/bpmonitor-tui`). Custom `-n` name still honored.
- **`docs/install.md`** — `## Install` → `## TUI`, intro describes both tarballs, flag table adds `-t` and per-target defaults.

## ⚠️ Rollout note

Once merged, `main`'s `install.sh` fetches `bpmonitor-tui-linux-x64.tar.gz` from the **latest** release. The TUI install one-liner will 404 until a release carrying that asset is cut — so a new tag (`v0.1.13`) should follow immediately after merge.

## Verification

- shellcheck + markdownlint clean; release YAML valid.
- Web install regression (default + custom `-n`) verified against `v0.1.12` (shared, unified code path).
- TUI publish → rename → tar → extract reproduced locally: tarball contains exactly `bpmonitor-tui` + `appsettings.json`, extracts to an executable bundle.