### PR TITLE
✨ feat: add multi-user (family) support with member-scoped readings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,12 +51,12 @@ The following are available as slash commands (defined in `.claude/skills/`):
 ```text
 code/
 ├── BpMonitor.slnx
-├── BpMonitor.Core        # Domain models, interfaces, business logic
-├── BpMonitor.Data        # EF Core + SQLite, repository implementations
-├── BpMonitor.Import      # Markdown and JSON importers
+├── BpMonitor.Core        # Domain models (BloodPressureReading + FamilyMember), interfaces, business logic
+├── BpMonitor.Data        # EF Core + SQLite, member-scoped repository implementations
+├── BpMonitor.Import      # Markdown and JSON importers (take memberId param)
 ├── BpMonitor.Export      # JSON serialisation and file write
 ├── BpMonitor.Charts      # Plotly.NET chart generation → HTML output
-├── BpMonitor.Web         # Falco web app (landing, add, history pages); Serilog structured stdout logging
+├── BpMonitor.Web         # Falco web app (landing, add, history, members pages); Serilog structured stdout logging
 └── BpMonitor.Arch.Tests  # ArchUnit Clean Architecture rules
 docs/                     # Product vision, architecture, ADRs
 ```

--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -12,6 +12,7 @@ open BpMonitor.Charts
 
 let private reading id systolic diastolic heartRate day hour comment =
   { Id = id
+    MemberId = 1
     Systolic = systolic
     Diastolic = diastolic
     HeartRate = heartRate

--- a/code/BpMonitor.Core.Tests/BloodPressureReadingTests.fs
+++ b/code/BpMonitor.Core.Tests/BloodPressureReadingTests.fs
@@ -82,3 +82,9 @@ let ``parse sets CreatedAt and ModifiedAt to MinValue`` () =
     test <@ reading.CreatedAt = DateTimeOffset.MinValue @>
     test <@ reading.ModifiedAt = DateTimeOffset.MinValue @>
   | Error _ -> failwith "Expected Ok"
+
+[<Fact>]
+let ``parse sets MemberId to 0`` () =
+  match BloodPressureReading.parse ranges validUnvalidated with
+  | Ok reading -> test <@ reading.MemberId = 0 @>
+  | Error _ -> failwith "Expected Ok"

--- a/code/BpMonitor.Core.Tests/ReadingRepositoryContractTests.fs
+++ b/code/BpMonitor.Core.Tests/ReadingRepositoryContractTests.fs
@@ -9,16 +9,24 @@ type private StubRepository(initial: BloodPressureReading list) =
   let readings = ResizeArray<BloodPressureReading>(initial)
 
   interface IReadingRepository with
-    member _.GetAll() = readings |> Seq.toList
-    member _.Add(r) = readings.Add(r)
-    member _.AddMany(rs) = rs |> List.iter readings.Add
+    member _.GetAll(memberId) =
+      readings |> Seq.filter (fun r -> r.MemberId = memberId) |> Seq.toList
+
+    member _.Add memberId r =
+      readings.Add({ r with MemberId = memberId })
+
+    member _.AddMany memberId rs =
+      rs |> List.iter (fun r -> readings.Add({ r with MemberId = memberId }))
 
     member _.Update(r) =
-      let idx = readings |> Seq.findIndex (fun x -> x.Id = r.Id)
+      let idx =
+        readings |> Seq.findIndex (fun x -> x.Id = r.Id && x.MemberId = r.MemberId)
+
       readings[idx] <- r
 
-let private reading id sys dia hr =
+let private reading id memberId sys dia hr =
   { Id = id
+    MemberId = memberId
     Systolic = sys
     Diastolic = dia
     HeartRate = hr
@@ -29,37 +37,64 @@ let private reading id sys dia hr =
 
 [<Fact>]
 let ``Update replaces the reading with the matching Id`` () =
-  let repo = StubRepository([ reading 1 120 80 70 ]) :> IReadingRepository
+  let repo = StubRepository([ reading 1 1 120 80 70 ]) :> IReadingRepository
 
   let updated =
-    { reading 1 135 88 75 with
+    { reading 1 1 135 88 75 with
         Comments = Some "updated" }
 
   repo.Update(updated)
-  test <@ repo.GetAll() |> List.exists (fun r -> r.Systolic = 135) @>
+  test <@ repo.GetAll(1) |> List.exists (fun r -> r.Systolic = 135) @>
 
 [<Fact>]
 let ``Update does not affect other readings`` () =
   let repo =
-    StubRepository([ reading 1 120 80 70; reading 2 130 85 72 ]) :> IReadingRepository
+    StubRepository([ reading 1 1 120 80 70; reading 2 1 130 85 72 ]) :> IReadingRepository
 
-  repo.Update({ reading 1 135 88 75 with Id = 1 })
-  test <@ repo.GetAll() |> List.exists (fun r -> r.Id = 2 && r.Systolic = 130) @>
+  repo.Update({ reading 1 1 135 88 75 with Id = 1 })
+  test <@ repo.GetAll(1) |> List.exists (fun r -> r.Id = 2 && r.Systolic = 130) @>
 
 [<Fact>]
 let ``Update preserves the Id`` () =
-  let repo = StubRepository([ reading 1 120 80 70 ]) :> IReadingRepository
-  let updated = reading 1 135 88 75
+  let repo = StubRepository([ reading 1 1 120 80 70 ]) :> IReadingRepository
+  let updated = reading 1 1 135 88 75
   repo.Update(updated)
-  test <@ repo.GetAll() |> List.forall (fun r -> r.Id = 1) @>
+  test <@ repo.GetAll(1) |> List.forall (fun r -> r.Id = 1) @>
 
 [<Fact>]
 let ``Update reflects changes in subsequent GetAll`` () =
-  let repo = StubRepository([ reading 1 120 80 70 ]) :> IReadingRepository
+  let repo = StubRepository([ reading 1 1 120 80 70 ]) :> IReadingRepository
 
   repo.Update(
-    { reading 1 120 80 70 with
+    { reading 1 1 120 80 70 with
         Comments = Some "after update" }
   )
 
-  test <@ repo.GetAll().[0].Comments = Some "after update" @>
+  test <@ repo.GetAll(1).[0].Comments = Some "after update" @>
+
+[<Fact>]
+let ``GetAll returns only readings for the requested member`` () =
+  let r1 = reading 1 1 120 80 70
+  let r2 = reading 2 2 130 85 72
+  let repo = StubRepository([ r1; r2 ]) :> IReadingRepository
+  test <@ repo.GetAll(1) |> List.length = 1 @>
+  test <@ repo.GetAll(1).[0].Id = 1 @>
+  test <@ repo.GetAll(2).[0].Id = 2 @>
+
+[<Fact>]
+let ``Add stamps the reading with the given memberId`` () =
+  let repo = StubRepository([]) :> IReadingRepository
+  repo.Add 2 (reading 0 0 120 80 70)
+  test <@ repo.GetAll(2) |> List.length = 1 @>
+  test <@ repo.GetAll(1) |> List.isEmpty @>
+
+[<Fact>]
+let ``Update does not affect a reading belonging to a different member`` () =
+  let r = reading 1 1 120 80 70
+  let repo = StubRepository([ r ]) :> IReadingRepository
+  // Attempt to update reading 1 as if it belonged to member 2 — should not find it
+  let crossMember = { reading 1 2 135 90 75 with Id = 1 }
+
+  let act () = repo.Update(crossMember)
+
+  Assert.ThrowsAny<Exception>(act) |> ignore

--- a/code/BpMonitor.Core/BloodPressureReading.fs
+++ b/code/BpMonitor.Core/BloodPressureReading.fs
@@ -9,6 +9,7 @@ type BloodPressureReadingUnvalidated =
 
 type BloodPressureReading =
   { Id: int
+    MemberId: int
     Systolic: int
     Diastolic: int
     HeartRate: int
@@ -86,6 +87,7 @@ module BloodPressureReading =
 
       return
         { Id = 0
+          MemberId = 0
           Systolic = sys
           Diastolic = dia
           HeartRate = hr

--- a/code/BpMonitor.Core/BpMonitor.Core.fsproj
+++ b/code/BpMonitor.Core/BpMonitor.Core.fsproj
@@ -5,6 +5,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="FamilyMember.fs" />
+    <Compile Include="IFamilyMemberRepository.fs" />
     <Compile Include="BloodPressureReading.fs" />
     <Compile Include="IReadingRepository.fs" />
   </ItemGroup>

--- a/code/BpMonitor.Core/FamilyMember.fs
+++ b/code/BpMonitor.Core/FamilyMember.fs
@@ -1,0 +1,22 @@
+namespace BpMonitor.Core
+
+open System
+
+type FamilyMember =
+  { Id: int
+    Name: string
+    CreatedAt: DateTimeOffset
+    ModifiedAt: DateTimeOffset }
+
+type FamilyMemberError = | NameIsEmpty
+
+module FamilyMember =
+  let create (name: string) : Result<FamilyMember, FamilyMemberError> =
+    if String.IsNullOrWhiteSpace(name) then
+      Error NameIsEmpty
+    else
+      Ok
+        { Id = 0
+          Name = name.Trim()
+          CreatedAt = DateTimeOffset.MinValue
+          ModifiedAt = DateTimeOffset.MinValue }

--- a/code/BpMonitor.Core/IFamilyMemberRepository.fs
+++ b/code/BpMonitor.Core/IFamilyMemberRepository.fs
@@ -1,0 +1,6 @@
+namespace BpMonitor.Core
+
+type IFamilyMemberRepository =
+  abstract GetAll: unit -> FamilyMember list
+  abstract GetById: int -> FamilyMember option
+  abstract Add: FamilyMember -> FamilyMember

--- a/code/BpMonitor.Core/IReadingRepository.fs
+++ b/code/BpMonitor.Core/IReadingRepository.fs
@@ -1,7 +1,7 @@
 namespace BpMonitor.Core
 
 type IReadingRepository =
-  abstract GetAll: unit -> BloodPressureReading list
-  abstract Add: BloodPressureReading -> unit
-  abstract AddMany: BloodPressureReading list -> unit
+  abstract GetAll: memberId: int -> BloodPressureReading list
+  abstract Add: memberId: int -> BloodPressureReading -> unit
+  abstract AddMany: memberId: int -> BloodPressureReading list -> unit
   abstract Update: BloodPressureReading -> unit

--- a/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
@@ -9,8 +9,11 @@ open Microsoft.Extensions.Time.Testing
 open BpMonitor.Core
 open BpMonitor.Data
 
+let private defaultMemberId = 1
+
 let private sample: BloodPressureReading =
   { Id = 0
+    MemberId = 0
     Systolic = 120
     Diastolic = 80
     HeartRate = 70
@@ -37,7 +40,7 @@ let ``GetAll returns empty list when database is empty`` () =
   let repo =
     EfReadingRepository(ctx, System.TimeProvider.System) :> IReadingRepository
 
-  test <@ repo.GetAll() = [] @>
+  test <@ repo.GetAll(defaultMemberId) = [] @>
 
 [<Fact>]
 let ``Add persists a reading`` () =
@@ -46,8 +49,8 @@ let ``Add persists a reading`` () =
   let repo =
     EfReadingRepository(ctx, System.TimeProvider.System) :> IReadingRepository
 
-  repo.Add(sample)
-  test <@ repo.GetAll().Length = 1 @>
+  repo.Add defaultMemberId sample
+  test <@ repo.GetAll(defaultMemberId).Length = 1 @>
 
 [<Fact>]
 let ``Add assigns a non-zero Id`` () =
@@ -56,8 +59,36 @@ let ``Add assigns a non-zero Id`` () =
   let repo =
     EfReadingRepository(ctx, System.TimeProvider.System) :> IReadingRepository
 
-  repo.Add(sample)
-  test <@ repo.GetAll().[0].Id > 0 @>
+  repo.Add defaultMemberId sample
+  test <@ repo.GetAll(defaultMemberId).[0].Id > 0 @>
+
+[<Fact>]
+let ``Add stamps the reading with the given memberId`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfReadingRepository(ctx, System.TimeProvider.System) :> IReadingRepository
+
+  repo.Add defaultMemberId sample
+  test <@ repo.GetAll(defaultMemberId).[0].MemberId = defaultMemberId @>
+
+[<Fact>]
+let ``GetAll returns only readings for the requested member`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfReadingRepository(ctx, System.TimeProvider.System) :> IReadingRepository
+
+  repo.Add 1 sample
+
+  repo.Add
+    2
+    { sample with
+        Timestamp = Timestamp.utc 2026 1 2 9 0 0 }
+
+  test <@ repo.GetAll(1).Length = 1 @>
+  test <@ repo.GetAll(2).Length = 1 @>
+  test <@ repo.GetAll(1).[0].MemberId = 1 @>
 
 [<Fact>]
 let ``Add preserves Comments when present`` () =
@@ -66,12 +97,12 @@ let ``Add preserves Comments when present`` () =
   let repo =
     EfReadingRepository(ctx, System.TimeProvider.System) :> IReadingRepository
 
-  repo.Add(
+  repo.Add
+    defaultMemberId
     { sample with
         Comments = Some "test note" }
-  )
 
-  test <@ repo.GetAll().[0].Comments = Some "test note" @>
+  test <@ repo.GetAll(defaultMemberId).[0].Comments = Some "test note" @>
 
 [<Fact>]
 let ``Add preserves Comments as None when absent`` () =
@@ -80,8 +111,8 @@ let ``Add preserves Comments as None when absent`` () =
   let repo =
     EfReadingRepository(ctx, System.TimeProvider.System) :> IReadingRepository
 
-  repo.Add(sample)
-  test <@ repo.GetAll().[0].Comments = None @>
+  repo.Add defaultMemberId sample
+  test <@ repo.GetAll(defaultMemberId).[0].Comments = None @>
 
 [<Fact>]
 let ``Add sets CreatedAt and ModifiedAt to current time`` () =
@@ -89,8 +120,8 @@ let ``Add sets CreatedAt and ModifiedAt to current time`` () =
   let timeProvider = FakeTimeProvider(now)
   use ctx = createContext ()
   let repo = EfReadingRepository(ctx, timeProvider) :> IReadingRepository
-  repo.Add(sample)
-  let result = repo.GetAll()[0]
+  repo.Add defaultMemberId sample
+  let result = repo.GetAll(defaultMemberId)[0]
   test <@ result.CreatedAt = now @>
   test <@ result.ModifiedAt = now @>
 
@@ -105,8 +136,8 @@ let ``AddMany persists all readings`` () =
     { sample with
         Timestamp = Timestamp.utc 2026 1 2 9 0 0 }
 
-  repo.AddMany([ sample; second ])
-  test <@ repo.GetAll().Length = 2 @>
+  repo.AddMany defaultMemberId [ sample; second ]
+  test <@ repo.GetAll(defaultMemberId).Length = 2 @>
 
 [<Fact>]
 let ``AddMany sets CreatedAt and ModifiedAt to current time`` () =
@@ -119,8 +150,8 @@ let ``AddMany sets CreatedAt and ModifiedAt to current time`` () =
     { sample with
         Timestamp = Timestamp.utc 2026 1 2 9 0 0 }
 
-  repo.AddMany([ sample; second ])
-  let readings = repo.GetAll()
+  repo.AddMany defaultMemberId [ sample; second ]
+  let readings = repo.GetAll(defaultMemberId)
   test <@ readings[0].CreatedAt = now @>
   test <@ readings[0].ModifiedAt = now @>
   test <@ readings[1].CreatedAt = now @>
@@ -133,10 +164,28 @@ let ``Update preserves CreatedAt and sets ModifiedAt to current time`` () =
   let timeProvider = FakeTimeProvider(createdAt)
   use ctx = createContext ()
   let repo = EfReadingRepository(ctx, timeProvider) :> IReadingRepository
-  repo.Add(sample)
-  let added = repo.GetAll()[0]
+  repo.Add defaultMemberId sample
+  let added = repo.GetAll(defaultMemberId)[0]
   timeProvider.SetUtcNow(updatedAt)
   repo.Update({ added with Systolic = 130 })
-  let result = repo.GetAll()[0]
+  let result = repo.GetAll(defaultMemberId)[0]
   test <@ result.CreatedAt = createdAt @>
   test <@ result.ModifiedAt = updatedAt @>
+
+[<Fact>]
+let ``Update does not affect a reading belonging to a different member`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfReadingRepository(ctx, System.TimeProvider.System) :> IReadingRepository
+
+  repo.Add 1 sample
+  let added = repo.GetAll(1)[0]
+  // Attempt to update as member 2 — MemberId guard should prevent it
+  repo.Update(
+    { added with
+        Systolic = 999
+        MemberId = 2 }
+  )
+  // Reading should remain unchanged for member 1
+  test <@ (repo.GetAll 1).[0].Systolic = 120 @>

--- a/code/BpMonitor.Data.Tests/InMemoryReadingRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/InMemoryReadingRepositoryTests.fs
@@ -6,8 +6,11 @@ open Swensen.Unquote
 open BpMonitor.Core
 open BpMonitor.Data
 
+let private defaultMemberId = 1
+
 let private sample: BloodPressureReading =
   { Id = 0
+    MemberId = 0
     Systolic = 120
     Diastolic = 80
     HeartRate = 70
@@ -19,20 +22,28 @@ let private sample: BloodPressureReading =
 [<Fact>]
 let ``GetAll returns default sample readings on startup`` () =
   let repo = InMemoryReadingRepository(None) :> IReadingRepository
-  test <@ repo.GetAll().Length > 0 @>
+  test <@ repo.GetAll(defaultMemberId).Length > 0 @>
 
 [<Fact>]
 let ``Add makes reading available via GetAll`` () =
   let repo = InMemoryReadingRepository(Some []) :> IReadingRepository
-  repo.Add(sample)
-  test <@ repo.GetAll().Length = 1 @>
+  repo.Add defaultMemberId sample
+  test <@ repo.GetAll(defaultMemberId).Length = 1 @>
+
+[<Fact>]
+let ``Add stamps the reading with the given memberId`` () =
+  let repo = InMemoryReadingRepository(Some []) :> IReadingRepository
+  repo.Add 2 sample
+  test <@ repo.GetAll(2).Length = 1 @>
+  test <@ repo.GetAll(2).[0].MemberId = 2 @>
+  test <@ repo.GetAll(defaultMemberId).Length = 0 @>
 
 [<Fact>]
 let ``Add assigns sequential Ids starting at 1`` () =
   let repo = InMemoryReadingRepository(Some []) :> IReadingRepository
-  repo.Add(sample)
-  repo.Add(sample)
-  let readings = repo.GetAll()
+  repo.Add defaultMemberId sample
+  repo.Add defaultMemberId sample
+  let readings = repo.GetAll(defaultMemberId)
   test <@ readings[0].Id = 1 @>
   test <@ readings[1].Id = 2 @>
 
@@ -44,8 +55,8 @@ let ``AddMany persists all readings`` () =
     { sample with
         Timestamp = Timestamp.utc 2026 1 2 9 0 0 }
 
-  repo.AddMany([ sample; second ])
-  test <@ repo.GetAll().Length = 2 @>
+  repo.AddMany defaultMemberId [ sample; second ]
+  test <@ repo.GetAll(defaultMemberId).Length = 2 @>
 
 [<Fact>]
 let ``AddMany assigns sequential Ids`` () =
@@ -55,7 +66,22 @@ let ``AddMany assigns sequential Ids`` () =
     { sample with
         Timestamp = Timestamp.utc 2026 1 2 9 0 0 }
 
-  repo.AddMany([ sample; second ])
-  let readings = repo.GetAll()
+  repo.AddMany defaultMemberId [ sample; second ]
+  let readings = repo.GetAll(defaultMemberId)
   test <@ readings[0].Id = 1 @>
   test <@ readings[1].Id = 2 @>
+
+[<Fact>]
+let ``GetAll returns only readings for the requested member`` () =
+  let r1 = { sample with Id = 1; MemberId = 1 }
+
+  let r2 =
+    { sample with
+        Id = 2
+        MemberId = 2
+        Timestamp = Timestamp.utc 2026 1 2 9 0 0 }
+
+  let repo = InMemoryReadingRepository(Some [ r1; r2 ]) :> IReadingRepository
+  test <@ repo.GetAll(1).Length = 1 @>
+  test <@ repo.GetAll(2).Length = 1 @>
+  test <@ repo.GetAll(1).[0].Id = 1 @>

--- a/code/BpMonitor.Data/BpMonitor.Data.fsproj
+++ b/code/BpMonitor.Data/BpMonitor.Data.fsproj
@@ -13,9 +13,12 @@
 
   <ItemGroup>
     <Compile Include="InMemoryReadingRepository.fs" />
+    <Compile Include="InMemoryFamilyMemberRepository.fs" />
     <Compile Include="ReadingRecord.fs" />
+    <Compile Include="MemberRecord.fs" />
     <Compile Include="BpMonitorDbContext.fs" />
     <Compile Include="BpMonitorDbContextFactory.fs" />
+    <Compile Include="EfFamilyMemberRepository.fs" />
     <Compile Include="SchemaMigrations.fs" />
     <Compile Include="EfReadingRepository.fs" />
     <Compile Include="ReadingRepositoryFactory.fs" />

--- a/code/BpMonitor.Data/BpMonitorDbContext.fs
+++ b/code/BpMonitor.Data/BpMonitorDbContext.fs
@@ -6,3 +6,4 @@ type BpMonitorDbContext(options: DbContextOptions<BpMonitorDbContext>) =
   inherit DbContext(options)
 
   member this.Readings = this.Set<ReadingRecord>()
+  member this.Members = this.Set<MemberRecord>()

--- a/code/BpMonitor.Data/EfFamilyMemberRepository.fs
+++ b/code/BpMonitor.Data/EfFamilyMemberRepository.fs
@@ -1,0 +1,34 @@
+namespace BpMonitor.Data
+
+open Microsoft.EntityFrameworkCore
+open BpMonitor.Core
+
+module private MemberMapping =
+  let toDomain (r: MemberRecord) : FamilyMember =
+    { Id = r.Id
+      Name = r.Name
+      CreatedAt = r.CreatedAt
+      ModifiedAt = r.ModifiedAt }
+
+  let toEntity (now: System.DateTimeOffset) (m: FamilyMember) : MemberRecord =
+    { Id = m.Id
+      Name = m.Name
+      CreatedAt = now
+      ModifiedAt = now }
+
+type EfFamilyMemberRepository(ctx: BpMonitorDbContext, timeProvider: System.TimeProvider) =
+  interface IFamilyMemberRepository with
+    member _.GetAll() =
+      ctx.Members.AsNoTracking() |> Seq.map MemberMapping.toDomain |> Seq.toList
+
+    member _.GetById(id) =
+      ctx.Members.AsNoTracking()
+      |> Seq.tryFind (fun m -> m.Id = id)
+      |> Option.map MemberMapping.toDomain
+
+    member _.Add(m) =
+      let now = timeProvider.GetUtcNow()
+      let entity = MemberMapping.toEntity now m
+      let entry = ctx.Members.Add(entity)
+      ctx.SaveChanges() |> ignore
+      MemberMapping.toDomain entry.Entity

--- a/code/BpMonitor.Data/EfReadingRepository.fs
+++ b/code/BpMonitor.Data/EfReadingRepository.fs
@@ -6,6 +6,7 @@ open BpMonitor.Core
 module private Mapping =
   let toDomain (r: ReadingRecord) : BloodPressureReading =
     { Id = r.Id
+      MemberId = r.MemberId
       Systolic = r.Systolic
       Diastolic = r.Diastolic
       HeartRate = r.HeartRate
@@ -23,6 +24,7 @@ module private Mapping =
 
   let toEntity (r: BloodPressureReading) : ReadingRecord =
     { Id = r.Id
+      MemberId = r.MemberId
       Systolic = r.Systolic
       Diastolic = r.Diastolic
       HeartRate = r.HeartRate
@@ -33,33 +35,54 @@ module private Mapping =
 
 type EfReadingRepository(ctx: BpMonitorDbContext, timeProvider: System.TimeProvider) =
   interface IReadingRepository with
-    member _.GetAll() =
-      ctx.Readings.AsNoTracking() |> Seq.map Mapping.toDomain |> Seq.toList
+    member _.GetAll(memberId) =
+      ctx.Readings.AsNoTracking()
+      |> Seq.filter (fun r -> r.MemberId = memberId)
+      |> Seq.map Mapping.toDomain
+      |> Seq.toList
 
-    member _.Add(reading) =
+    member _.Add memberId reading =
       let now = timeProvider.GetUtcNow()
 
-      ctx.Readings.Add(reading |> Mapping.withTimestamps now |> Mapping.toEntity)
+      ctx.Readings.Add(
+        reading
+        |> Mapping.withTimestamps now
+        |> (fun r -> { r with MemberId = memberId })
+        |> Mapping.toEntity
+      )
       |> ignore
 
       ctx.SaveChanges() |> ignore
 
-    member _.AddMany(readings) =
+    member _.AddMany memberId readings =
       let now = timeProvider.GetUtcNow()
 
       readings
-      |> List.iter (fun r -> ctx.Readings.Add(r |> Mapping.withTimestamps now |> Mapping.toEntity) |> ignore)
+      |> List.iter (fun r ->
+        ctx.Readings.Add(
+          r
+          |> Mapping.withTimestamps now
+          |> (fun r -> { r with MemberId = memberId })
+          |> Mapping.toEntity
+        )
+        |> ignore)
 
       ctx.SaveChanges() |> ignore
 
     member _.Update(reading) =
       let now = timeProvider.GetUtcNow()
 
-      ctx.ChangeTracker.Entries<ReadingRecord>()
-      |> Seq.tryFind (fun e -> e.Entity.Id = reading.Id)
-      |> Option.iter (fun e -> e.State <- Microsoft.EntityFrameworkCore.EntityState.Detached)
+      // Guard: only update if reading belongs to the expected member (prevents cross-member writes)
+      let existsForMember =
+        ctx.Readings.AsNoTracking()
+        |> Seq.exists (fun r -> r.Id = reading.Id && r.MemberId = reading.MemberId)
 
-      ctx.Readings.Update(reading |> Mapping.withModifiedAt now |> Mapping.toEntity)
-      |> ignore
+      if existsForMember then
+        ctx.ChangeTracker.Entries<ReadingRecord>()
+        |> Seq.tryFind (fun e -> e.Entity.Id = reading.Id)
+        |> Option.iter (fun e -> e.State <- Microsoft.EntityFrameworkCore.EntityState.Detached)
 
-      ctx.SaveChanges() |> ignore
+        ctx.Readings.Update(reading |> Mapping.withModifiedAt now |> Mapping.toEntity)
+        |> ignore
+
+        ctx.SaveChanges() |> ignore

--- a/code/BpMonitor.Data/InMemoryFamilyMemberRepository.fs
+++ b/code/BpMonitor.Data/InMemoryFamilyMemberRepository.fs
@@ -1,0 +1,35 @@
+namespace BpMonitor.Data
+
+open System
+open BpMonitor.Core
+
+module private MemberDefaults =
+  let members =
+    [ { Id = 1
+        Name = "Me"
+        CreatedAt = DateTimeOffset.MinValue
+        ModifiedAt = DateTimeOffset.MinValue } ]
+
+type InMemoryFamilyMemberRepository(initialMembers: FamilyMember list option) =
+  let members =
+    ResizeArray<FamilyMember>(defaultArg initialMembers MemberDefaults.members)
+
+  let mutable nextId =
+    let initial = defaultArg initialMembers MemberDefaults.members
+
+    if initial.IsEmpty then
+      1
+    else
+      (initial |> List.map _.Id |> List.max) + 1
+
+  interface IFamilyMemberRepository with
+    member _.GetAll() = members |> Seq.toList
+
+    member _.GetById(id) =
+      members |> Seq.tryFind (fun m -> m.Id = id)
+
+    member _.Add(m) =
+      let created = { m with Id = nextId }
+      members.Add(created)
+      nextId <- nextId + 1
+      created

--- a/code/BpMonitor.Data/InMemoryReadingRepository.fs
+++ b/code/BpMonitor.Data/InMemoryReadingRepository.fs
@@ -6,6 +6,7 @@ open BpMonitor.Core
 module private Defaults =
   let readings =
     [ { Id = 1
+        MemberId = 1
         Systolic = 122
         Diastolic = 78
         HeartRate = 65
@@ -14,6 +15,7 @@ module private Defaults =
         CreatedAt = DateTimeOffset.MinValue
         ModifiedAt = DateTimeOffset.MinValue }
       { Id = 2
+        MemberId = 1
         Systolic = 135
         Diastolic = 88
         HeartRate = 78
@@ -22,6 +24,7 @@ module private Defaults =
         CreatedAt = DateTimeOffset.MinValue
         ModifiedAt = DateTimeOffset.MinValue }
       { Id = 3
+        MemberId = 1
         Systolic = 118
         Diastolic = 74
         HeartRate = 62
@@ -30,6 +33,7 @@ module private Defaults =
         CreatedAt = DateTimeOffset.MinValue
         ModifiedAt = DateTimeOffset.MinValue }
       { Id = 4
+        MemberId = 1
         Systolic = 128
         Diastolic = 82
         HeartRate = 70
@@ -51,18 +55,32 @@ type InMemoryReadingRepository(initialReadings: BloodPressureReading list option
       (initial |> List.map _.Id |> List.max) + 1
 
   interface IReadingRepository with
-    member _.GetAll() = readings |> Seq.toList
+    member _.GetAll(memberId) =
+      readings |> Seq.filter (fun r -> r.MemberId = memberId) |> Seq.toList
 
-    member _.Add(reading) =
-      readings.Add({ reading with Id = nextId })
+    member _.Add memberId reading =
+      readings.Add(
+        { reading with
+            Id = nextId
+            MemberId = memberId }
+      )
+
       nextId <- nextId + 1
 
-    member _.AddMany(newReadings) =
+    member _.AddMany memberId newReadings =
       newReadings
       |> List.iter (fun r ->
-        readings.Add({ r with Id = nextId })
+        readings.Add(
+          { r with
+              Id = nextId
+              MemberId = memberId }
+        )
+
         nextId <- nextId + 1)
 
     member _.Update(reading) =
-      let idx = readings |> Seq.findIndex (fun r -> r.Id = reading.Id)
+      let idx =
+        readings
+        |> Seq.findIndex (fun r -> r.Id = reading.Id && r.MemberId = reading.MemberId)
+
       readings[idx] <- reading

--- a/code/BpMonitor.Data/MemberRecord.fs
+++ b/code/BpMonitor.Data/MemberRecord.fs
@@ -1,0 +1,10 @@
+namespace BpMonitor.Data
+
+open System
+
+[<CLIMutable>]
+type MemberRecord =
+  { Id: int
+    Name: string
+    CreatedAt: DateTimeOffset
+    ModifiedAt: DateTimeOffset }

--- a/code/BpMonitor.Data/ReadingRecord.fs
+++ b/code/BpMonitor.Data/ReadingRecord.fs
@@ -5,6 +5,7 @@ open System
 [<CLIMutable>]
 type ReadingRecord =
   { Id: int
+    MemberId: int
     Systolic: int
     Diastolic: int
     HeartRate: int

--- a/code/BpMonitor.Data/ReadingRepositoryFactory.fs
+++ b/code/BpMonitor.Data/ReadingRepositoryFactory.fs
@@ -11,3 +11,11 @@ module ReadingRepository =
     let ctx = new BpMonitorDbContext(options)
     SchemaMigrations.apply ctx
     EfReadingRepository(ctx, System.TimeProvider.System)
+
+module FamilyMemberRepository =
+  let create (connectionString: string) : IFamilyMemberRepository =
+    let options =
+      DbContextOptionsBuilder<BpMonitorDbContext>().UseSqlite(connectionString).Options
+
+    let ctx = new BpMonitorDbContext(options)
+    EfFamilyMemberRepository(ctx, System.TimeProvider.System)

--- a/code/BpMonitor.Data/SchemaMigrations.fs
+++ b/code/BpMonitor.Data/SchemaMigrations.fs
@@ -3,20 +3,30 @@ namespace BpMonitor.Data
 open Microsoft.EntityFrameworkCore
 
 module SchemaMigrations =
-  let private columnExists (ctx: BpMonitorDbContext) (table: string) (column: string) =
-    let sql =
-      $"SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = '{column}'"
-
+  let private withConn (ctx: BpMonitorDbContext) (f: System.Data.IDbConnection -> 'a) : 'a =
     let conn = ctx.Database.GetDbConnection()
-    conn.Open()
+    let wasOpen = conn.State = System.Data.ConnectionState.Open
+
+    if not wasOpen then
+      conn.Open()
 
     try
-      use cmd = conn.CreateCommand()
-      cmd.CommandText <- sql
-      let count = cmd.ExecuteScalar() :?> int64
-      count > 0L
+      f conn
     finally
-      conn.Close()
+      if not wasOpen then
+        conn.Close()
+
+  let private scalarInt64 (conn: System.Data.IDbConnection) (sql: string) : int64 =
+    use cmd = conn.CreateCommand()
+    cmd.CommandText <- sql
+    cmd.ExecuteScalar() :?> int64
+
+  let private columnExists (ctx: BpMonitorDbContext) (table: string) (column: string) =
+    withConn ctx (fun conn ->
+      let count =
+        scalarInt64 conn $"SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = '{column}'"
+
+      count > 0L)
 
   let private addColumnIfMissing
     (ctx: BpMonitorDbContext)
@@ -31,7 +41,52 @@ module SchemaMigrations =
       )
       |> ignore
 
+  /// Creates the Members table if it does not already exist.
+  /// EnsureCreated() handles fresh databases, but existing databases that predate
+  /// the Members entity need this explicit DDL.
+  let private createMembersTableIfMissing (ctx: BpMonitorDbContext) =
+    ctx.Database.ExecuteSqlRaw(
+      """CREATE TABLE IF NOT EXISTS "Members" (
+        "Id" INTEGER NOT NULL CONSTRAINT "PK_Members" PRIMARY KEY AUTOINCREMENT,
+        "Name" TEXT NOT NULL,
+        "CreatedAt" TEXT NOT NULL,
+        "ModifiedAt" TEXT NOT NULL
+      )"""
+    )
+    |> ignore
+
+  /// Ensures a default family member exists. Returns its Id, which is used as the
+  /// default value when back-filling the MemberId column on existing readings.
+  let private ensureDefaultMember (ctx: BpMonitorDbContext) : int =
+    let count =
+      withConn ctx (fun conn -> scalarInt64 conn "SELECT COUNT(*) FROM \"Members\"")
+
+    if count = 0L then
+      ctx.Database.ExecuteSqlRaw(
+        "INSERT INTO \"Members\" (\"Name\", \"CreatedAt\", \"ModifiedAt\") VALUES ('Me', '0001-01-01 00:00:00 +00:00', '0001-01-01 00:00:00 +00:00')"
+      )
+      |> ignore
+
+      withConn ctx (fun conn -> scalarInt64 conn "SELECT last_insert_rowid()") |> int
+    else
+      withConn ctx (fun conn -> scalarInt64 conn "SELECT \"Id\" FROM \"Members\" ORDER BY \"Id\" LIMIT 1")
+      |> int
+
   let apply (ctx: BpMonitorDbContext) =
     ctx.Database.EnsureCreated() |> ignore
+
+    // Enable WAL mode for better read/write concurrency under light multi-user load.
+    ctx.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL") |> ignore
+    ctx.Database.ExecuteSqlRaw("PRAGMA busy_timeout=5000") |> ignore
+
     addColumnIfMissing ctx "Readings" "CreatedAt" "TEXT" "0001-01-01 00:00:00 +00:00"
     addColumnIfMissing ctx "Readings" "ModifiedAt" "TEXT" "0001-01-01 00:00:00 +00:00"
+
+    // Create the Members table (no-op on fresh DBs where EnsureCreated already created it).
+    createMembersTableIfMissing ctx
+
+    // Ensure at least one default member exists and get its Id.
+    let defaultMemberId = ensureDefaultMember ctx
+
+    // Back-fill existing readings with the default member Id.
+    addColumnIfMissing ctx "Readings" "MemberId" "INTEGER" (string defaultMemberId)

--- a/code/BpMonitor.Export.Tests/JsonExportTests.fs
+++ b/code/BpMonitor.Export.Tests/JsonExportTests.fs
@@ -15,6 +15,7 @@ open Xunit
 let ``serialize readings to JSON matches snapshot`` () : Task =
   let reading =
     { Id = 1
+      MemberId = 1
       Systolic = 120
       Diastolic = 80
       HeartRate = 70
@@ -30,6 +31,7 @@ let ``serialize readings to JSON matches snapshot`` () : Task =
 let ``tryWriteToFile writes serialized readings to the given path`` () =
   let reading =
     { Id = 1
+      MemberId = 1
       Systolic = 120
       Diastolic = 80
       HeartRate = 70

--- a/code/BpMonitor.Export.Tests/JsonExportTests.serialize readings to JSON matches snapshot.verified.txt
+++ b/code/BpMonitor.Export.Tests/JsonExportTests.serialize readings to JSON matches snapshot.verified.txt
@@ -1,6 +1,7 @@
-﻿[
+[
   {
     id: 1,
+    memberId: 1,
     systolic: 120,
     diastolic: 80,
     heartRate: 70,

--- a/code/BpMonitor.Import.Tests/Generators.fs
+++ b/code/BpMonitor.Import.Tests/Generators.fs
@@ -40,6 +40,7 @@ let timestampGen: Gen<DateTimeOffset> =
 let readingGen: Gen<BloodPressureReading> =
   gen {
     let! id = Gen.choose (0, 100000)
+    let! memberId = Gen.choose (1, 10)
     let! sys = Gen.choose (1, 300)
     let! dia = Gen.choose (1, 200)
     let! hr = Gen.choose (1, 300)
@@ -50,6 +51,7 @@ let readingGen: Gen<BloodPressureReading> =
 
     return
       { Id = id
+        MemberId = memberId
         Systolic = sys
         Diastolic = dia
         HeartRate = hr

--- a/code/BpMonitor.Import.Tests/ImportPropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/ImportPropertyTests.fs
@@ -7,6 +7,8 @@ open BpMonitor.Data
 open BpMonitor.Import
 open BpMonitor.Import.Tests.Generators
 
+let private defaultMemberId = 1
+
 let private emptyRepo () =
   InMemoryReadingRepository(Some []) :> IReadingRepository
 
@@ -17,7 +19,7 @@ let private withLines (readings: BloodPressureReadingUnvalidated list) =
 let ``markdown import accounts for every input row`` () =
   Prop.forAll (Arb.fromGen mixedUnvalidatedListGen) (fun readings ->
     let summary =
-      MarkdownImport.import (emptyRepo ()) ReadingRanges.defaults (withLines readings)
+      MarkdownImport.import (emptyRepo ()) defaultMemberId ReadingRanges.defaults (withLines readings)
 
     summary.Added + summary.Updated + summary.Failed.Length = readings.Length)
 
@@ -26,22 +28,22 @@ let ``markdown re-import of valid distinct readings updates all and adds none`` 
   Prop.forAll (Arb.fromGen distinctValidUnvalidatedGen) (fun readings ->
     let repo = emptyRepo ()
     let rows = withLines readings
-    MarkdownImport.import repo ReadingRanges.defaults rows |> ignore
-    let second = MarkdownImport.import repo ReadingRanges.defaults rows
+    MarkdownImport.import repo defaultMemberId ReadingRanges.defaults rows |> ignore
+    let second = MarkdownImport.import repo defaultMemberId ReadingRanges.defaults rows
 
     second.Added = 0 && second.Updated = readings.Length && second.Failed.IsEmpty)
 
 [<Property>]
 let ``json import accounts for every input reading`` () =
   Prop.forAll (Arb.fromGen (Gen.listOf readingGen)) (fun readings ->
-    let summary = JsonImport.import (emptyRepo ()) readings
+    let summary = JsonImport.import (emptyRepo ()) defaultMemberId readings
     summary.Added + summary.Updated = readings.Length)
 
 [<Property>]
 let ``json re-import of distinct readings updates all and adds none`` () =
   Prop.forAll (Arb.fromGen distinctValidReadingsGen) (fun readings ->
     let repo = emptyRepo ()
-    JsonImport.import repo readings |> ignore
-    let second = JsonImport.import repo readings
+    JsonImport.import repo defaultMemberId readings |> ignore
+    let second = JsonImport.import repo defaultMemberId readings
 
     second.Added = 0 && second.Updated = readings.Length)

--- a/code/BpMonitor.Import.Tests/JsonImportTests.fs
+++ b/code/BpMonitor.Import.Tests/JsonImportTests.fs
@@ -8,8 +8,9 @@ open BpMonitor.Import.JsonImport
 open Swensen.Unquote
 open Xunit
 
-let private makeReading id systolic diastolic heartRate (ts: DateTimeOffset) comments =
+let private makeReading id memberId systolic diastolic heartRate (ts: DateTimeOffset) comments =
   { Id = id
+    MemberId = memberId
     Systolic = systolic
     Diastolic = diastolic
     HeartRate = heartRate
@@ -21,11 +22,11 @@ let private makeReading id systolic diastolic heartRate (ts: DateTimeOffset) com
 [<Fact>]
 let ``parse - valid JSON returns reading list`` () =
   let json =
-    """[{"id":1,"systolic":120,"diastolic":80,"heartRate":70,"timestamp":"2024-10-15T09:00:00+00:00","comments":null,"createdAt":"0001-01-01T00:00:00+00:00","modifiedAt":"0001-01-01T00:00:00+00:00"}]"""
+    """[{"id":1,"memberId":0,"systolic":120,"diastolic":80,"heartRate":70,"timestamp":"2024-10-15T09:00:00+00:00","comments":null,"createdAt":"0001-01-01T00:00:00+00:00","modifiedAt":"0001-01-01T00:00:00+00:00"}]"""
 
   let result = parse json
 
-  let expected = makeReading 1 120 80 70 (Timestamp.utc 2024 10 15 9 0 0) None
+  let expected = makeReading 1 0 120 80 70 (Timestamp.utc 2024 10 15 9 0 0) None
 
   test <@ result = Ok [ expected ] @>
 
@@ -51,13 +52,13 @@ let ``tryReadFromFile returns Ok with readings when file contains valid JSON`` (
 
   File.WriteAllText(
     path,
-    """[{"id":1,"systolic":120,"diastolic":80,"heartRate":70,"timestamp":"2024-10-15T09:00:00+00:00","comments":"morning","createdAt":"0001-01-01T00:00:00+00:00","modifiedAt":"0001-01-01T00:00:00+00:00"}]"""
+    """[{"id":1,"memberId":0,"systolic":120,"diastolic":80,"heartRate":70,"timestamp":"2024-10-15T09:00:00+00:00","comments":"morning","createdAt":"0001-01-01T00:00:00+00:00","modifiedAt":"0001-01-01T00:00:00+00:00"}]"""
   )
 
   let result = tryReadFromFile path
 
   let expected =
-    makeReading 1 120 80 70 (Timestamp.utc 2024 10 15 9 0 0) (Some "morning")
+    makeReading 1 0 120 80 70 (Timestamp.utc 2024 10 15 9 0 0) (Some "morning")
 
   test <@ result = Ok [ expected ] @>
 
@@ -108,27 +109,27 @@ let ``ensureFileExists - does not overwrite existing file`` () =
 let ``import - new reading is added to repository`` () =
   let repo = InMemoryReadingRepository(Some []) :> IReadingRepository
 
-  let reading = makeReading 99 120 80 70 (Timestamp.utc 2024 10 15 9 0 0) None
+  let reading = makeReading 99 0 120 80 70 (Timestamp.utc 2024 10 15 9 0 0) None
 
-  let result = import repo [ reading ]
+  let result = import repo 1 [ reading ]
   test <@ result.Added = 1 @>
   test <@ result.Updated = 0 @>
 
 [<Fact>]
 let ``import - existing reading with same timestamp is updated`` () =
   let ts = Timestamp.utc 2024 10 15 9 0 0
-  let existing = makeReading 1 110 70 60 ts None
+  let existing = makeReading 1 1 110 70 60 ts None
   let repo = InMemoryReadingRepository(Some [ existing ]) :> IReadingRepository
-  let updated = makeReading 99 120 80 70 ts None
-  let result = import repo [ updated ]
+  let updated = makeReading 99 0 120 80 70 ts None
+  let result = import repo 1 [ updated ]
   test <@ result.Added = 0 @>
   test <@ result.Updated = 1 @>
-  test <@ repo.GetAll().[0].Systolic = 120 @>
-  test <@ repo.GetAll().[0].Id = 1 @>
+  test <@ repo.GetAll(1).[0].Systolic = 120 @>
+  test <@ repo.GetAll(1).[0].Id = 1 @>
 
 [<Fact>]
 let ``import - empty list returns zero counts`` () =
   let repo = InMemoryReadingRepository(Some []) :> IReadingRepository
-  let result = import repo []
+  let result = import repo 1 []
   test <@ result.Added = 0 @>
   test <@ result.Updated = 0 @>

--- a/code/BpMonitor.Import.Tests/MarkdownImportTests.fs
+++ b/code/BpMonitor.Import.Tests/MarkdownImportTests.fs
@@ -229,7 +229,7 @@ let ``import - new valid reading is added to repository`` () =
       Comments = None }
 
   let result =
-    import repo ReadingRanges.defaults [ (1, "- 09:00: 120/80 70", reading) ]
+    import repo 1 ReadingRanges.defaults [ (1, "- 09:00: 120/80 70", reading) ]
 
   test <@ result.Added = 1 @>
   test <@ result.Updated = 0 @>
@@ -239,6 +239,7 @@ let ``import - new valid reading is added to repository`` () =
 let ``import - existing reading with same timestamp is updated`` () =
   let existing: BloodPressureReading =
     { Id = 1
+      MemberId = 1
       Systolic = 110
       Diastolic = 70
       HeartRate = 60
@@ -257,12 +258,12 @@ let ``import - existing reading with same timestamp is updated`` () =
       Comments = None }
 
   let result =
-    import repo ReadingRanges.defaults [ (1, "- 09:00: 120/80 70", updated) ]
+    import repo 1 ReadingRanges.defaults [ (1, "- 09:00: 120/80 70", updated) ]
 
   test <@ result.Added = 0 @>
   test <@ result.Updated = 1 @>
   test <@ result.Failed = [] @>
-  test <@ repo.GetAll().[0].Systolic = 120 @>
+  test <@ repo.GetAll(1).[0].Systolic = 120 @>
 
 [<Fact>]
 let ``import - invalid reading is captured in Failed, valid ones still imported`` () =
@@ -283,7 +284,7 @@ let ``import - invalid reading is captured in Failed, valid ones still imported`
       Comments = None }
 
   let result =
-    import repo ReadingRanges.defaults [ (1, "- 09:00: 0/80 70", invalid); (2, "- 10:00: 120/80 70", valid) ]
+    import repo 1 ReadingRanges.defaults [ (1, "- 09:00: 0/80 70", invalid); (2, "- 10:00: 120/80 70", valid) ]
 
   test <@ result.Added = 1 @>
   test <@ result.Updated = 0 @>

--- a/code/BpMonitor.Import/JsonImport.fs
+++ b/code/BpMonitor.Import/JsonImport.fs
@@ -31,16 +31,21 @@ let tryReadFromFile (path: string) : Result<BloodPressureReading list, string> =
   | :? UnauthorizedAccessException as ex -> Error ex.Message
   |> Result.bind parse
 
-let import (repository: IReadingRepository) (readings: BloodPressureReading list) : JsonImportSummary =
-  let existing = repository.GetAll()
+let import (repository: IReadingRepository) (memberId: int) (readings: BloodPressureReading list) : JsonImportSummary =
+  let existing = repository.GetAll(memberId)
 
   let folder (added, updated) (reading: BloodPressureReading) =
     match existing |> List.tryFind (fun r -> r.Timestamp = reading.Timestamp) with
     | None ->
-      repository.Add(reading)
+      repository.Add memberId reading
       (added + 1, updated)
     | Some existingReading ->
-      repository.Update({ reading with Id = existingReading.Id })
+      repository.Update(
+        { reading with
+            Id = existingReading.Id
+            MemberId = memberId }
+      )
+
       (added, updated + 1)
 
   let (added, updated) = readings |> List.fold folder (0, 0)

--- a/code/BpMonitor.Import/MarkdownImport.fs
+++ b/code/BpMonitor.Import/MarkdownImport.fs
@@ -63,10 +63,11 @@ let parseMarkdown (markdown: string) : (int * string * BloodPressureReadingUnval
 
 let import
   (repository: IReadingRepository)
+  (memberId: int)
   (ranges: ReadingRanges)
   (unvalidated: (int * string * BloodPressureReadingUnvalidated) list)
   : ImportSummary =
-  let existing = repository.GetAll()
+  let existing = repository.GetAll(memberId)
 
   let folder acc (lineNumber, line, reading) =
     let (added, updated, failed) = acc
@@ -76,12 +77,13 @@ let import
     | Ok validated ->
       match existing |> List.tryFind (fun r -> r.Timestamp = validated.Timestamp) with
       | None ->
-        repository.Add(validated)
+        repository.Add memberId validated
         (added + 1, updated, failed)
       | Some existingReading ->
         repository.Update(
           { validated with
-              Id = existingReading.Id }
+              Id = existingReading.Id
+              MemberId = memberId }
         )
 
         (added, updated + 1, failed)

--- a/code/BpMonitor.Web.Tests/HandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerTests.fs
@@ -7,8 +7,12 @@ open BpMonitor.Core
 open BpMonitor.Data
 open BpMonitor.Web
 
+// All tests use member 1 — the default member seeded by InMemoryFamilyMemberRepository.
+let private defaultMemberId = 1
+
 let private sample: BloodPressureReading =
   { Id = 1
+    MemberId = defaultMemberId
     Systolic = 120
     Diastolic = 80
     HeartRate = 66
@@ -56,7 +60,24 @@ let ``createReading persists a valid reading and redirects`` () =
 
   test <@ ctx.Response.StatusCode = 302 @>
   test <@ ctx.Response.Headers.Location.ToString() = "/history" @>
-  test <@ repo.GetAll() |> List.length = 1 @>
+  test <@ repo.GetAll(defaultMemberId) |> List.length = 1 @>
+
+[<Fact>]
+let ``createReading stamps reading with active member Id`` () =
+  let repo = repoWith []
+  let ctx = TestHost.context repo
+
+  TestHost.setForm
+    ctx
+    [ "Timestamp", "2026-05-01 09:00"
+      "Systolic", "120"
+      "Diastolic", "80"
+      "HeartRate", "66"
+      "Comments", "" ]
+
+  TestHost.run Handlers.createReading ctx
+
+  test <@ repo.GetAll(defaultMemberId).[0].MemberId = defaultMemberId @>
 
 [<Fact>]
 let ``createReading rejects an out-of-range reading with 422 and does not persist`` () =
@@ -75,7 +96,7 @@ let ``createReading rejects an out-of-range reading with 422 and does not persis
 
   test <@ ctx.Response.StatusCode = 422 @>
   test <@ (TestHost.readBody ctx).Contains "out of range" @>
-  test <@ repo.GetAll() |> List.isEmpty @>
+  test <@ repo.GetAll(defaultMemberId) |> List.isEmpty @>
 
 [<Fact>]
 let ``createReading rejects a non-numeric field with 422`` () =
@@ -94,7 +115,7 @@ let ``createReading rejects a non-numeric field with 422`` () =
 
   test <@ ctx.Response.StatusCode = 422 @>
   test <@ (TestHost.readBody ctx).Contains "not a valid integer" @>
-  test <@ repo.GetAll() |> List.isEmpty @>
+  test <@ repo.GetAll(defaultMemberId) |> List.isEmpty @>
 
 [<Fact>]
 let ``editReading prefills the form for an existing reading`` () =
@@ -133,5 +154,5 @@ let ``updateReading saves changes and redirects`` () =
 
   test <@ ctx.Response.StatusCode = 302 @>
   test <@ ctx.Response.Headers.Location.ToString() = "/history" @>
-  let updated = repo.GetAll() |> List.exactlyOne
+  let updated = repo.GetAll(defaultMemberId) |> List.exactlyOne
   test <@ updated.Systolic = 111 && updated.Comments = Some "updated" @>

--- a/code/BpMonitor.Web.Tests/TestHost.fs
+++ b/code/BpMonitor.Web.Tests/TestHost.fs
@@ -8,18 +8,25 @@ open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Primitives
 open BpMonitor.Core
+open BpMonitor.Data
 
-/// Builds a DefaultHttpContext wired with the given repository (and default
-/// ranges) so the real Falco handlers can be invoked directly in tests.
+/// Builds a DefaultHttpContext wired with the given reading repository (and default
+/// ranges + a single in-memory family member) so the real Falco handlers can be
+/// invoked directly in tests. The default member has Id=1; the bp_member cookie
+/// is pre-set so activeMember resolves to it without needing a DB.
 let context (repo: IReadingRepository) : HttpContext =
+  let memberRepo = InMemoryFamilyMemberRepository(None) :> IFamilyMemberRepository
+
   let services = ServiceCollection()
   services.AddLogging() |> ignore
   services.AddSingleton<IReadingRepository>(repo) |> ignore
+  services.AddSingleton<IFamilyMemberRepository>(memberRepo) |> ignore
   services.AddSingleton<IConfiguration>(ConfigurationBuilder().Build()) |> ignore
 
   let ctx = DefaultHttpContext()
   ctx.RequestServices <- services.BuildServiceProvider()
   ctx.Response.Body <- new MemoryStream()
+  // No cookie set: activeMember falls back to the first member (Id=1) from InMemoryFamilyMemberRepository.
   ctx
 
 /// Reads back whatever a handler wrote to the response body.

--- a/code/BpMonitor.Web.Tests/ViewTests.fs
+++ b/code/BpMonitor.Web.Tests/ViewTests.fs
@@ -7,8 +7,15 @@ open Falco.Markup
 open BpMonitor.Core
 open BpMonitor.Web
 
+let private defaultMember: FamilyMember =
+  { Id = 1
+    Name = "Me"
+    CreatedAt = DateTimeOffset.MinValue
+    ModifiedAt = DateTimeOffset.MinValue }
+
 let private sample =
   { Id = 7
+    MemberId = 1
     Systolic = 123
     Diastolic = 81
     HeartRate = 67
@@ -30,7 +37,7 @@ let ``landing renders links to add and history`` () =
 let ``every page has a BpMonitor footer`` () =
   let pages =
     [ renderHtml Views.landing
-      renderHtml (Views.history [ sample ])
+      renderHtml (Views.history defaultMember [ sample ])
       renderHtml (Views.readingForm "/add" "Add reading" "/readings" [] Binding.empty) ]
 
   for html in pages do
@@ -39,7 +46,7 @@ let ``every page has a BpMonitor footer`` () =
 
 [<Fact>]
 let ``history renders reading values, chart iframe and nav links`` () =
-  let html = renderHtml (Views.history [ sample ])
+  let html = renderHtml (Views.history defaultMember [ sample ])
 
   test <@ html.Contains "123" @>
   test <@ html.Contains "after walk" @>
@@ -74,7 +81,7 @@ let ``view encodes user-supplied content`` () =
     { sample with
         Comments = Some "<script>x</script>" }
 
-  let html = renderHtml (Views.history [ nasty ])
+  let html = renderHtml (Views.history defaultMember [ nasty ])
 
   test <@ not (html.Contains "<script>x</script>") @>
   test <@ html.Contains "&lt;script&gt;" @>

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -16,6 +16,9 @@ module Handlers =
   let private repo (ctx: HttpContext) =
     ctx.RequestServices.GetRequiredService<IReadingRepository>()
 
+  let private memberRepo (ctx: HttpContext) =
+    ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
+
   let private ranges (ctx: HttpContext) =
     Config.readRanges (ctx.RequestServices.GetRequiredService<IConfiguration>())
 
@@ -51,8 +54,26 @@ module Handlers =
           Binding.Comments = get "Comments" }
     }
 
-  let private sortedReadings (ctx: HttpContext) =
-    (repo ctx).GetAll() |> List.sortByDescending _.Timestamp
+  /// Resolves the active family member from the bp_member cookie, falling back to
+  /// the first member when no cookie is set or the cookie Id is invalid.
+  let private activeMember (ctx: HttpContext) : FamilyMember =
+    let allMembers = (memberRepo ctx).GetAll()
+
+    let cookieMemberId =
+      match ctx.Request.Cookies.TryGetValue("bp_member") with
+      | true, v ->
+        match Int32.TryParse(v) with
+        | true, id -> Some id
+        | _ -> None
+      | _ -> None
+
+    cookieMemberId
+    |> Option.bind (fun id -> allMembers |> List.tryFind (fun m -> m.Id = id))
+    |> Option.orElse (allMembers |> List.tryHead)
+    |> Option.defaultWith (fun () -> failwith "No family members configured. Visit /members to create one.")
+
+  let private sortedReadings (memberId: int) (ctx: HttpContext) =
+    (repo ctx).GetAll(memberId) |> List.sortByDescending _.Timestamp
 
   /// Renders the add/edit form after a failed submit (status 422).
   let private renderFormErrors (ctx: HttpContext) active title action errors model : Task =
@@ -95,12 +116,15 @@ module Handlers =
   let landing: HttpContext -> Task = fun ctx -> htmlResponse Views.landing ctx
 
   let history: HttpContext -> Task =
-    fun ctx -> htmlResponse (Views.history (sortedReadings ctx)) ctx
+    fun ctx ->
+      let m = activeMember ctx
+      htmlResponse (Views.history m (sortedReadings m.Id ctx)) ctx
 
   let chart: HttpContext -> Task =
     fun ctx ->
+      let m = activeMember ctx
       ctx.Response.ContentType <- "text/html; charset=utf-8"
-      ctx.Response.WriteAsync(BpChart.toHtml ((repo ctx).GetAll()))
+      ctx.Response.WriteAsync(BpChart.toHtml ((repo ctx).GetAll(m.Id)))
 
   let newReading: HttpContext -> Task =
     fun ctx ->
@@ -111,11 +135,14 @@ module Handlers =
       htmlResponse (Views.readingForm "/add" "Add reading" "/readings" [] prefill) ctx
 
   let createReading: HttpContext -> Task =
-    fun ctx -> submit ctx "/add" "Add reading" "/readings" (repo ctx).Add
+    fun ctx ->
+      let m = activeMember ctx
+      submit ctx "/add" "Add reading" "/readings" ((repo ctx).Add m.Id)
 
   let editReading: HttpContext -> Task =
     fun ctx ->
       let log = logger ctx
+      let m = activeMember ctx
 
       match routeInt ctx "id" with
       | None ->
@@ -123,20 +150,74 @@ module Handlers =
         ctx.Response.StatusCode <- 400
         ctx.Response.WriteAsync("Bad request")
       | Some id ->
-        match (repo ctx).GetAll() |> List.tryFind (fun r -> r.Id = id) with
+        match (repo ctx).GetAll(m.Id) |> List.tryFind (fun r -> r.Id = id) with
         | Some r -> htmlResponse (Views.readingForm "" "Edit reading" $"/readings/{id}" [] (Binding.ofReading r)) ctx
         | None ->
-          log.LogWarning("editReading: reading {Id} not found", id)
+          log.LogWarning("editReading: reading {Id} not found for member {MemberId}", id, m.Id)
           ctx.Response.StatusCode <- 404
           ctx.Response.WriteAsync("Not found")
 
   let updateReading: HttpContext -> Task =
     fun ctx ->
       let log = logger ctx
+      let m = activeMember ctx
 
       match routeInt ctx "id" with
       | None ->
         log.LogWarning("updateReading: bad route value for {{id}}")
         ctx.Response.StatusCode <- 400
         ctx.Response.WriteAsync("Bad request")
-      | Some id -> submit ctx "" "Edit reading" $"/readings/{id}" (fun r -> (repo ctx).Update { r with Id = id })
+      | Some id ->
+        submit ctx "" "Edit reading" $"/readings/{id}" (fun r -> (repo ctx).Update { r with Id = id; MemberId = m.Id })
+
+  let members: HttpContext -> Task =
+    fun ctx ->
+      let allMembers = (memberRepo ctx).GetAll()
+      let active = activeMember ctx
+      htmlResponse (Views.members allMembers active) ctx
+
+  let createMember: HttpContext -> Task =
+    fun ctx ->
+      task {
+        let! form = ctx.Request.ReadFormAsync()
+        let name = form["Name"].ToString()
+
+        match FamilyMember.create name with
+        | Error NameIsEmpty ->
+          let allMembers = (memberRepo ctx).GetAll()
+          let active = activeMember ctx
+          ctx.Response.StatusCode <- 422
+          do! htmlResponse (Views.membersWithError allMembers active "Name cannot be empty") ctx
+        | Ok m ->
+          let created = (memberRepo ctx).Add(m)
+
+          ctx.Response.Cookies.Append(
+            "bp_member",
+            string created.Id,
+            CookieOptions(HttpOnly = true, SameSite = SameSiteMode.Strict)
+          )
+
+          ctx.Response.Redirect "/members"
+      }
+      :> Task
+
+  let switchMember: HttpContext -> Task =
+    fun ctx ->
+      task {
+        let! form = ctx.Request.ReadFormAsync()
+        let memberId = form["MemberId"].ToString()
+
+        ctx.Response.Cookies.Append(
+          "bp_member",
+          memberId,
+          CookieOptions(HttpOnly = true, SameSite = SameSiteMode.Strict)
+        )
+
+        let returnUrl =
+          match form.TryGetValue("ReturnUrl") with
+          | true, v when v.ToString() <> "" -> v.ToString()
+          | _ -> "/"
+
+        ctx.Response.Redirect(returnUrl)
+      }
+      :> Task

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -19,7 +19,10 @@ let private endpoints =
     get "/chart" Handlers.chart
     post "/readings" Handlers.createReading
     get "/readings/{id:int}/edit" Handlers.editReading
-    post "/readings/{id:int}" Handlers.updateReading ]
+    post "/readings/{id:int}" Handlers.updateReading
+    get "/members" Handlers.members
+    post "/members" Handlers.createMember
+    post "/members/switch" Handlers.switchMember ]
 
 [<EntryPoint>]
 let main args =
@@ -42,6 +45,10 @@ let main args =
 
     builder.Services.AddScoped<IReadingRepository>(fun sp ->
       EfReadingRepository(sp.GetRequiredService<BpMonitorDbContext>(), TimeProvider.System))
+    |> ignore
+
+    builder.Services.AddScoped<IFamilyMemberRepository>(fun sp ->
+      EfFamilyMemberRepository(sp.GetRequiredService<BpMonitorDbContext>(), TimeProvider.System))
     |> ignore
 
     let app = builder.Build()

--- a/code/BpMonitor.Web/Views.fs
+++ b/code/BpMonitor.Web/Views.fs
@@ -45,7 +45,8 @@ module Views =
                   [ Elem.li [] [ Elem.strong [] [ Text.raw "BpMonitor" ] ]
                     navLink active "/" "Home"
                     navLink active "/add" "Add"
-                    navLink active "/history" "History" ]
+                    navLink active "/history" "History"
+                    navLink active "/members" "Members" ]
                 Elem.ul
                   []
                   [ Elem.li
@@ -116,11 +117,11 @@ module Views =
             Elem.a [ Attr.href "/history"; Attr.role "button" ] [ Text.raw "History" ] ] ]
 
   /// History: chart (isolated in an iframe) above the readings table.
-  let history (readings: BloodPressureReading list) : XmlNode =
+  let history (activeMember: FamilyMember) (readings: BloodPressureReading list) : XmlNode =
     layout
       "/history"
       "History"
-      [ Elem.h1 [] [ Text.raw "History" ]
+      [ Elem.h1 [] [ Text.raw $"History — {activeMember.Name}" ]
         Elem.details
           []
           [ Elem.summary [ Attr.class' "chart-toggle" ] [ Text.raw "Blood Pressure Graph" ]
@@ -165,3 +166,55 @@ module Views =
               [ Attr.class' "actions" ]
               [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Save" ]
                 Elem.a [ Attr.href "/history"; Attr.role "button"; Attr.class' "secondary" ] [ Text.raw "Cancel" ] ] ] ]
+
+  let private membersList
+    (allMembers: FamilyMember list)
+    (active: FamilyMember)
+    (errorMsg: string option)
+    : XmlNode list =
+    let memberRow (m: FamilyMember) =
+      let isCurrent = m.Id = active.Id
+
+      Elem.tr
+        []
+        [ Elem.td [] [ Text.enc m.Name ]
+          Elem.td
+            []
+            [ if isCurrent then
+                Elem.span [ Attr.class' "current-member" ] [ Text.raw "Active" ]
+              else
+                Elem.form
+                  [ Attr.method "post"; Attr.action "/members/switch" ]
+                  [ Elem.input [ Attr.type' "hidden"; Attr.name "MemberId"; Attr.value (string m.Id) ]
+                    Elem.input [ Attr.type' "hidden"; Attr.name "ReturnUrl"; Attr.value "/members" ]
+                    Elem.button [ Attr.type' "submit"; Attr.class' "outline" ] [ Text.raw "Switch" ] ] ] ]
+
+    [ match errorMsg with
+      | Some msg -> yield errorBox [ msg ]
+      | None -> ()
+      yield
+        Elem.table
+          []
+          [ Elem.thead [] [ Elem.tr [] [ Elem.th [] [ Text.raw "Name" ]; Elem.th [] [ Text.raw "" ] ] ]
+            Elem.tbody [] (allMembers |> List.map memberRow) ]
+      yield Elem.h2 [] [ Text.raw "Add family member" ]
+      yield
+        Elem.form
+          [ Attr.method "post"; Attr.action "/members" ]
+          [ Elem.div
+              [ Attr.class' "field" ]
+              [ Elem.label [ Attr.for' "Name" ] [ Text.raw "Name" ]
+                Elem.input [ Attr.type' "text"; Attr.id "Name"; Attr.name "Name" ] ]
+            Elem.button [ Attr.type' "submit" ] [ Text.raw "Add member" ] ] ]
+
+  /// Members page: list of family members with Switch buttons and an add form.
+  let members (allMembers: FamilyMember list) (active: FamilyMember) : XmlNode =
+    layout "/members" "Family Members" (Elem.h1 [] [ Text.raw "Family Members" ] :: membersList allMembers active None)
+
+  /// Members page rendered with a validation error message.
+  let membersWithError (allMembers: FamilyMember list) (active: FamilyMember) (error: string) : XmlNode =
+    layout
+      "/members"
+      "Family Members"
+      (Elem.h1 [] [ Text.raw "Family Members" ]
+       :: membersList allMembers active (Some error))

--- a/docs/adr/0005-multi-user-family-support.md
+++ b/docs/adr/0005-multi-user-family-support.md
@@ -1,0 +1,54 @@
+# ADR 0005 — Multi-user (family) support
+
+**Date:** 2026-06-04  
+**Status:** Accepted
+
+## Context
+
+BpMonitor was originally a single-stream app: one global `Readings` table with no notion of ownership. The product needs to serve a family — each member tracking their own blood pressure independently.
+
+Two design questions arose:
+
+1. **Database engine:** Should we switch from SQLite to Postgres to support multiple users?
+2. **Active-member mechanism:** Without a login system (deferred), how should the app know which family member is "active"?
+
+## Decisions
+
+### 1. Stay on SQLite — multi-user is a data-model change, not a DB-engine change
+
+"Multi-user" for a family means a handful of profiles and very light, mostly-serial write load. SQLite's only real constraint is concurrent *writers* under heavy load. With WAL mode enabled and per-request scoped `DbContext`, even a busy family's write pattern is well within SQLite's capabilities.
+
+Postgres would add an external server, credentials, container, backup strategy, and connection management for zero practical benefit at this scale. The correct response to "do we need Postgres?" is: "only when we genuinely have many concurrent writers or require DB-level features SQLite can't provide."
+
+**Consequence:** multi-user support is implemented as a data-model change:
+- New `Members` SQLite table and `FamilyMember` domain type
+- `MemberId` foreign key on `Readings`
+- All repository read/write methods are now member-scoped
+
+### 2. Active member via `bp_member` cookie — explicit stepping stone for future auth
+
+Login is explicitly deferred. The active member is determined by a `bp_member` cookie (HttpOnly, SameSite=Strict) set when the user picks a profile from `/members`. If no cookie is set (first visit, new browser), the app falls back to the first family member.
+
+This is a deliberate stepping stone: when real authentication is added later, only the active-member resolver needs to change (read the session/JWT claim instead of the cookie). The data model, repository interfaces, and handler logic remain unchanged.
+
+### 3. Existing data backfill
+
+Schema migration (`SchemaMigrations.apply`) seeds a default member ("Me") on first run and back-fills all existing readings to that member's ID, so current data stays visible without manual intervention.
+
+### 4. WAL mode enabled
+
+WAL + `busy_timeout=5000` are now applied at startup (they were previously assumed but not actually set). This was the right moment to close that gap.
+
+## Alternatives considered
+
+- **Postgres**: ruled out — see above
+- **Route-segment per member** (`/members/{id}/history`): explicit and bookmarkable, but rewrites every route, nav link, and the chart iframe URL. Cookie-based selection keeps URLs stable and is simpler to layer auth on top of.
+- **Query param `?member=`**: lightweight but ugly URLs, easy to lose the selection, fragile with htmx boosting.
+
+## Consequences
+
+- `IReadingRepository` is now member-scoped: `GetAll memberId`, `Add memberId`, `AddMany memberId`, `Update` (guards by `reading.MemberId`)
+- `BloodPressureReading` has a new `MemberId: int` field (defaults to 0 from `parse`; stamped with the real ID at persist time)
+- `InMemoryFamilyMemberRepository` is used in tests; `EfFamilyMemberRepository` in production
+- Import/Export functions gained a `memberId` parameter
+- Login, per-member permissions, member delete/merge, and per-member chart colours are out of scope for this iteration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,13 @@ code/
 
 ```fsharp
 // BpMonitor.Core
+type FamilyMember = {
+    Id:         int
+    Name:       string
+    CreatedAt:  DateTimeOffset
+    ModifiedAt: DateTimeOffset
+}
+
 type BloodPressureReadingUnvalidated = {
     Systolic:  int
     Diastolic: int
@@ -49,6 +56,7 @@ type BloodPressureReadingUnvalidated = {
 
 type BloodPressureReading = {
     Id:         int
+    MemberId:   int           // which family member this reading belongs to
     Systolic:   int
     Diastolic:  int
     HeartRate:  int
@@ -88,18 +96,20 @@ graph TD
 
 ### BpMonitor.Core
 
-- Domain models (`BloodPressureReading`, `BloodPressureReadingUnvalidated`)
-- Repository interface (`IReadingRepository`)
+- Domain models (`BloodPressureReading`, `BloodPressureReadingUnvalidated`, `FamilyMember`)
+- Repository interfaces (`IReadingRepository`, `IFamilyMemberRepository`)
+- `IReadingRepository` is member-scoped: `GetAll memberId`, `Add memberId`, `AddMany memberId`, `Update` (uses `reading.MemberId` as the guard)
 - Business logic: applicative validation via `FsToolkit.ErrorHandling`
 - No dependencies on other projects
 
 ### BpMonitor.Data
 
-- EF Core `DbContext` and `ReadingRecord` entity
-- SQLite configuration (`appsettings.json`)
-- `IReadingRepository` implementations: `EfReadingRepository`, `InMemoryReadingRepository`
-- Manual schema migrations via `SchemaMigrations` module (EF Core migrations do not support F#)
-- `ReadingRepositoryFactory` wiring
+- EF Core `DbContext` with two `DbSet`s: `Readings` (`ReadingRecord`) and `Members` (`MemberRecord`)
+- SQLite with WAL mode + 5 s busy timeout (applied at startup)
+- `IReadingRepository` implementations: `EfReadingRepository` (filters by `MemberId`), `InMemoryReadingRepository`
+- `IFamilyMemberRepository` implementations: `EfFamilyMemberRepository`, `InMemoryFamilyMemberRepository`
+- Manual schema migrations via `SchemaMigrations.apply` (EF Core migrations do not support F#); handles `Members` table creation, default-member seeding, and `MemberId` backfill for existing rows
+- `ReadingRepositoryFactory` / `FamilyMemberRepository` factory wiring
 
 ### BpMonitor.Import
 
@@ -122,7 +132,10 @@ graph TD
 ### BpMonitor.Web
 
 - Falco web application serving on `0.0.0.0:5000`
-- Three pages: `/` landing hub, `/add` entry form, `/history` table + chart iframe
+- Pages: `/` landing hub, `/add` entry form, `/history` table + chart iframe, `/members` family-member management
+- Active family member tracked via `bp_member` cookie (HttpOnly, SameSite=Strict); falls back to the first member when no cookie is set. Login is deferred — this cookie is the stepping stone for real auth later
+- `POST /members/switch` sets the cookie and redirects; `POST /members` creates a new family member
+- Every reading handler resolves the active member first; `IReadingRepository` calls are all member-scoped
 - Server-rendered HTML via `Falco.Markup`; htmx for partial updates
 - Scoped `DbContext` per request (concurrency-safe)
 - Structured logging via Serilog: one CLEF JSON line per request + domain events; logs flow to stdout → container/journal


### PR DESCRIPTION
## Summary

- Adds `FamilyMember` domain type + `IFamilyMemberRepository` interface (Core); all `IReadingRepository` methods are now member-scoped (`GetAll memberId`, `Add memberId`, `AddMany memberId`); `Update` guards against cross-member writes via `reading.MemberId`
- New `Members` SQLite table (`MemberRecord`, `EfFamilyMemberRepository`, `InMemoryFamilyMemberRepository`); `SchemaMigrations` creates the table on existing DBs, seeds a default "Me" member, and back-fills `MemberId` on all existing readings; WAL mode + 5 s busy timeout now actually enabled
- Web: `/members` page (list members, add new, switch active); `POST /members/switch` sets the `bp_member` cookie (HttpOnly, SameSite=Strict); active-member resolution falls back to the first member when no cookie is set — deliberate stepping stone for real auth later; "Members" link added to nav; history heading shows active member name
- Import functions (`JsonImport.import`, `MarkdownImport.import`) now take a `memberId` parameter
- ADR 0005, `docs/architecture.md`, and `AGENTS.md` updated

**Database:** stays on SQLite — multi-user for a family is a data-model change, not a DB-engine change. See ADR 0005.

**Login:** explicitly deferred. The cookie-based active member is the stepping stone; real auth later replaces only the `activeMember` resolver.