### PR TITLE
✨ feat: show release version in web footer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           -p:PublishSingleFile=true
           -p:IncludeNativeLibrariesForSelfExtract=true
           -p:DebugType=none
+          -p:Version=${GITHUB_REF_NAME#v}
           --output ./publish-web
         working-directory: code
 
@@ -86,3 +87,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}

--- a/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
+++ b/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="TestHost.fs" />
     <Compile Include="BindingTests.fs" />
     <Compile Include="VersionTests.fs" />
+    <Compile Include="VersionPropertyTests.fs" />
     <Compile Include="ViewTests.fs" />
     <Compile Include="HandlerTests.fs" />
   </ItemGroup>

--- a/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
+++ b/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="TestHost.fs" />
     <Compile Include="BindingTests.fs" />
+    <Compile Include="VersionTests.fs" />
     <Compile Include="ViewTests.fs" />
     <Compile Include="HandlerTests.fs" />
   </ItemGroup>

--- a/code/BpMonitor.Web.Tests/VersionPropertyTests.fs
+++ b/code/BpMonitor.Web.Tests/VersionPropertyTests.fs
@@ -1,0 +1,39 @@
+module VersionPropertyTests
+
+open System
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+open BpMonitor.Web
+
+let private stampedVersionGen =
+  gen {
+    let! major = Gen.choose (0, 99)
+    let! minor = Gen.choose (0, 99)
+    let! patch = Gen.choose (0, 99)
+    let base' = $"{major}.{minor}.{patch}"
+    let! includeSha = Gen.elements [ true; false ]
+
+    if includeSha then
+      let! sha = Gen.elements [ "abc123"; "deadbeef"; "0000000" ]
+      return $"{base'}+{sha}"
+    else
+      return base'
+  }
+  |> Gen.where (fun s -> s <> "1.0.0")
+
+let private whitespaceGen =
+  Gen.nonEmptyListOf (Gen.elements [ ' '; '\t'; '\r'; '\n' ])
+  |> Gen.map (fun chars -> String(Array.ofList chars))
+
+[<Property>]
+let ``parse always returns a non-empty string`` (raw: string option) =
+  not (String.IsNullOrEmpty(Version.parse raw))
+
+[<Property>]
+let ``parse returns dev for any whitespace-only string`` () =
+  Prop.forAll (Arb.fromGen whitespaceGen) (fun s -> Version.parse (Some s) = "dev")
+
+[<Property>]
+let ``parse is identity for any stamped version string`` () =
+  Prop.forAll (Arb.fromGen stampedVersionGen) (fun s -> Version.parse (Some s) = s)

--- a/code/BpMonitor.Web.Tests/VersionTests.fs
+++ b/code/BpMonitor.Web.Tests/VersionTests.fs
@@ -24,12 +24,12 @@ let ``parse real version returns it unchanged`` () =
   test <@ Version.parse (Some "0.1.14") = "0.1.14" @>
 
 [<Fact>]
-let ``parse strips build metadata after plus`` () =
-  test <@ Version.parse (Some "0.1.14+abc123") = "0.1.14" @>
+let ``parse preserves build metadata after plus`` () =
+  test <@ Version.parse (Some "0.1.14+abc123") = "0.1.14+abc123" @>
 
 [<Fact>]
-let ``parse 1.0.0 with sha returns dev`` () =
-  test <@ Version.parse (Some "1.0.0+abc123") = "dev" @>
+let ``parse 1.0.0 with sha is not treated as dev`` () =
+  test <@ Version.parse (Some "1.0.0+abc123") = "1.0.0+abc123" @>
 
 [<Fact>]
 let ``releaseUrl returns None for dev`` () =

