### PR TITLE
✨ feat: add Serilog structured stdout logging to web app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ code/
 ├── BpMonitor.Import      # Markdown and JSON importers
 ├── BpMonitor.Export      # JSON serialisation and file write
 ├── BpMonitor.Charts      # Plotly.NET chart generation → HTML output
-├── BpMonitor.Web         # Falco web app (landing, add, history pages)
+├── BpMonitor.Web         # Falco web app (landing, add, history pages); Serilog structured stdout logging
 └── BpMonitor.Arch.Tests  # ArchUnit Clean Architecture rules
 docs/                     # Product vision, architecture, ADRs
 ```

--- a/code/BpMonitor.Web.Tests/TestHost.fs
+++ b/code/BpMonitor.Web.Tests/TestHost.fs
@@ -5,6 +5,7 @@ open System.IO
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Primitives
 open BpMonitor.Core
 
@@ -12,6 +13,7 @@ open BpMonitor.Core
 /// ranges) so the real Falco handlers can be invoked directly in tests.
 let context (repo: IReadingRepository) : HttpContext =
   let services = ServiceCollection()
+  services.AddLogging() |> ignore
   services.AddSingleton<IReadingRepository>(repo) |> ignore
   services.AddSingleton<IConfiguration>(ConfigurationBuilder().Build()) |> ignore
 

--- a/code/BpMonitor.Web/BpMonitor.Web.fsproj
+++ b/code/BpMonitor.Web/BpMonitor.Web.fsproj
@@ -18,6 +18,7 @@
     <PackageReference Include="FsToolkit.ErrorHandling" />
     <PackageReference Include="Falco" />
     <PackageReference Include="Falco.Markup" />
+    <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
 

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -5,6 +5,7 @@ open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
 open Falco.Markup
 open BpMonitor.Core
 open BpMonitor.Charts
@@ -17,6 +18,9 @@ module Handlers =
 
   let private ranges (ctx: HttpContext) =
     Config.readRanges (ctx.RequestServices.GetRequiredService<IConfiguration>())
+
+  let private logger (ctx: HttpContext) =
+    ctx.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger("BpMonitor.Web.Handlers")
 
   let private htmlResponse (node: XmlNode) (ctx: HttpContext) : Task =
     ctx.Response.ContentType <- "text/html; charset=utf-8"
@@ -59,17 +63,32 @@ module Handlers =
   /// the form with messages. Shared by create and update.
   let private submit (ctx: HttpContext) active title action (save: BloodPressureReading -> unit) : Task =
     task {
+      let log = logger ctx
       let! model = formModel ctx
       let rg = ranges ctx
 
       match Binding.toUnvalidated model with
-      | Error errorMessages -> do! renderFormErrors ctx active title action errorMessages model
+      | Error errorMessages ->
+        log.LogWarning("Reading form validation failed (binding): {Errors}", errorMessages)
+        do! renderFormErrors ctx active title action errorMessages model
       | Ok unvalidated ->
         match BloodPressureReading.parse rg unvalidated with
         | Ok reading ->
           save reading
+
+          log.LogInformation(
+            "Saved reading — systolic={Systolic} diastolic={Diastolic} heartRate={HeartRate} timestamp={Timestamp}",
+            reading.Systolic,
+            reading.Diastolic,
+            reading.HeartRate,
+            reading.Timestamp
+          )
+
           ctx.Response.Redirect "/history"
-        | Error errors -> do! renderFormErrors ctx active title action (Config.formatValidationErrors rg errors) model
+        | Error errors ->
+          let messages = Config.formatValidationErrors rg errors
+          log.LogWarning("Reading form validation failed (domain): {Errors}", messages)
+          do! renderFormErrors ctx active title action messages model
     }
     :> Task
 
@@ -96,21 +115,28 @@ module Handlers =
 
   let editReading: HttpContext -> Task =
     fun ctx ->
+      let log = logger ctx
+
       match routeInt ctx "id" with
       | None ->
+        log.LogWarning("editReading: bad route value for {{id}}")
         ctx.Response.StatusCode <- 400
         ctx.Response.WriteAsync("Bad request")
       | Some id ->
         match (repo ctx).GetAll() |> List.tryFind (fun r -> r.Id = id) with
         | Some r -> htmlResponse (Views.readingForm "" "Edit reading" $"/readings/{id}" [] (Binding.ofReading r)) ctx
         | None ->
+          log.LogWarning("editReading: reading {Id} not found", id)
           ctx.Response.StatusCode <- 404
           ctx.Response.WriteAsync("Not found")
 
   let updateReading: HttpContext -> Task =
     fun ctx ->
+      let log = logger ctx
+
       match routeInt ctx "id" with
       | None ->
+        log.LogWarning("updateReading: bad route value for {{id}}")
         ctx.Response.StatusCode <- 400
         ctx.Response.WriteAsync("Bad request")
       | Some id -> submit ctx "" "Edit reading" $"/readings/{id}" (fun r -> (repo ctx).Update { r with Id = id })

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -7,6 +7,7 @@ open Microsoft.AspNetCore.Builder
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.EntityFrameworkCore
+open Serilog
 open BpMonitor.Core
 open BpMonitor.Data
 open BpMonitor.Web
@@ -22,24 +23,45 @@ let private endpoints =
 
 [<EntryPoint>]
 let main args =
-  let builder = WebApplication.CreateBuilder(args)
+  // Bootstrap logger captures startup failures before the host is built.
+  Log.Logger <- LoggerConfiguration().WriteTo.Console().CreateBootstrapLogger()
 
-  let connectionString =
-    builder.Configuration.GetConnectionString("DefaultConnection")
+  try
+    let builder = WebApplication.CreateBuilder(args)
 
-  builder.Services.AddDbContext<BpMonitorDbContext>(fun opts -> opts.UseSqlite(connectionString) |> ignore)
-  |> ignore
+    // Replace the default logging pipeline with Serilog, configured from appsettings.
+    builder.Host.UseSerilog(fun ctx _services cfg ->
+      cfg.ReadFrom.Configuration(ctx.Configuration).Enrich.FromLogContext() |> ignore)
+    |> ignore
 
-  builder.Services.AddScoped<IReadingRepository>(fun sp ->
-    EfReadingRepository(sp.GetRequiredService<BpMonitorDbContext>(), TimeProvider.System))
-  |> ignore
+    let connectionString =
+      builder.Configuration.GetConnectionString("DefaultConnection")
 
-  let app = builder.Build()
+    builder.Services.AddDbContext<BpMonitorDbContext>(fun opts -> opts.UseSqlite(connectionString) |> ignore)
+    |> ignore
 
-  // Apply schema migrations once at startup against a transient scope.
-  use scope = app.Services.CreateScope()
-  SchemaMigrations.apply (scope.ServiceProvider.GetRequiredService<BpMonitorDbContext>())
+    builder.Services.AddScoped<IReadingRepository>(fun sp ->
+      EfReadingRepository(sp.GetRequiredService<BpMonitorDbContext>(), TimeProvider.System))
+    |> ignore
 
-  app.UseStaticFiles().UseRouting().UseFalco(endpoints) |> ignore
-  app.Run()
-  0
+    let app = builder.Build()
+
+    // Apply schema migrations once at startup against a transient scope.
+    Log.Information("Applying schema migrations…")
+    use scope = app.Services.CreateScope()
+    SchemaMigrations.apply (scope.ServiceProvider.GetRequiredService<BpMonitorDbContext>())
+
+    // One structured log line per request (method, path, status, elapsed ms).
+    app.UseSerilogRequestLogging() |> ignore
+    app.UseStaticFiles().UseRouting().UseFalco(endpoints) |> ignore
+
+    Log.Information("BpMonitor.Web {Version} starting on {Urls}", Version.current, app.Urls)
+    app.Run()
+    0
+  with ex ->
+    Log.Fatal(ex, "BpMonitor.Web terminated unexpectedly")
+
+    1
+    |> fun exitCode ->
+      Log.CloseAndFlush()
+      exitCode

--- a/code/BpMonitor.Web/appsettings.json
+++ b/code/BpMonitor.Web/appsettings.json
@@ -10,5 +10,24 @@
     "DiastolicMax": 200,
     "HeartRateMin": 1,
     "HeartRateMax": 300
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext" ]
   }
 }

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -6,6 +6,9 @@
     <PackageVersion Include="Falco" Version="5.2.0" />
     <PackageVersion Include="Falco.Markup" Version="1.4.0" />
   </ItemGroup>
+  <ItemGroup Label="Logging">
+    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+  </ItemGroup>
   <ItemGroup Label="Charts">
     <PackageVersion Include="Plotly.NET" Version="5.1.0" />
   </ItemGroup>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,7 @@ code/
 | Language / Runtime | F# on .NET |
 | Web Framework | Falco 5 + Falco.Markup (server-rendered F# HTML) |
 | Web interactivity | htmx (vendored, no build step) |
+| Logging | Serilog.AspNetCore — structured CLEF JSON to stdout; `UseSerilogRequestLogging` for per-request lines; configured via `appsettings.json` `Serilog` section; captured by `docker logs` / `podman logs` / journald |
 | Database | SQLite + EF Core |
 | Charting | Plotly.NET — generates interactive HTML, opens in default browser |
 | Validation | `FsToolkit.ErrorHandling` — applicative validation with `Validation<'ok, 'err>` |
@@ -124,6 +125,7 @@ graph TD
 - Three pages: `/` landing hub, `/add` entry form, `/history` table + chart iframe
 - Server-rendered HTML via `Falco.Markup`; htmx for partial updates
 - Scoped `DbContext` per request (concurrency-safe)
+- Structured logging via Serilog: one CLEF JSON line per request + domain events; logs flow to stdout → container/journal
 - References Core + Data + Charts
 
 ### BpMonitor.Arch.Tests


### PR DESCRIPTION
## Summary
- Add `Serilog.AspNetCore` 9.0.0 — structured CLEF JSON logs to stdout via `CompactJsonFormatter`
- Bootstrap logger captures startup failures before the host builds; `UseSerilogRequestLogging` emits one structured line per request (method, path, status, elapsed ms)
- Domain logs in `Handlers`: `Warning` on validation failures and 400/404 branches, `Information` on successful save with structured reading properties
- `Serilog` section in `appsettings.json` configures minimum levels (`Microsoft.*` overridden to `Warning`) and the console sink
- Fix `TestHost` to register `AddLogging()` so `ILoggerFactory` resolves in unit tests
- Update `docs/architecture.md` and `AGENTS.md`