### PR TITLE
🔧 chore: simplify docker compose example

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,32 +1,16 @@
-# Example Docker Compose for running BpMonitor.Web in a container.
-#
-# Pulls the prebuilt image published to GitHub Container Registry on each
-# release (see .github/workflows/release.yml). Run it from anywhere:
+# Example Docker Compose for running BpMonitor.Web.
 #
 #   docker compose -f deploy/docker-compose.yml up -d
 #
-# The web UI is then reachable on http://localhost:5000 (and on the LAN, since
-# the app binds 0.0.0.0). The SQLite database lives on a named volume so it
-# survives container recreation. Pin a specific version by replacing :latest
-# with a release tag, e.g. ghcr.io/draptik/bpmonitor-web:0.1.11.
-#
-# Podman users: `podman compose -f deploy/docker-compose.yml up -d` works too,
-# or use the systemd Quadlet units in this directory instead.
+# Pulls the prebuilt image from GitHub Container Registry and serves the UI on
+# http://localhost:5000. The SQLite database is kept in ./data so it survives
+# container recreation. Pin a version by replacing :latest with a release tag.
 
 services:
   bpmonitor-web:
     image: ghcr.io/draptik/bpmonitor-web:latest
-    container_name: bpmonitor-web
     ports:
       - "5000:5000"
     volumes:
-      - bpmonitor-data:/data
-    # The image already sets these defaults; listed here so they are easy to
-    # override (e.g. point at a different database path).
-    environment:
-      - ASPNETCORE_URLS=http://0.0.0.0:5000
-      - ConnectionStrings__DefaultConnection=Data Source=/data/bpmonitor.db
+      - ./data:/data
     restart: unless-stopped
-
-volumes:
-  bpmonitor-data:

--- a/docs/install.md
+++ b/docs/install.md
@@ -74,8 +74,8 @@ cd ~/.local/bin/bpweb && \
 
 To run the web app in a container instead, use the example Compose file at
 `deploy/docker-compose.yml`. It pulls the prebuilt image published to GitHub
-Container Registry (`ghcr.io/draptik/bpmonitor-web`) on each release and
-persists the database on a named volume:
+Container Registry (`ghcr.io/draptik/bpmonitor-web`) on each release and keeps
+the database in `./data`:
 
 ```bash
 docker compose -f deploy/docker-compose.yml up -d


### PR DESCRIPTION
## What

Trims `deploy/docker-compose.yml` to the essentials.

**Before** → **After**
```yaml
services:                                services:
  bpmonitor-web:                           bpmonitor-web:
    image: ghcr.io/.../bpmonitor-web:latest    image: ghcr.io/.../bpmonitor-web:latest
    container_name: bpmonitor-web              ports:
    ports:                                       - "5000:5000"
      - "5000:5000"                          volumes:
    volumes:                                     - ./data:/data
      - bpmonitor-data:/data                 restart: unless-stopped
    environment:
      - ASPNETCORE_URLS=http://0.0.0.0:5000
      - ConnectionStrings__DefaultConnection=Data Source=/data/bpmonitor.db
    restart: unless-stopped

volumes:
  bpmonitor-data:
```

Removed:
- **`environment:` block** — the image's Containerfile already sets `ASPNETCORE_URLS` and `ConnectionStrings__DefaultConnection`, so it was redundant.
- **Named volume + top-level `volumes:`** — replaced with a plain `./data` bind mount.
- `container_name` — non-essential.

`docs/install.md` updated to say the DB is kept in `./data`.

## Verification

`docker compose up` (anonymous pull of the public GHCR image) serves `/` and `/app.css` (200) and persists the DB to `./data` with the simplified file. markdownlint clean.