### PR TITLE
🔧 chore: add biome lint task to husky pre-commit hook

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -27,6 +27,15 @@
          "pathMode": "absolute",
          "cwd": "code",
          "staged": true
+      },
+      {
+         "name": "biome",
+         "group": "pre-commit",
+         "command": "mise",
+         "args": ["exec", "--", "biome", "lint", "${staged}"],
+         "include": ["code/BpMonitor.Web/wwwroot/*.js"],
+         "exclude": ["**/htmx.min.js"],
+         "staged": true
       }
    ]
 }


### PR DESCRIPTION
## Summary
- Adds a `biome` task to `.husky/task-runner.json` so staged JS files are linted locally on commit, mirroring the existing `lint-js` CI job
- Scoped to `code/BpMonitor.Web/wwwroot/*.js`, excludes the vendored `htmx.min.js`
- Only fires when a matching file is staged — unrelated commits are unaffected
- `CONTRIBUTING.md` already states Husky runs all linters automatically; this makes that true for JS