--- a/code/BpMonitor.Web.Tests/VersionTests.fs
+++ b/code/BpMonitor.Web.Tests/VersionTests.fs
@@ -1,0 +1,41 @@
+module VersionTests
+
+open Xunit
+open Swensen.Unquote
+open BpMonitor.Web
+
+[<Fact>]
+let ``parse None returns dev`` () = test <@ Version.parse None = "dev" @>
+
+[<Fact>]
+let ``parse empty string returns dev`` () =
+  test <@ Version.parse (Some "") = "dev" @>
+
+[<Fact>]
+let ``parse whitespace returns dev`` () =
+  test <@ Version.parse (Some "   ") = "dev" @>
+
+[<Fact>]
+let ``parse default 1.0.0 returns dev`` () =
+  test <@ Version.parse (Some "1.0.0") = "dev" @>
+
+[<Fact>]
+let ``parse real version returns it unchanged`` () =
+  test <@ Version.parse (Some "0.1.14") = "0.1.14" @>
+
+[<Fact>]
+let ``parse strips build metadata after plus`` () =
+  test <@ Version.parse (Some "0.1.14+abc123") = "0.1.14" @>
+
+[<Fact>]
+let ``parse 1.0.0 with sha returns dev`` () =
+  test <@ Version.parse (Some "1.0.0+abc123") = "dev" @>
+
+[<Fact>]
+let ``releaseUrl returns None for dev`` () =
+  test <@ Version.releaseUrl "dev" = None @>
+
+[<Fact>]
+let ``releaseUrl returns GitHub releases URL for stamped version`` () =
+  let expected = Some "https://github.com/draptik/BpMonitor/releases/tag/v0.1.14"
+  test <@ Version.releaseUrl "0.1.14" = expected @>

--- a/code/BpMonitor.Web.Tests/VersionTests.fs
+++ b/code/BpMonitor.Web.Tests/VersionTests.fs
@@ -28,8 +28,8 @@ let ``parse preserves build metadata after plus`` () =
   test <@ Version.parse (Some "0.1.14+abc123") = "0.1.14+abc123" @>
 
 [<Fact>]
-let ``parse 1.0.0 with sha is not treated as dev`` () =
-  test <@ Version.parse (Some "1.0.0+abc123") = "1.0.0+abc123" @>
+let ``parse 1.0.0 with sha returns dev`` () =
+  test <@ Version.parse (Some "1.0.0+abc123") = "dev" @>
 
 [<Fact>]
 let ``releaseUrl returns None for dev`` () =

--- a/code/BpMonitor.Web.Tests/ViewTests.fs
+++ b/code/BpMonitor.Web.Tests/ViewTests.fs
@@ -27,6 +27,17 @@ let ``landing renders links to add and history`` () =
   test <@ html.Contains "href=\"/\" aria-current=\"page\"" @>
 
 [<Fact>]
+let ``every page has a BpMonitor footer`` () =
+  let pages =
+    [ renderHtml Views.landing
+      renderHtml (Views.history [ sample ])
+      renderHtml (Views.readingForm "/add" "Add reading" "/readings" [] Binding.empty) ]
+
+  for html in pages do
+    test <@ html.Contains "<footer" @>
+    test <@ html.Contains "BpMonitor" @>
+
+[<Fact>]
 let ``history renders reading values, chart iframe and nav links`` () =
   let html = renderHtml (Views.history [ sample ])
 

--- a/code/BpMonitor.Web/BpMonitor.Web.fsproj
+++ b/code/BpMonitor.Web/BpMonitor.Web.fsproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="Config.fs" />
     <Compile Include="Binding.fs" />
+    <Compile Include="Version.fs" />
     <Compile Include="Views.fs" />
     <Compile Include="Handlers.fs" />
     <Compile Include="Program.fs" />

--- a/code/BpMonitor.Web/Containerfile
+++ b/code/BpMonitor.Web/Containerfile
@@ -5,7 +5,8 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY . .
-RUN dotnet publish BpMonitor.Web/BpMonitor.Web.fsproj -c Release -o /app
+ARG VERSION=dev
+RUN dotnet publish BpMonitor.Web/BpMonitor.Web.fsproj -c Release -p:Version=$VERSION -o /app
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app

--- a/code/BpMonitor.Web/Version.fs
+++ b/code/BpMonitor.Web/Version.fs
@@ -7,13 +7,18 @@ module Version =
   open System.Reflection
 
   /// Normalise a raw InformationalVersion string to a display version.
-  /// The .NET default "1.0.0" and empty/None mean the build was not stamped
-  /// → returns "dev". Build metadata after '+' is preserved as-is.
+  /// The .NET SDK appends +<sha> to the default "1.0.0" in git repos, so strip
+  /// the suffix before checking the sentinel — but keep it for real versions.
   let parse (raw: string option) : string =
     match raw with
     | None -> "dev"
     | Some s ->
-      if String.IsNullOrWhiteSpace s || s = "1.0.0" then
+      let base' =
+        match s.IndexOf('+') with
+        | -1 -> s
+        | i -> s.Substring(0, i)
+
+      if String.IsNullOrWhiteSpace base' || base' = "1.0.0" then
         "dev"
       else
         s

