### PR TITLE
📝 docs: explain the badges orphan branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,14 @@ For details on how Claude was used and configured for this project, see [AGENTS.
 
 - [Vision](docs/vision.md) — what the app does and why
 - [Architecture](docs/architecture.md) — tech stack and structural decisions
+
+## The `badges` branch
+
+The `badges` branch is an **orphan branch** (no shared history with `main`) used only as
+storage for the generated coverage badge. It holds a single file, `coverage.svg`, which the
+coverage badge above links to via `raw.githubusercontent.com`.
+
+CI regenerates and force-pushes this file on every run (see the "Push coverage badge to badges
+branch" step in `.github/workflows/ci.yml`). The branch is **intentionally never merged** into
+`main` — keeping the generated artifact and its churn out of the source history. Treat it as
+machine-owned: don't branch off it or commit to it. If deleted, the next CI run recreates it.


### PR DESCRIPTION
Adds a short section to the README explaining the `badges` branch.

- It's an orphan branch (no shared history with `main`) holding only `coverage.svg`
- CI force-pushes it each run via the "Push coverage badge to badges branch" step in `ci.yml`
- It's intentionally never merged, and is machine-owned (don't branch off or commit to it)

Motivated by the question "is it ok that the badges branch never gets merged?" — documenting the intended behaviour so it isn't mistaken for a stale branch.