### PR TITLE
🔧 chore: route all non-dotnet linters through mise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: jdx/mise-action@v2
+
       - name: Run markdownlint-cli2
-        run: npx markdownlint-cli2 "**/*.md"
+        run: mise run lint:md
 
   lint-js:
     name: Lint JS
@@ -24,12 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: biomejs/setup-biome@v2
-        with:
-          version: 2.4.16
+      - uses: jdx/mise-action@v2
 
       - name: Run Biome
-        run: biome check
+        run: mise run lint:js
 
   lint-shell:
     name: Lint Shell
@@ -38,8 +38,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: jdx/mise-action@v2
+
       - name: Run shellcheck
-        run: find . -name "*.sh" -not -path "./.husky/_/*" | xargs shellcheck
+        run: mise run lint:shell
 
   lint-fsharp:
     name: Lint F#

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -4,8 +4,8 @@
       {
          "name": "shellcheck",
          "group": "pre-commit",
-         "command": "shellcheck",
-         "args": ["${staged}"],
+         "command": "mise",
+         "args": ["exec", "--", "shellcheck", "${staged}"],
          "include": ["**/*.sh"],
          "exclude": [".husky/_/*.sh"],
          "staged": true
@@ -13,8 +13,8 @@
       {
          "name": "markdownlint",
          "group": "pre-commit",
-         "command": "markdownlint-cli2",
-         "args": ["${staged}"],
+         "command": "mise",
+         "args": ["exec", "--", "markdownlint-cli2", "${staged}"],
          "include": ["**/*.md"],
          "staged": true
       },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,9 @@ Never start work on `main`. Creating the branch is the first step, not an aftert
 
 ## Dev Tooling
 
-Tool versions are pinned in `mise.toml` (repo root). Run `mise install` once after cloning.
+All non-dotnet linter versions are pinned in `mise.toml` (repo root). Run `mise install` once after cloning.
 
 - `biome.json` — Biome JS linter config (scoped to `wwwroot/theme.js` and `wwwroot/theme-label.js`)
-- Run `mise exec -- biome check` to lint; `mise exec -- biome check --write` to auto-fix
+- `.markdownlint-cli2.yaml` — markdownlint config
+- Run `mise run lint` to run all non-dotnet linters; `mise run lint:js` / `lint:md` / `lint:shell` individually
+- Run `mise exec -- biome check --write` to auto-fix JS issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,12 @@
 ## Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download) — version is pinned in `code/global.json`
-- [mise](https://mise.jdx.dev/) — manages the JS tooling (Biome)
+- [mise](https://mise.jdx.dev/) — manages all non-dotnet linting tools (Biome, markdownlint-cli2, shellcheck, node)
 
 ## Getting started
 
 ```bash
-# Install pinned tools (Biome)
+# Install pinned tools (Biome, markdownlint-cli2, shellcheck, node)
 mise install
 
 # Restore .NET local tools (Fantomas, dotnet-ef) and dependencies
@@ -48,8 +48,17 @@ cd code && dotnet tool restore   # only needed once after cloning
 | ---- | ------- | -------------- |
 | Fantomas | `cd code && dotnet fantomas --check .` | F# formatting |
 | Biome | `mise exec -- biome check` | JS linting |
-| markdownlint | `npx markdownlint-cli2 "**/*.md"` | Markdown style |
-| shellcheck | `shellcheck <file>.sh` | Shell scripts |
+| markdownlint | `mise exec -- markdownlint-cli2 "**/*.md"` | Markdown style |
+| shellcheck | `mise exec -- shellcheck <file>.sh` | Shell scripts |
+
+Run all non-dotnet linters at once:
+
+```bash
+mise run lint        # markdownlint + biome + shellcheck
+mise run lint:md     # markdownlint only
+mise run lint:js     # biome only
+mise run lint:shell  # shellcheck only
+```
 
 Auto-fix where supported:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,21 +145,27 @@ graph TD
 
 ## Development Tooling
 
-[mise](https://mise.jdx.dev/) manages language runtimes and standalone tools for this project. The `mise.toml` at the repo root pins all tool versions; run `mise install` once after cloning to set up the local environment.
+[mise](https://mise.jdx.dev/) manages all non-dotnet linting tools for this project. The `mise.toml` at the repo root pins all tool versions; run `mise install` once after cloning to set up the local environment.
 
 | Tool | Version source | Purpose |
 | --- | --- | --- |
+| node | `mise.toml` | Runtime for npm-based tools (markdownlint-cli2) |
 | Biome | `mise.toml` | JS linter (`biome check`) for files in `wwwroot/` |
+| markdownlint-cli2 | `mise.toml` | Markdown style linter |
+| shellcheck | `mise.toml` | Shell script linter |
 
 **Local usage:**
 
 ```bash
 mise install          # install all pinned tools
-mise exec -- biome check          # lint JS files
-mise exec -- biome check --write  # auto-fix safe issues
+mise run lint         # run all non-dotnet linters
+mise run lint:md      # markdownlint only
+mise run lint:js      # biome only
+mise run lint:shell   # shellcheck only
+mise exec -- biome check --write  # auto-fix safe JS issues
 ```
 
-**CI:** the `lint-js` job in `.github/workflows/ci.yml` runs `biome check` via the `biomejs/setup-biome` action with the same pinned version.
+**CI:** the `lint-markdown`, `lint-js`, and `lint-shell` jobs in `.github/workflows/ci.yml` each install tools via `jdx/mise-action` and invoke the corresponding `mise run lint:*` task — the same command as local dev.
 
 ## Architecture Decision Records
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,18 @@
 [tools]
+node = "26.3.0"
 biome = "2.4.16"
+markdownlint-cli2 = "0.22.1"
+shellcheck = "0.11.0"
+
+[tasks."lint:md"]
+run = 'markdownlint-cli2 "**/*.md"'
+
+[tasks."lint:js"]
+run = "biome check"
+
+[tasks."lint:shell"]
+# mirror the CI/hook exclusion of Husky's generated wrapper scripts
+run = 'find . -name "*.sh" -not -path "./.husky/_/*" | xargs shellcheck'
+
+[tasks.lint]
+depends = ["lint:md", "lint:js", "lint:shell"]


### PR DESCRIPTION
## Summary

- Add `markdownlint-cli2`, `shellcheck`, and `node` to `mise.toml` alongside `biome` so all non-dotnet linter versions are pinned in one place
- Define `mise run lint:md`, `lint:js`, `lint:shell`, and umbrella `lint` tasks as the single source of truth for non-dotnet linting
- Update `.husky/task-runner.json` so the `shellcheck` and `markdownlint` pre-commit tasks invoke via `mise exec --`, matching the existing `biome` task
- Replace `biomejs/setup-biome`, bare `npx`, and the system `shellcheck` in CI with `jdx/mise-action` + `mise run lint:*` — CI and local dev now run identical commands with identical pinned versions
- Update `CONTRIBUTING.md`, `docs/architecture.md`, and `AGENTS.md` to reflect the unified tooling