### PR TITLE
✨ feat(web): split into landing, add and history pages with nav

### DIFF
--- a/code/BpMonitor.Web.Tests/HandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerTests.fs
@@ -21,10 +21,20 @@ let private repoWith readings : IReadingRepository =
   InMemoryReadingRepository(Some readings)
 
 [<Fact>]
-let ``dashboard renders a row per reading`` () =
+let ``landing renders links to add and history`` () =
+  let repo = repoWith []
+  let ctx = TestHost.context repo
+  TestHost.run Handlers.landing ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "href=\"/add\"" && body.Contains "href=\"/history\"" @>
+
+[<Fact>]
+let ``history renders a row per reading`` () =
   let repo = repoWith [ sample ]
   let ctx = TestHost.context repo
-  TestHost.run Handlers.dashboard ctx
+  TestHost.run Handlers.history ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
   test <@ (TestHost.readBody ctx).Contains "/readings/1/edit" @>
@@ -45,7 +55,7 @@ let ``createReading persists a valid reading and redirects`` () =
   TestHost.run Handlers.createReading ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
-  test <@ ctx.Response.Headers.Location.ToString() = "/" @>
+  test <@ ctx.Response.Headers.Location.ToString() = "/history" @>
   test <@ repo.GetAll() |> List.length = 1 @>
 
 [<Fact>]
@@ -122,5 +132,6 @@ let ``updateReading saves changes and redirects`` () =
   TestHost.run Handlers.updateReading ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
+  test <@ ctx.Response.Headers.Location.ToString() = "/history" @>
   let updated = repo.GetAll() |> List.exactlyOne
   test <@ updated.Systolic = 111 && updated.Comments = Some "updated" @>

--- a/code/BpMonitor.Web.Tests/ViewTests.fs
+++ b/code/BpMonitor.Web.Tests/ViewTests.fs
@@ -18,19 +18,30 @@ let private sample =
     ModifiedAt = DateTimeOffset.MinValue }
 
 [<Fact>]
-let ``dashboard renders reading values, chart iframe and add link`` () =
-  let html = renderHtml (Views.dashboard [ sample ])
+let ``landing renders links to add and history`` () =
+  let html = renderHtml Views.landing
+
+  test <@ html.Contains "href=\"/add\"" @>
+  test <@ html.Contains "href=\"/history\"" @>
+  // the Home nav link is marked active on the landing page
+  test <@ html.Contains "href=\"/\" aria-current=\"page\"" @>
+
+[<Fact>]
+let ``history renders reading values, chart iframe and nav links`` () =
+  let html = renderHtml (Views.history [ sample ])
 
   test <@ html.Contains "123" @>
   test <@ html.Contains "after walk" @>
   test <@ html.Contains "<iframe" && html.Contains "src=\"/chart\"" @>
-  test <@ html.Contains "/readings/new" @>
+  test <@ html.Contains "href=\"/add\"" @>
   test <@ html.Contains "/readings/7/edit" @>
+  // the History nav link is marked active on the history page
+  test <@ html.Contains "href=\"/history\" aria-current=\"page\"" @>
 
 [<Fact>]
 let ``edit form is prefilled from the reading`` () =
   let html =
-    renderHtml (Views.readingForm "Edit reading" "/readings/7" [] (Binding.ofReading sample))
+    renderHtml (Views.readingForm "" "Edit reading" "/readings/7" [] (Binding.ofReading sample))
 
   test <@ html.Contains "name=\"Systolic\" value=\"123\"" @>
   test <@ html.Contains "action=\"/readings/7\"" @>
@@ -41,7 +52,7 @@ let ``form renders the validation errors it is given`` () =
   let errors = [ "Systolic 999 is out of range (1–300)" ]
 
   let html =
-    renderHtml (Views.readingForm "Add reading" "/readings" errors Binding.empty)
+    renderHtml (Views.readingForm "/add" "Add reading" "/readings" errors Binding.empty)
 
   test <@ html.Contains "errors" @>
   test <@ html.Contains "out of range" @>
@@ -52,7 +63,7 @@ let ``view encodes user-supplied content`` () =
     { sample with
         Comments = Some "<script>x</script>" }
 
-  let html = renderHtml (Views.dashboard [ nasty ])
+  let html = renderHtml (Views.history [ nasty ])
 
   test <@ not (html.Contains "<script>x</script>") @>
   test <@ html.Contains "&lt;script&gt;" @>

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -51,30 +51,32 @@ module Handlers =
     (repo ctx).GetAll() |> List.sortByDescending _.Timestamp
 
   /// Renders the add/edit form after a failed submit (status 422).
-  let private renderFormErrors (ctx: HttpContext) title action errors model : Task =
+  let private renderFormErrors (ctx: HttpContext) active title action errors model : Task =
     ctx.Response.StatusCode <- 422
