### PR TITLE
📝 docs: slim down README, move badges-branch section to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,17 @@
 [![Coverage](https://raw.githubusercontent.com/draptik/BpMonitor/badges/coverage.svg)](https://github.com/draptik/BpMonitor/actions)
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 
-A personal blood pressure monitoring application.
+A personal blood pressure monitoring application built with F# on .NET. Ships a TUI (Terminal.Gui) and a web frontend (Falco), sharing the same SQLite database.
+
+## Docs
+
+- [Vision](docs/vision.md) — what the app does and why
+- [Architecture](docs/architecture.md) — tech stack and structural decisions
+- [Install](docs/install.md) — install, configure, and deploy
+- [Badges branch](docs/badges-branch.md) — how the coverage badge is generated and stored
 
 ## About This Project
 
 This project was created with extensive assistance from [Claude](https://claude.ai) (Anthropic's AI assistant). Claude contributed throughout the development process — from architecture decisions and domain modelling to writing code, tests, and tooling configuration.
 
 For details on how Claude was used and configured for this project, see [AGENTS.md](AGENTS.md).
-
-## Documentation
-
-- [Vision](docs/vision.md) — what the app does and why
-- [Architecture](docs/architecture.md) — tech stack and structural decisions
-
-## The `badges` branch
-
-The `badges` branch is an **orphan branch** (no shared history with `main`) used only as
-storage for the generated coverage badge. It holds a single file, `coverage.svg`, which the
-coverage badge above links to via `raw.githubusercontent.com`.
-
-CI regenerates and force-pushes this file on every run (see the "Push coverage badge to badges
-branch" step in `.github/workflows/ci.yml`). The branch is **intentionally never merged** into
-`main` — keeping the generated artifact and its churn out of the source history. Treat it as
-machine-owned: don't branch off it or commit to it. If deleted, the next CI run recreates it.

--- a/docs/badges-branch.md
+++ b/docs/badges-branch.md
@@ -1,0 +1,10 @@
+# The `badges` branch
+
+The `badges` branch is an **orphan branch** (no shared history with `main`) used only as
+storage for the generated coverage badge. It holds a single file, `coverage.svg`, which the
+coverage badge in the README links to via `raw.githubusercontent.com`.
+
+CI regenerates and force-pushes this file on every run (see the "Push coverage badge to badges
+branch" step in `.github/workflows/ci.yml`). The branch is **intentionally never merged** into
+`main` — keeping the generated artifact and its churn out of the source history. Treat it as
+machine-owned: don't branch off it or commit to it. If deleted, the next CI run recreates it.


### PR DESCRIPTION
## Summary
- Trim README to essentials: badges, one-line description, docs links, About section
- Move badges-branch explanation to `docs/badges-branch.md` and link from README
- Add TUI/Web frontend description and link to `docs/install.md`