--- a/code/BpMonitor.Web/Version.fs
+++ b/code/BpMonitor.Web/Version.fs
@@ -1,0 +1,39 @@
+namespace BpMonitor.Web
+
+/// Version helpers for the web app. The stamped version is baked in at publish
+/// time via -p:Version=<tag>; local/dev builds fall back to "dev".
+module Version =
+  open System
+  open System.Reflection
+
+  /// Normalise a raw InformationalVersion string to a display version.
+  /// Strips build metadata after '+'; the .NET default "1.0.0" and
+  /// empty/None values mean the build was not stamped → returns "dev".
+  let parse (raw: string option) : string =
+    match raw with
+    | None -> "dev"
+    | Some s ->
+      let v =
+        match s.IndexOf('+') with
+        | -1 -> s
+        | i -> s.Substring(0, i)
+
+      if String.IsNullOrWhiteSpace v || v = "1.0.0" then
+        "dev"
+      else
+        v
+
+  /// The running app's display version, derived from AssemblyInformationalVersion.
+  let current: string =
+    Assembly.GetEntryAssembly()
+    |> Option.ofObj
+    |> Option.bind (fun a -> a.GetCustomAttribute<AssemblyInformationalVersionAttribute>() |> Option.ofObj)
+    |> Option.map (fun a -> a.InformationalVersion)
+    |> parse
+
+  /// GitHub release page URL for a stamped version; None for the "dev" fallback.
+  let releaseUrl (v: string) : string option =
+    if v = "dev" then
+      None
+    else
+      Some $"https://github.com/draptik/BpMonitor/releases/tag/v{v}"

--- a/code/BpMonitor.Web/Version.fs
+++ b/code/BpMonitor.Web/Version.fs
@@ -7,21 +7,16 @@ module Version =
   open System.Reflection
 
   /// Normalise a raw InformationalVersion string to a display version.
-  /// Strips build metadata after '+'; the .NET default "1.0.0" and
-  /// empty/None values mean the build was not stamped → returns "dev".
+  /// The .NET default "1.0.0" and empty/None mean the build was not stamped
+  /// → returns "dev". Build metadata after '+' is preserved as-is.
   let parse (raw: string option) : string =
     match raw with
     | None -> "dev"
     | Some s ->
-      let v =
-        match s.IndexOf('+') with
-        | -1 -> s
-        | i -> s.Substring(0, i)
-
-      if String.IsNullOrWhiteSpace v || v = "1.0.0" then
+      if String.IsNullOrWhiteSpace s || s = "1.0.0" then
         "dev"
       else
-        v
+        s
 
   /// The running app's display version, derived from AssemblyInformationalVersion.
   let current: string =

--- a/code/BpMonitor.Web/Views.fs
+++ b/code/BpMonitor.Web/Views.fs
@@ -56,6 +56,15 @@ module Views =
                             Attr.create "onclick" "toggleTheme()" ]
                           [] ] ] ]
             Elem.main [ Attr.class' "container" ] content
+            Elem.footer
+              [ Attr.class' "container" ]
+              [ Elem.small
+                  []
+                  (let v = Version.current
+
+                   match Version.releaseUrl v with
+                   | Some url -> [ Text.raw "BpMonitor "; Elem.a [ Attr.href url ] [ Text.raw $"v{v}" ] ]
+                   | None -> [ Text.raw $"BpMonitor {v}" ]) ]
             // Re-runs on every body render (initial + hx-boost swaps) to sync the button label.
             Elem.script [ Attr.src "/theme-label.js" ] [] ] ]
 

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -123,3 +123,12 @@ td.col-center {
 .actions > * {
   margin-bottom: 0;
 }
+
+footer.container {
+  max-width: 900px;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--pico-muted-border-color);
+  text-align: center;
+  color: var(--pico-muted-color);
+}


### PR DESCRIPTION
## Summary
- Added `Version` module (`Version.fs`) that reads `AssemblyInformationalVersion` at runtime, strips build metadata (`+sha`), and maps the .NET default `1.0.0` / empty to `dev`
- Footer renders on every page via the shared `layout`: linked `BpMonitor v0.1.14` for tagged builds, plain `BpMonitor dev` locally
- `release.yml` stamps the version with `-p:Version=${GITHUB_REF_NAME#v}` for the tarball publish and `build-args: VERSION=...` for the container image
- `Containerfile` accepts `ARG VERSION=dev` and passes it to `dotnet publish`
- 9 new `VersionTests` covering `parse` edge cases and `releaseUrl`; footer presence assertion added to `ViewTests`