-    htmlResponse (Views.readingForm title action errors model) ctx
+    htmlResponse (Views.readingForm active title action errors model) ctx
 
   /// Validates a submitted form and persists via `save`; on any error re-renders
   /// the form with messages. Shared by create and update.
-  let private submit (ctx: HttpContext) title action (save: BloodPressureReading -> unit) : Task =
+  let private submit (ctx: HttpContext) active title action (save: BloodPressureReading -> unit) : Task =
     task {
       let! model = formModel ctx
       let rg = ranges ctx
 
       match Binding.toUnvalidated model with
-      | Error errorMessages -> do! renderFormErrors ctx title action errorMessages model
+      | Error errorMessages -> do! renderFormErrors ctx active title action errorMessages model
       | Ok unvalidated ->
         match BloodPressureReading.parse rg unvalidated with
         | Ok reading ->
           save reading
-          ctx.Response.Redirect "/"
-        | Error errors -> do! renderFormErrors ctx title action (Config.formatValidationErrors rg errors) model
+          ctx.Response.Redirect "/history"
+        | Error errors -> do! renderFormErrors ctx active title action (Config.formatValidationErrors rg errors) model
     }
     :> Task
 
-  let dashboard: HttpContext -> Task =
-    fun ctx -> htmlResponse (Views.dashboard (sortedReadings ctx)) ctx
+  let landing: HttpContext -> Task = fun ctx -> htmlResponse Views.landing ctx
+
+  let history: HttpContext -> Task =
+    fun ctx -> htmlResponse (Views.history (sortedReadings ctx)) ctx
 
   let chart: HttpContext -> Task =
     fun ctx ->
@@ -87,10 +89,10 @@ module Handlers =
         { Binding.empty with
             Binding.Timestamp = DateTimeOffset.Now.ToString(Formats.timestamp) }
 
-      htmlResponse (Views.readingForm "Add reading" "/readings" [] prefill) ctx
+      htmlResponse (Views.readingForm "/add" "Add reading" "/readings" [] prefill) ctx
 
   let createReading: HttpContext -> Task =
-    fun ctx -> submit ctx "Add reading" "/readings" (repo ctx).Add
+    fun ctx -> submit ctx "/add" "Add reading" "/readings" (repo ctx).Add
 
   let editReading: HttpContext -> Task =
     fun ctx ->
@@ -100,7 +102,7 @@ module Handlers =
         ctx.Response.WriteAsync("Bad request")
       | Some id ->
         match (repo ctx).GetAll() |> List.tryFind (fun r -> r.Id = id) with
-        | Some r -> htmlResponse (Views.readingForm "Edit reading" $"/readings/{id}" [] (Binding.ofReading r)) ctx
+        | Some r -> htmlResponse (Views.readingForm "" "Edit reading" $"/readings/{id}" [] (Binding.ofReading r)) ctx
         | None ->
           ctx.Response.StatusCode <- 404
           ctx.Response.WriteAsync("Not found")
@@ -111,4 +113,4 @@ module Handlers =
       | None ->
         ctx.Response.StatusCode <- 400
         ctx.Response.WriteAsync("Bad request")
-      | Some id -> submit ctx "Edit reading" $"/readings/{id}" (fun r -> (repo ctx).Update { r with Id = id })
+      | Some id -> submit ctx "" "Edit reading" $"/readings/{id}" (fun r -> (repo ctx).Update { r with Id = id })

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -12,9 +12,10 @@ open BpMonitor.Data
 open BpMonitor.Web
 
 let private endpoints =
