### PR TITLE
📝 docs: split install guide into user and contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,8 @@ Never start work on `main`. Creating the branch is the first step, not an aftert
 
 - `docs/vision.md` — product vision and requirements
 - `docs/architecture.md` — tech stack, architectural decisions, and dev tooling (mise, Biome)
+- `docs/install.md` — end-user install guide (Web app)
+- `CONTRIBUTING.md` — developer setup, linting, testing, release process
 - `.claude/skills/` — skill definitions (git-workflow, review-tests, setup-tooling, model-advisor, status-bar)
 
 ## Dev Tooling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to BpMonitor
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download) — version is pinned in `code/global.json`
+- [mise](https://mise.jdx.dev/) — manages the JS tooling (Biome)
+
+## Getting started
+
+```bash
+# Install pinned tools (Biome)
+mise install
+
+# Restore .NET local tools (Fantomas, dotnet-ef) and dependencies
+cd code
+dotnet tool restore
+dotnet restore
+
+# Build and test
+dotnet build
+dotnet test
+```
+
+## Running locally
+
+```bash
+# Web app (recommended) — served at http://localhost:5000
+dotnet run --project code/BpMonitor.Web
+
+# TUI (deprecated)
+dotnet run --project code/BpMonitor.Tui
+```
+
+## Project structure
+
+The solution is split into focused projects under `code/` — Core domain, Data
+(EF Core + SQLite), Import, Export, Charts, Tui, and Web — following Clean
+Architecture. See [docs/architecture.md](docs/architecture.md) for the full
+structure, dependency diagram, and tech stack.
+
+## Linting and formatting
+
+These mirror the jobs in `.github/workflows/ci.yml`. [Husky](https://alirezanet.github.io/Husky.Net/)
+pre-commit hooks run them automatically — restore tools once to activate:
+
+```bash
+cd code && dotnet tool restore   # only needed once after cloning
+```
+
+| Tool | Command | What it checks |
+| ---- | ------- | -------------- |
+| Fantomas | `cd code && dotnet fantomas --check .` | F# formatting |
+| Biome | `mise exec -- biome check` | JS linting |
+| markdownlint | `npx markdownlint-cli2 "**/*.md"` | Markdown style |
+| shellcheck | `shellcheck <file>.sh` | Shell scripts |
+
+Auto-fix where supported:
+
+```bash
+cd code && dotnet fantomas .          # reformat F#
+mise exec -- biome check --write      # fix JS
+```
+
+## Testing
+
+```bash
+cd code && dotnet test
+```
+
+All code changes follow strict TDD (Red → Green → Refactor). See the "Working Rules"
+section in [AGENTS.md](AGENTS.md) for the full expectations.
+
+## Code style
+
+F# conventions (lambda shorthand, indexer syntax, `IDisposable` rules) are documented in
+the "F# Style Conventions" section of [AGENTS.md](AGENTS.md).
+
+## Git workflow
+
+- Branch prefixes: `feature/`, `fix/`, `chore/`
+- Commit format: gitmoji + conventional commits (e.g. `✨ feat: add reading form`)
+- Merge strategy: squash-merge via PR — one clean commit per PR on `main`
+- Never commit directly to `main`
+
+See [AGENTS.md](AGENTS.md) for the full git workflow rules.
+
+## Creating a release
+
+Push a version tag on `main` to trigger the release workflow:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+`release.yml` builds both self-contained tarballs (`bpmonitor-tui-linux-x64.tar.gz`,
+`bpmonitor-web-linux-x64.tar.gz`) and publishes a container image to
+`ghcr.io/draptik/bpmonitor-web`. Tags containing `-` (e.g. `v1.2.3-rc1`) are
+automatically flagged as GitHub pre-releases, keeping `/releases/latest` on the
+stable release.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A personal blood pressure monitoring application built with F# on .NET. Ships a 
 - [Vision](docs/vision.md) — what the app does and why
 - [Architecture](docs/architecture.md) — tech stack and structural decisions
 - [Install](docs/install.md) — install, configure, and deploy
+- [Contributing](CONTRIBUTING.md) — build, test, and release the project
 - [Badges branch](docs/badges-branch.md) — how the coverage badge is generated and stored
 
 ## About This Project

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,17 +1,21 @@
-# Installing BpMonitor on Arch Linux
+# Installing BpMonitor
 
-BpMonitor ships two apps — a terminal UI (TUI) and a web UI — each published as a
-self-contained tarball (`bpmonitor-tui-linux-x64.tar.gz` and
-`bpmonitor-web-linux-x64.tar.gz`). No .NET runtime required.
+BpMonitor Web ships as a self-contained Linux binary — no .NET runtime required.
 
-## TUI
+## Quick install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -t web
 ```
 
-This downloads the latest release and installs the TUI (the default target) to
-`~/.local/bin/bp/bpmonitor-tui`.
+This installs the latest release to `~/.local/bin/bpweb/bpmonitor-web`. Run it
+**from its install directory** so the bundled `wwwroot/` static assets resolve:
+
+```bash
+cd ~/.local/bin/bpweb && ./bpmonitor-web
+```
+
+The server binds `http://0.0.0.0:5000`.
 
 ## Custom install location
 
@@ -19,101 +23,50 @@ Use flags to override defaults:
 
 | Flag | Default | Description |
 | ---- | ------- | ----------- |
-| `-t TARGET` | `tui` | Which app to install (`tui` or `web`) |
 | `-b PATH` | `~/.local/bin` | Base directory |
-| `-d NAME` | `bp` (tui), `bpweb` (web) | Subdirectory under base path |
-| `-n NAME` | `bpmonitor-tui` / `bpmonitor-web` | Executable name |
+| `-d NAME` | `bpweb` | Subdirectory under base path |
+| `-n NAME` | `bpmonitor-web` | Executable name |
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -b /usr/local/bin -d bp -n bpmonitor-tui
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -t web -b /usr/local/bin -d bpweb
 ```
 
 Or via environment variables:
 
 ```bash
-BASE_PATH=/usr/local/bin INSTALL_DIR_NAME=bp BINARY_NAME=bpmonitor-tui \
-  curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
+BASE_PATH=/usr/local/bin INSTALL_DIR_NAME=bpweb \
+  curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -t web
 ```
 
-Run with `-h` for full usage:
+## Configuration
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -h
-```
+- **Database** — defaults to `Data Source=<install-dir>/bpmonitor.db`; override with `ConnectionStrings__DefaultConnection`.
+- **Bind address / port** — defaults to `http://0.0.0.0:5000`; configured via `appsettings.json` (takes precedence over `ASPNETCORE_URLS`).
 
-## Web UI
+## Docker Compose
 
-The web frontend ships as a self-contained bundle on the same release. It needs
-no .NET runtime; the single-file executable carries its own `wwwroot/` static
-assets and `appsettings.json`.
-
-Install it with the same script, passing `-t web`:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -t web
-```
-
-This installs to `~/.local/bin/bpweb/bpmonitor-web`. Run it **from its install
-directory** so the bundled `wwwroot/` static assets resolve:
-
-```bash
-cd ~/.local/bin/bpweb && ./bpmonitor-web
-```
-
-The server binds `http://0.0.0.0:5000` (configured via the bundled
-`appsettings.json`). Override the database location with the
-`ConnectionStrings__DefaultConnection` environment variable:
-
-```bash
-cd ~/.local/bin/bpweb && \
-  ConnectionStrings__DefaultConnection="Data Source=$HOME/.local/share/bpmonitor/bpmonitor.db" \
-  ./bpmonitor-web
-```
-
-### Docker Compose
-
-To run the web app in a container instead, use the example Compose file at
-`deploy/docker-compose.yml`. It pulls the prebuilt image published to GitHub
-Container Registry (`ghcr.io/draptik/bpmonitor-web`) on each release and keeps
-the database in `./data`:
+To run as a container instead (pulls the prebuilt image from GitHub Container Registry):
 
 ```bash
 docker compose -f deploy/docker-compose.yml up -d
 ```
 
-The UI is then served on `http://localhost:5000`. Pin a specific version by
-replacing `:latest` with a release tag (e.g.
-`ghcr.io/draptik/bpmonitor-web:0.1.11`). Podman users can substitute
-`podman compose`, or use the systemd Quadlet units (`deploy/*.container`,
-`deploy/*.volume`).
+See [deploy/README.md](../deploy/README.md) for container configuration, Podman, and systemd Quadlet instructions.
 
 ## Helper scripts
 
-`docs/scripts/` contains convenience scripts for managing a local installation.
+`docs/scripts/` contains convenience scripts for managing a local installation:
 
-### Install and configure
+- **Install and configure:** patches `appsettings.json` with a custom `MarkdownDirectory`:
 
-```bash
-IMPORT_FILE_LOCATION=~/documents/health bash docs/scripts/install.sh
-```
+  ```bash
+  IMPORT_FILE_LOCATION=~/documents/health bash docs/scripts/install.sh
+  ```
 
-Runs `install.sh` and patches `appsettings.json` to set `MarkdownDirectory` to the given path. Defaults to `.` if `IMPORT_FILE_LOCATION` is not set.
+- **Remove local installation:**
 
-### Remove local installation
+  ```bash
+  bash docs/scripts/clean.sh
+  ```
 
-```bash
-bash docs/scripts/clean.sh
-```
-
-Removes the `~/.local/bin/bp/` directory.
-
-## Creating a new release
-
-Push a version tag on `main` to trigger the release workflow:
-
-```bash
-git tag v1.2.3
-git push origin v1.2.3
-```
-
-The workflow builds the executable and publishes a GitHub Release with auto-generated release notes.
+> The TUI is deprecated. If you still need it, the install script accepts `-t tui`.


### PR DESCRIPTION
## Summary
- Rewrite `docs/install.md` as a Web-first end-user guide; remove TUI as primary target (one-line deprecation note); drop the release section
- Add `CONTRIBUTING.md` at repo root with developer setup, linting/formatting commands, testing expectations, git workflow, and the release process (moved from `install.md`)
- Add `CONTRIBUTING.md` link to `README.md` and `AGENTS.md`