-  [ get "/" Handlers.dashboard
+  [ get "/" Handlers.landing
+    get "/add" Handlers.newReading
+    get "/history" Handlers.history
     get "/chart" Handlers.chart
-    get "/readings/new" Handlers.newReading
     post "/readings" Handlers.createReading
     get "/readings/{id:int}/edit" Handlers.editReading
     post "/readings/{id:int}" Handlers.updateReading ]

--- a/code/BpMonitor.Web/Views.fs
+++ b/code/BpMonitor.Web/Views.fs
@@ -6,8 +6,20 @@ open BpMonitor.Core
 /// Server-rendered HTML views (Falco.Markup). Pure functions of their inputs so
 /// they can be unit-/snapshot-tested without a running host.
 module Views =
+  /// A single nav link, marked `aria-current="page"` (which Pico styles as active)
+  /// when its href matches the page's `active` route.
+  let private navLink (active: string) (href: string) (label: string) : XmlNode =
+    let attrs =
+      if href = active then
+        [ Attr.href href; Attr.create "aria-current" "page" ]
+      else
+        [ Attr.href href ]
+
+    Elem.li [] [ Elem.a attrs [ Text.raw label ] ]
+
   /// Page shell: shared <head>, vendored htmx, stylesheet and hx-boosted body.
-  let private layout (title: string) (content: XmlNode list) : XmlNode =
+  /// `active` is the route of the current page so the nav can highlight it.
+  let private layout (active: string) (title: string) (content: XmlNode list) : XmlNode =
     // Runs once on initial load; survives hx-boost navigations because it lives in <head>.
     let themeScript =
       """(function(){
@@ -43,7 +55,12 @@ window.toggleTheme=function(){
           [ Attr.create "hx-boost" "true" ]
           [ Elem.nav
               [ Attr.class' "container" ]
-              [ Elem.ul [] [ Elem.li [] [ Elem.strong [] [ Text.raw "BpMonitor" ] ] ]
+              [ Elem.ul
+                  []
+                  [ Elem.li [] [ Elem.strong [] [ Text.raw "BpMonitor" ] ]
+                    navLink active "/" "Home"
+                    navLink active "/add" "Add"
+                    navLink active "/history" "History" ]
                 Elem.ul
                   []
                   [ Elem.li
@@ -91,12 +108,24 @@ window.toggleTheme=function(){
 
     Elem.div [ Attr.id "readings" ] [ Elem.table [] [ header; Elem.tbody [] (readings |> List.map row) ] ]
 
-  /// Dashboard: chart (isolated in an iframe) above the readings table.
-  let dashboard (readings: BloodPressureReading list) : XmlNode =
+  /// Landing page: a simple hub linking to the app's main destinations.
+  let landing: XmlNode =
     layout
+      "/"
       "BpMonitor"
-      [ Elem.h1 [] [ Text.raw "Blood Pressure" ]
-        Elem.p [] [ Elem.a [ Attr.href "/readings/new"; Attr.role "button" ] [ Text.raw "Add reading" ] ]
+      [ Elem.h1 [] [ Text.raw "BpMonitor" ]
+        Elem.p [] [ Text.raw "Track and review your blood pressure readings." ]
+        Elem.div
+          [ Attr.class' "actions" ]
+          [ Elem.a [ Attr.href "/add"; Attr.role "button" ] [ Text.raw "Add reading" ]
+            Elem.a [ Attr.href "/history"; Attr.role "button" ] [ Text.raw "History" ] ] ]
+
+  /// History: chart (isolated in an iframe) above the readings table.
+  let history (readings: BloodPressureReading list) : XmlNode =
+    layout
+      "/history"
+      "History"
+      [ Elem.h1 [] [ Text.raw "History" ]
         Elem.details
           []
           [ Elem.summary [ Attr.class' "chart-toggle" ] [ Text.raw "Blood Pressure Graph" ]
@@ -105,7 +134,13 @@ window.toggleTheme=function(){
 
   /// Shared add/edit form. `action` is the POST target; `errors` are rendered
   /// above the fields when re-displaying after a failed submit.
-  let readingForm (title: string) (action: string) (errors: string list) (m: Binding.FormModel) : XmlNode =
+  let readingForm
+    (active: string)
+    (title: string)
+    (action: string)
+    (errors: string list)
+    (m: Binding.FormModel)
+    : XmlNode =
     let field (labelText: string) (name: string) (value: string) (inputType: string) =
       Elem.div
         [ Attr.class' "field" ]
@@ -120,6 +155,7 @@ window.toggleTheme=function(){
           Elem.input [ Attr.type' inputType; Attr.id name; Attr.name name; Attr.value value ] ]
 
     layout
+      active
       title
       [ Elem.h1 [] [ Text.raw title ]
         errorBox errors
@@ -133,4 +169,4 @@ window.toggleTheme=function(){
             Elem.div
               [ Attr.class' "actions" ]
               [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Save" ]
-                Elem.a [ Attr.href "/"; Attr.role "button"; Attr.class' "secondary" ] [ Text.raw "Cancel" ] ] ] ]
+                Elem.a [ Attr.href "/history"; Attr.role "button"; Attr.class' "secondary" ] [ Text.raw "Cancel" ] ] ] ]

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -3,6 +3,15 @@ nav.container {
   max-width: 900px;
 }
 
+nav a[aria-current="page"] {
+  background: var(--pico-primary);
+  color: var(--pico-primary-inverse);
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--pico-border-radius);
+  text-decoration: none;
+}
+
 #theme-toggle {
   padding: 0.25rem 0.75rem;
   font-size: 0.875rem;


### PR DESCRIPTION
## What

Restructure the web UI into three single-purpose pages with real navigation:

- **`/`** — new landing hub linking to the app's destinations
- **`/add`** — blood-pressure input form (moved off `/readings/new`)
- **`/history`** — readings table + chart iframe (was the old `/` dashboard)

## Navigation

- Nav bar gains **Home / Add / History** links (brand + theme toggle kept)
- The current page is highlighted via `aria-current="page"`, styled as a filled primary pill
- Successful create/update now redirect to `/history`; the form's Cancel returns there too

## Tests

- Updated handler/view tests for the renamed routes/views and new redirect target
- Added tests for the landing page links and the active-nav highlight
- 18/18 web tests pass; Fantomas clean