### PR TITLE
✨ feat: add IsAdmin and IsActive fields to family members with edit flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ code/
 ├── BpMonitor.Import      # Markdown and JSON importers (take memberId param)
 ├── BpMonitor.Export      # JSON serialisation and file write
 ├── BpMonitor.Charts      # Plotly.NET chart generation → HTML output
-├── BpMonitor.Web         # Falco web app (landing, add, history, members pages); Serilog structured stdout logging
+├── BpMonitor.Web         # Falco web app (landing, add, history, members pages + member edit); Serilog structured stdout logging
 └── BpMonitor.Arch.Tests  # ArchUnit Clean Architecture rules
 docs/                     # Product vision, architecture, ADRs
 ```

--- a/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
+++ b/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="BloodPressureReadingTests.fs" />
     <Compile Include="BloodPressureReadingPropertyTests.fs" />
     <Compile Include="ReadingRepositoryContractTests.fs" />
+    <Compile Include="FamilyMemberTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Core.Tests/FamilyMemberTests.fs
+++ b/code/BpMonitor.Core.Tests/FamilyMemberTests.fs
@@ -1,0 +1,77 @@
+module FamilyMemberTests
+
+open Xunit
+open Swensen.Unquote
+open BpMonitor.Core
+
+[<Fact>]
+let ``create with isAdmin=true yields admin active member`` () =
+  match FamilyMember.create "Alice" true with
+  | Error _ -> failwith "unexpected error"
+  | Ok m ->
+    test <@ m.IsAdmin = true @>
+    test <@ m.IsActive = true @>
+
+[<Fact>]
+let ``create with isAdmin=false yields non-admin active member`` () =
+  match FamilyMember.create "Bob" false with
+  | Error _ -> failwith "unexpected error"
+  | Ok m ->
+    test <@ m.IsAdmin = false @>
+    test <@ m.IsActive = true @>
+
+[<Fact>]
+let ``create trims name and keeps it`` () =
+  match FamilyMember.create "  Alice  " false with
+  | Error _ -> failwith "unexpected error"
+  | Ok m -> test <@ m.Name = "Alice" @>
+
+[<Fact>]
+let ``create blank name returns NameIsEmpty`` () =
+  test <@ FamilyMember.create "   " false = Error NameIsEmpty @>
+
+[<Fact>]
+let ``hasActiveAdmin is false for empty list`` () =
+  test <@ FamilyMember.hasActiveAdmin [] = false @>
+
+[<Fact>]
+let ``hasActiveAdmin is false when no member is admin`` () =
+  let members =
+    [ { Id = 1
+        Name = "A"
+        IsAdmin = false
+        IsActive = true
+        CreatedAt = System.DateTimeOffset.MinValue
+        ModifiedAt = System.DateTimeOffset.MinValue } ]
+
+  test <@ FamilyMember.hasActiveAdmin members = false @>
+
+[<Fact>]
+let ``hasActiveAdmin is false when admin member is inactive`` () =
+  let members =
+    [ { Id = 1
+        Name = "A"
+        IsAdmin = true
+        IsActive = false
+        CreatedAt = System.DateTimeOffset.MinValue
+        ModifiedAt = System.DateTimeOffset.MinValue } ]
+
+  test <@ FamilyMember.hasActiveAdmin members = false @>
+
+[<Fact>]
+let ``hasActiveAdmin is true when at least one member is admin and active`` () =
+  let members =
+    [ { Id = 1
+        Name = "A"
+        IsAdmin = false
+        IsActive = true
+        CreatedAt = System.DateTimeOffset.MinValue
+        ModifiedAt = System.DateTimeOffset.MinValue }
+      { Id = 2
+        Name = "B"
+        IsAdmin = true
+        IsActive = true
+        CreatedAt = System.DateTimeOffset.MinValue
+        ModifiedAt = System.DateTimeOffset.MinValue } ]
+
+  test <@ FamilyMember.hasActiveAdmin members = true @>

--- a/code/BpMonitor.Core/FamilyMember.fs
+++ b/code/BpMonitor.Core/FamilyMember.fs
@@ -5,18 +5,27 @@ open System
 type FamilyMember =
   { Id: int
     Name: string
+    IsAdmin: bool
+    IsActive: bool
     CreatedAt: DateTimeOffset
     ModifiedAt: DateTimeOffset }
 
 type FamilyMemberError = | NameIsEmpty
 
 module FamilyMember =
-  let create (name: string) : Result<FamilyMember, FamilyMemberError> =
+  let create (name: string) (isAdmin: bool) : Result<FamilyMember, FamilyMemberError> =
     if String.IsNullOrWhiteSpace(name) then
       Error NameIsEmpty
     else
       Ok
         { Id = 0
           Name = name.Trim()
+          IsAdmin = isAdmin
+          IsActive = true
           CreatedAt = DateTimeOffset.MinValue
           ModifiedAt = DateTimeOffset.MinValue }
+
+  /// Returns true when the list contains at least one member that is both admin and active.
+  /// Used to enforce the invariant before saving member changes.
+  let hasActiveAdmin (members: FamilyMember list) =
+    members |> List.exists (fun m -> m.IsAdmin && m.IsActive)

--- a/code/BpMonitor.Core/IFamilyMemberRepository.fs
+++ b/code/BpMonitor.Core/IFamilyMemberRepository.fs
@@ -4,3 +4,4 @@ type IFamilyMemberRepository =
   abstract GetAll: unit -> FamilyMember list
   abstract GetById: int -> FamilyMember option
   abstract Add: FamilyMember -> FamilyMember
+  abstract Update: FamilyMember -> unit

--- a/code/BpMonitor.Data/EfFamilyMemberRepository.fs
+++ b/code/BpMonitor.Data/EfFamilyMemberRepository.fs
@@ -7,12 +7,16 @@ module private MemberMapping =
   let toDomain (r: MemberRecord) : FamilyMember =
     { Id = r.Id
       Name = r.Name
+      IsAdmin = r.IsAdmin
+      IsActive = r.IsActive
       CreatedAt = r.CreatedAt
       ModifiedAt = r.ModifiedAt }
 
   let toEntity (now: System.DateTimeOffset) (m: FamilyMember) : MemberRecord =
     { Id = m.Id
       Name = m.Name
+      IsAdmin = m.IsAdmin
+      IsActive = m.IsActive
       CreatedAt = now
       ModifiedAt = now }
 
@@ -32,3 +36,22 @@ type EfFamilyMemberRepository(ctx: BpMonitorDbContext, timeProvider: System.Time
       let entry = ctx.Members.Add(entity)
       ctx.SaveChanges() |> ignore
       MemberMapping.toDomain entry.Entity
+
+    member _.Update(m) =
+      let now = timeProvider.GetUtcNow()
+
+      // Detach any tracked entity with the same Id to avoid EF tracking conflicts.
+      ctx.ChangeTracker.Entries<MemberRecord>()
+      |> Seq.tryFind (fun e -> e.Entity.Id = m.Id)
+      |> Option.iter (fun e -> e.State <- Microsoft.EntityFrameworkCore.EntityState.Detached)
+
+      let entity: MemberRecord =
+        { Id = m.Id
+          Name = m.Name
+          IsAdmin = m.IsAdmin
+          IsActive = m.IsActive
+          CreatedAt = m.CreatedAt
+          ModifiedAt = now }
+
+      ctx.Members.Update(entity) |> ignore
+      ctx.SaveChanges() |> ignore

--- a/code/BpMonitor.Data/InMemoryFamilyMemberRepository.fs
+++ b/code/BpMonitor.Data/InMemoryFamilyMemberRepository.fs
@@ -7,6 +7,8 @@ module private MemberDefaults =
   let members =
     [ { Id = 1
         Name = "Me"
+        IsAdmin = true
+        IsActive = true
         CreatedAt = DateTimeOffset.MinValue
         ModifiedAt = DateTimeOffset.MinValue } ]
 
@@ -33,3 +35,10 @@ type InMemoryFamilyMemberRepository(initialMembers: FamilyMember list option) =
       members.Add(created)
       nextId <- nextId + 1
       created
+
+    member _.Update(m) =
+      let idx = members |> Seq.tryFindIndex (fun r -> r.Id = m.Id)
+
+      match idx with
+      | Some i -> members[i] <- m
+      | None -> ()

--- a/code/BpMonitor.Data/MemberRecord.fs
+++ b/code/BpMonitor.Data/MemberRecord.fs
@@ -6,5 +6,7 @@ open System
 type MemberRecord =
   { Id: int
     Name: string
+    IsAdmin: bool
+    IsActive: bool
     CreatedAt: DateTimeOffset
     ModifiedAt: DateTimeOffset }

--- a/code/BpMonitor.Data/SchemaMigrations.fs
+++ b/code/BpMonitor.Data/SchemaMigrations.fs
@@ -49,6 +49,8 @@ module SchemaMigrations =
       """CREATE TABLE IF NOT EXISTS "Members" (
         "Id" INTEGER NOT NULL CONSTRAINT "PK_Members" PRIMARY KEY AUTOINCREMENT,
         "Name" TEXT NOT NULL,
+        "IsAdmin" INTEGER NOT NULL DEFAULT 0,
+        "IsActive" INTEGER NOT NULL DEFAULT 1,
         "CreatedAt" TEXT NOT NULL,
         "ModifiedAt" TEXT NOT NULL
       )"""
@@ -62,8 +64,10 @@ module SchemaMigrations =
       withConn ctx (fun conn -> scalarInt64 conn "SELECT COUNT(*) FROM \"Members\"")
 
     if count = 0L then
+      let now = System.DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm:ss zzz")
+
       ctx.Database.ExecuteSqlRaw(
-        "INSERT INTO \"Members\" (\"Name\", \"CreatedAt\", \"ModifiedAt\") VALUES ('Me', '0001-01-01 00:00:00 +00:00', '0001-01-01 00:00:00 +00:00')"
+        $"INSERT INTO \"Members\" (\"Name\", \"IsAdmin\", \"IsActive\", \"CreatedAt\", \"ModifiedAt\") VALUES ('Me', 1, 1, '{now}', '{now}')"
       )
       |> ignore
 
@@ -71,6 +75,21 @@ module SchemaMigrations =
     else
       withConn ctx (fun conn -> scalarInt64 conn "SELECT \"Id\" FROM \"Members\" ORDER BY \"Id\" LIMIT 1")
       |> int
+
+  /// Promotes the lowest-Id member to admin+active when no active admin exists.
+  /// Protects databases seeded before IsAdmin/IsActive columns were added — those
+  /// members received IsAdmin=0 (the column default) and would otherwise violate the
+  /// invariant.
+  let private ensureActiveAdmin (ctx: BpMonitorDbContext) =
+    let count =
+      withConn ctx (fun conn ->
+        scalarInt64 conn "SELECT COUNT(*) FROM \"Members\" WHERE \"IsAdmin\" = 1 AND \"IsActive\" = 1")
+
+    if count = 0L then
+      ctx.Database.ExecuteSqlRaw(
+        "UPDATE \"Members\" SET \"IsAdmin\" = 1, \"IsActive\" = 1 WHERE \"Id\" = (SELECT MIN(\"Id\") FROM \"Members\")"
+      )
+      |> ignore
 
   let apply (ctx: BpMonitorDbContext) =
     ctx.Database.EnsureCreated() |> ignore
@@ -85,8 +104,15 @@ module SchemaMigrations =
     // Create the Members table (no-op on fresh DBs where EnsureCreated already created it).
     createMembersTableIfMissing ctx
 
+    // Add IsAdmin/IsActive to existing Members tables that predate these columns.
+    addColumnIfMissing ctx "Members" "IsAdmin" "INTEGER" "0"
+    addColumnIfMissing ctx "Members" "IsActive" "INTEGER" "1"
+
     // Ensure at least one default member exists and get its Id.
     let defaultMemberId = ensureDefaultMember ctx
 
     // Back-fill existing readings with the default member Id.
     addColumnIfMissing ctx "Readings" "MemberId" "INTEGER" (string defaultMemberId)
+
+    // Promote the lowest-Id member to admin+active when no active admin exists yet.
+    ensureActiveAdmin ctx

--- a/code/BpMonitor.Web.Tests/HandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerTests.fs
@@ -3,6 +3,7 @@ module HandlerTests
 open System
 open Xunit
 open Swensen.Unquote
+open Microsoft.Extensions.DependencyInjection
 open BpMonitor.Core
 open BpMonitor.Data
 open BpMonitor.Web
@@ -156,3 +157,113 @@ let ``updateReading saves changes and redirects`` () =
   test <@ ctx.Response.Headers.Location.ToString() = "/history" @>
   let updated = repo.GetAll(defaultMemberId) |> List.exactlyOne
   test <@ updated.Systolic = 111 && updated.Comments = Some "updated" @>
+
+// ─── Member handler tests ─────────────────────────────────────────────────────
+
+let private adminMember (id: int) (name: string) : BpMonitor.Core.FamilyMember =
+  { Id = id
+    Name = name
+    IsAdmin = true
+    IsActive = true
+    CreatedAt = DateTimeOffset.MinValue
+    ModifiedAt = DateTimeOffset.MinValue }
+
+[<Fact>]
+let ``createMember with IsAdmin checkbox persists an admin member`` () =
+  let repo = repoWith []
+  let ctx = TestHost.context repo
+
+  TestHost.setForm ctx [ "Name", "Alice"; "IsAdmin", "on" ]
+  TestHost.run Handlers.createMember ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+  // The newly added member should be accessible via the member repo; verify via editMember prefill.
+  let memberRepo = ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
+
+  let added = memberRepo.GetAll() |> List.find (fun m -> m.Name = "Alice")
+  test <@ added.IsAdmin = true @>
+  test <@ added.IsActive = true @>
+
+[<Fact>]
+let ``createMember without IsAdmin checkbox persists a non-admin member`` () =
+  let repo = repoWith []
+  let ctx = TestHost.context repo
+
+  TestHost.setForm ctx [ "Name", "Bob" ]
+  TestHost.run Handlers.createMember ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+
+  let memberRepo = ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
+
+  let added = memberRepo.GetAll() |> List.find (fun m -> m.Name = "Bob")
+  test <@ added.IsAdmin = false @>
+
+[<Fact>]
+let ``editMember prefills the form for an existing member`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ adminMember 1 "Me" ]
+  TestHost.setRouteId ctx 1
+  TestHost.run Handlers.editMember ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  test <@ (TestHost.readBody ctx).Contains "value=\"Me\"" @>
+
+[<Fact>]
+let ``editMember returns 404 for an unknown id`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ adminMember 1 "Me" ]
+  TestHost.setRouteId ctx 999
+  TestHost.run Handlers.editMember ctx
+
+  test <@ ctx.Response.StatusCode = 404 @>
+
+[<Fact>]
+let ``updateMember saves changes and redirects to /members`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ adminMember 1 "Me" ]
+  TestHost.setRouteId ctx 1
+
+  TestHost.setForm ctx [ "Name", "Myself"; "IsAdmin", "on"; "IsActive", "on" ]
+  TestHost.run Handlers.updateMember ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+  test <@ ctx.Response.Headers.Location.ToString() = "/members" @>
+
+  let memberRepo = ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
+
+  let updated = memberRepo.GetAll() |> List.exactlyOne
+  test <@ updated.Name = "Myself" @>
+
+[<Fact>]
+let ``updateMember rejects demoting the last active admin with 422`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ adminMember 1 "Me" ]
+  TestHost.setRouteId ctx 1
+
+  // Uncheck both IsAdmin and IsActive — would leave no active admin.
+  TestHost.setForm ctx [ "Name", "Me" ]
+  TestHost.run Handlers.updateMember ctx
+
+  test <@ ctx.Response.StatusCode = 422 @>
+  test <@ (TestHost.readBody ctx).Contains "active admin" @>
+
+[<Fact>]
+let ``updateMember allows demoting one admin when another active admin exists`` () =
+  let secondAdmin: FamilyMember =
+    { Id = 2
+      Name = "Alice"
+      IsAdmin = true
+      IsActive = true
+      CreatedAt = DateTimeOffset.MinValue
+      ModifiedAt = DateTimeOffset.MinValue }
+
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ adminMember 1 "Me"; secondAdmin ]
+  TestHost.setRouteId ctx 1
+
+  // Demote member 1 to non-admin; member 2 remains active admin → invariant holds.
+  TestHost.setForm ctx [ "Name", "Me"; "IsActive", "on" ]
+  TestHost.run Handlers.updateMember ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>

--- a/code/BpMonitor.Web.Tests/TestHost.fs
+++ b/code/BpMonitor.Web.Tests/TestHost.fs
@@ -29,6 +29,23 @@ let context (repo: IReadingRepository) : HttpContext =
   // No cookie set: activeMember falls back to the first member (Id=1) from InMemoryFamilyMemberRepository.
   ctx
 
+/// Variant of `context` that uses a custom list of family members. Useful for
+/// multi-member scenarios (e.g. testing edit/update invariant enforcement).
+let contextWithMembers (repo: IReadingRepository) (members: FamilyMember list) : HttpContext =
+  let memberRepo =
+    InMemoryFamilyMemberRepository(Some members) :> IFamilyMemberRepository
+
+  let services = ServiceCollection()
+  services.AddLogging() |> ignore
+  services.AddSingleton<IReadingRepository>(repo) |> ignore
+  services.AddSingleton<IFamilyMemberRepository>(memberRepo) |> ignore
+  services.AddSingleton<IConfiguration>(ConfigurationBuilder().Build()) |> ignore
+
+  let ctx = DefaultHttpContext()
+  ctx.RequestServices <- services.BuildServiceProvider()
+  ctx.Response.Body <- new MemoryStream()
+  ctx
+
 /// Reads back whatever a handler wrote to the response body.
 let readBody (ctx: HttpContext) : string =
   ctx.Response.Body.Position <- 0L

--- a/code/BpMonitor.Web.Tests/ViewTests.fs
+++ b/code/BpMonitor.Web.Tests/ViewTests.fs
@@ -10,6 +10,8 @@ open BpMonitor.Web
 let private defaultMember: FamilyMember =
   { Id = 1
     Name = "Me"
+    IsAdmin = true
+    IsActive = true
     CreatedAt = DateTimeOffset.MinValue
     ModifiedAt = DateTimeOffset.MinValue }
 
@@ -85,3 +87,51 @@ let ``view encodes user-supplied content`` () =
 
   test <@ not (html.Contains "<script>x</script>") @>
   test <@ html.Contains "&lt;script&gt;" @>
+
+[<Fact>]
+let ``members page renders Admin and Active columns and Edit link`` () =
+  let otherMember =
+    { Id = 2
+      Name = "Alice"
+      IsAdmin = false
+      IsActive = true
+      CreatedAt = DateTimeOffset.MinValue
+      ModifiedAt = DateTimeOffset.MinValue }
+
+  let html = renderHtml (Views.members [ defaultMember; otherMember ] defaultMember)
+
+  test <@ html.Contains "Admin" @>
+  test <@ html.Contains "Active" @>
+  test <@ html.Contains "href=\"/members/1/edit\"" @>
+  test <@ html.Contains "href=\"/members/2/edit\"" @>
+
+[<Fact>]
+let ``memberForm prefills name and reflects IsAdmin and IsActive`` () =
+  let m =
+    { Id = 3
+      Name = "Bob"
+      IsAdmin = true
+      IsActive = false
+      CreatedAt = DateTimeOffset.MinValue
+      ModifiedAt = DateTimeOffset.MinValue }
+
+  let html = renderHtml (Views.memberForm "/members" "Edit member" "/members/3" [] m)
+
+  test <@ html.Contains "value=\"Bob\"" @>
+  test <@ html.Contains "action=\"/members/3\"" @>
+  // IsAdmin checked → checked attribute present
+  test <@ html.Contains "checked" @>
+
+[<Fact>]
+let ``memberForm renders errors`` () =
+  let html =
+    renderHtml (
+      Views.memberForm
+        "/members"
+        "Edit member"
+        "/members/3"
+        [ "At least one member must be an active admin" ]
+        defaultMember
+    )
+
+  test <@ html.Contains "active admin" @>

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -181,8 +181,9 @@ module Handlers =
       task {
         let! form = ctx.Request.ReadFormAsync()
         let name = form["Name"].ToString()
+        let isAdmin = form.ContainsKey("IsAdmin")
 
-        match FamilyMember.create name with
+        match FamilyMember.create name isAdmin with
         | Error NameIsEmpty ->
           let allMembers = (memberRepo ctx).GetAll()
           let active = activeMember ctx
@@ -198,6 +199,89 @@ module Handlers =
           )
 
           ctx.Response.Redirect "/members"
+      }
+      :> Task
+
+  let editMember: HttpContext -> Task =
+    fun ctx ->
+      let log = logger ctx
+
+      match routeInt ctx "id" with
+      | None ->
+        log.LogWarning("editMember: bad route value for {{id}}")
+        ctx.Response.StatusCode <- 400
+        ctx.Response.WriteAsync("Bad request")
+      | Some id ->
+        match (memberRepo ctx).GetById(id) with
+        | Some m -> htmlResponse (Views.memberForm "/members" "Edit member" $"/members/{id}" [] m) ctx
+        | None ->
+          log.LogWarning("editMember: member {Id} not found", id)
+          ctx.Response.StatusCode <- 404
+          ctx.Response.WriteAsync("Not found")
+
+  let updateMember: HttpContext -> Task =
+    fun ctx ->
+      task {
+        let log = logger ctx
+
+        match routeInt ctx "id" with
+        | None ->
+          log.LogWarning("updateMember: bad route value for {{id}}")
+          ctx.Response.StatusCode <- 400
+          do! ctx.Response.WriteAsync("Bad request")
+        | Some id ->
+          match (memberRepo ctx).GetById(id) with
+          | None ->
+            log.LogWarning("updateMember: member {Id} not found", id)
+            ctx.Response.StatusCode <- 404
+            do! ctx.Response.WriteAsync("Not found")
+          | Some existing ->
+            let! form = ctx.Request.ReadFormAsync()
+            let name = form["Name"].ToString()
+            let isAdmin = form.ContainsKey("IsAdmin")
+            let isActive = form.ContainsKey("IsActive")
+
+            match FamilyMember.create name isAdmin with
+            | Error NameIsEmpty ->
+              let updated =
+                { existing with
+                    Name = ""
+                    IsAdmin = isAdmin
+                    IsActive = isActive }
+
+              ctx.Response.StatusCode <- 422
+
+              do!
+                htmlResponse
+                  (Views.memberForm "/members" "Edit member" $"/members/{id}" [ "Name cannot be empty" ] updated)
+                  ctx
+            | Ok _ ->
+              let updated =
+                { existing with
+                    Name = name.Trim()
+                    IsAdmin = isAdmin
+                    IsActive = isActive }
+              // Compute what the member list would look like after the edit.
+              let allMembers = (memberRepo ctx).GetAll()
+
+              let postEditList =
+                allMembers |> List.map (fun m -> if m.Id = id then updated else m)
+
+              if not (FamilyMember.hasActiveAdmin postEditList) then
+                ctx.Response.StatusCode <- 422
+
+                do!
+                  htmlResponse
+                    (Views.memberForm
+                      "/members"
+                      "Edit member"
+                      $"/members/{id}"
+                      [ "At least one member must be an active admin" ]
+                      updated)
+                    ctx
+              else
+                (memberRepo ctx).Update(updated)
+                ctx.Response.Redirect "/members"
       }
       :> Task
 

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -22,6 +22,8 @@ let private endpoints =
     post "/readings/{id:int}" Handlers.updateReading
     get "/members" Handlers.members
     post "/members" Handlers.createMember
+    get "/members/{id:int}/edit" Handlers.editMember
+    post "/members/{id:int}" Handlers.updateMember
     post "/members/switch" Handlers.switchMember ]
 
 [<EntryPoint>]

--- a/code/BpMonitor.Web/Views.fs
+++ b/code/BpMonitor.Web/Views.fs
@@ -172,22 +172,28 @@ module Views =
     (active: FamilyMember)
     (errorMsg: string option)
     : XmlNode list =
+    let badge (text: string) =
+      Elem.span [ Attr.class' "badge" ] [ Text.raw text ]
+
     let memberRow (m: FamilyMember) =
       let isCurrent = m.Id = active.Id
 
       Elem.tr
         []
         [ Elem.td [] [ Text.enc m.Name ]
+          Elem.td [] [ if m.IsAdmin then badge "Admin" else Text.raw "—" ]
+          Elem.td [] [ if m.IsActive then badge "Active" else Text.raw "—" ]
           Elem.td
-            []
+            [ Attr.style "display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap" ]
             [ if isCurrent then
-                Elem.span [ Attr.class' "current-member" ] [ Text.raw "Active" ]
+                Elem.span [ Attr.class' "current-member" ] [ Text.raw "Current" ]
               else
                 Elem.form
                   [ Attr.method "post"; Attr.action "/members/switch" ]
                   [ Elem.input [ Attr.type' "hidden"; Attr.name "MemberId"; Attr.value (string m.Id) ]
                     Elem.input [ Attr.type' "hidden"; Attr.name "ReturnUrl"; Attr.value "/members" ]
-                    Elem.button [ Attr.type' "submit"; Attr.class' "outline" ] [ Text.raw "Switch" ] ] ] ]
+                    Elem.button [ Attr.type' "submit"; Attr.class' "outline" ] [ Text.raw "Switch" ] ]
+              Elem.a [ Attr.href $"/members/{m.Id}/edit"; Attr.class' "outline" ] [ Text.raw "Edit" ] ] ]
 
     [ match errorMsg with
       | Some msg -> yield errorBox [ msg ]
@@ -195,19 +201,67 @@ module Views =
       yield
         Elem.table
           []
-          [ Elem.thead [] [ Elem.tr [] [ Elem.th [] [ Text.raw "Name" ]; Elem.th [] [ Text.raw "" ] ] ]
+          [ Elem.thead
+              []
+              [ Elem.tr
+                  []
+                  [ Elem.th [] [ Text.raw "Name" ]
+                    Elem.th [] [ Text.raw "Admin" ]
+                    Elem.th [] [ Text.raw "Active" ]
+                    Elem.th [] [ Text.raw "" ] ] ]
             Elem.tbody [] (allMembers |> List.map memberRow) ]
       yield Elem.h2 [] [ Text.raw "Add family member" ]
       yield
         Elem.form
-          [ Attr.method "post"; Attr.action "/members" ]
+          [ Attr.method "post"; Attr.action "/members"; Attr.class' "stacked" ]
           [ Elem.div
               [ Attr.class' "field" ]
               [ Elem.label [ Attr.for' "Name" ] [ Text.raw "Name" ]
                 Elem.input [ Attr.type' "text"; Attr.id "Name"; Attr.name "Name" ] ]
+            Elem.label
+              [ Attr.for' "IsAdmin" ]
+              [ Elem.input [ Attr.type' "checkbox"; Attr.id "IsAdmin"; Attr.name "IsAdmin" ]
+                Text.raw " Admin" ]
             Elem.button [ Attr.type' "submit" ] [ Text.raw "Add member" ] ] ]
 
-  /// Members page: list of family members with Switch buttons and an add form.
+  /// Shared add/edit form for family members. `action` is the POST target; `errors`
+  /// are rendered above the fields when re-displaying after a failed submit.
+  let memberForm (active: string) (title: string) (action: string) (errors: string list) (m: FamilyMember) : XmlNode =
+    let checkedAttr isChecked =
+      if isChecked then
+        [ Attr.type' "checkbox"; Attr.create "checked" "checked" ]
+      else
+        [ Attr.type' "checkbox" ]
+
+    layout
+      active
+      title
+      [ Elem.h1 [] [ Text.raw title ]
+        errorBox errors
+        Elem.form
+          [ Attr.method "post"; Attr.action action ]
+          [ Elem.div
+              [ Attr.class' "field" ]
+              [ Elem.label [ Attr.for' "Name" ] [ Text.raw "Name" ]
+                Elem.input [ Attr.type' "text"; Attr.id "Name"; Attr.name "Name"; Attr.value m.Name ] ]
+            Elem.div
+              [ Attr.class' "field" ]
+              [ Elem.label
+                  [ Attr.for' "IsAdmin" ]
+                  [ Elem.input (checkedAttr m.IsAdmin @ [ Attr.id "IsAdmin"; Attr.name "IsAdmin" ])
+                    Text.raw " Admin" ] ]
+            Elem.div
+              [ Attr.class' "field" ]
+              [ Elem.label
+                  [ Attr.for' "IsActive" ]
+                  [ Elem.input (checkedAttr m.IsActive @ [ Attr.id "IsActive"; Attr.name "IsActive" ])
+                    Text.raw " Active" ] ]
+            Elem.div
+              [ Attr.class' "actions" ]
+              [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Save" ]
+                Elem.a [ Attr.href "/members"; Attr.role "button"; Attr.class' "secondary" ] [ Text.raw "Cancel" ] ] ] ]
+
+  /// Members page: list of family members with Switch/Edit buttons and an add form.
   let members (allMembers: FamilyMember list) (active: FamilyMember) : XmlNode =
     layout "/members" "Family Members" (Elem.h1 [] [ Text.raw "Family Members" ] :: membersList allMembers active None)
 

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -68,6 +68,14 @@ form input {
   font-size: inherit;
 }
 
+label input[type="checkbox"] {
+  vertical-align: middle;
+}
+
+form.stacked {
+  display: block;
+}
+
 input#Timestamp {
   width: 10.5rem;
   margin-inline: auto;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,8 @@ code/
 type FamilyMember = {
     Id:         int
     Name:       string
+    IsAdmin:    bool
+    IsActive:   bool
     CreatedAt:  DateTimeOffset
     ModifiedAt: DateTimeOffset
 }
@@ -99,6 +101,8 @@ graph TD
 - Domain models (`BloodPressureReading`, `BloodPressureReadingUnvalidated`, `FamilyMember`)
 - Repository interfaces (`IReadingRepository`, `IFamilyMemberRepository`)
 - `IReadingRepository` is member-scoped: `GetAll memberId`, `Add memberId`, `AddMany memberId`, `Update` (uses `reading.MemberId` as the guard)
+- `IFamilyMemberRepository`: `GetAll`, `GetById`, `Add`, `Update`
+- `FamilyMember.hasActiveAdmin` enforces the invariant: at least one member must have `IsAdmin = true` and `IsActive = true`; checked before every `Update`
 - Business logic: applicative validation via `FsToolkit.ErrorHandling`
 - No dependencies on other projects
 
@@ -108,7 +112,7 @@ graph TD
 - SQLite with WAL mode + 5 s busy timeout (applied at startup)
 - `IReadingRepository` implementations: `EfReadingRepository` (filters by `MemberId`), `InMemoryReadingRepository`
 - `IFamilyMemberRepository` implementations: `EfFamilyMemberRepository`, `InMemoryFamilyMemberRepository`
-- Manual schema migrations via `SchemaMigrations.apply` (EF Core migrations do not support F#); handles `Members` table creation, default-member seeding, and `MemberId` backfill for existing rows
+- Manual schema migrations via `SchemaMigrations.apply` (EF Core migrations do not support F#); handles `Members` table creation, default-member seeding, `MemberId` backfill for existing rows, and `IsAdmin`/`IsActive` column additions; `ensureActiveAdmin` promotes the lowest-Id member when no active admin exists (upgrade path for pre-PR#157 DBs)
 - `ReadingRepositoryFactory` / `FamilyMemberRepository` factory wiring
 
 ### BpMonitor.Import
@@ -132,9 +136,10 @@ graph TD
 ### BpMonitor.Web
 
 - Falco web application serving on `0.0.0.0:5000`
-- Pages: `/` landing hub, `/add` entry form, `/history` table + chart iframe, `/members` family-member management
+- Pages: `/` landing hub, `/add` entry form, `/history` table + chart iframe, `/members` family-member management (list + add), `/members/{id}/edit` member edit form
 - Active family member tracked via `bp_member` cookie (HttpOnly, SameSite=Strict); falls back to the first member when no cookie is set. Login is deferred — this cookie is the stepping stone for real auth later
-- `POST /members/switch` sets the cookie and redirects; `POST /members` creates a new family member
+- `POST /members/switch` sets the cookie and redirects; `POST /members` creates a new family member; `GET/POST /members/{id}/edit` edits an existing member
+- `IsAdmin` and `IsActive` are stored on each member; `IsActive`/`IsAdmin` flags do not yet affect cookie-based member resolution (deferred to login milestone). Invariant: at least one member must be admin + active — enforced on `updateMember` (POST /members/{id})
 - Every reading handler resolves the active member first; `IReadingRepository` calls are all member-scoped
 - Server-rendered HTML via `Falco.Markup`; htmx for partial updates
 - Scoped `DbContext` per request (concurrency-safe)


### PR DESCRIPTION
## Summary

- Add `IsAdmin: bool` and `IsActive: bool` to `FamilyMember`; `create` now takes `isAdmin` (new members always start active)
- Add `FamilyMember.hasActiveAdmin` to enforce the invariant: at least one member must be admin **and** active — checked on every edit
- Add `Update` to `IFamilyMemberRepository` with EF and InMemory implementations
- `SchemaMigrations`: adds `IsAdmin`/`IsActive` columns via `addColumnIfMissing` for existing DBs; seeds default "Me" with current timestamp (replaces `MinValue`); `ensureActiveAdmin` promotes the lowest-Id member when no active admin exists (upgrade path for pre-existing DBs)
- New `GET /members/{id}/edit` + `POST /members/{id}` routes with `editMember`/`updateMember` handlers; `updateMember` returns 422 with error message if the edit would leave no active admin
- Member list gains Admin/Active badge columns and an Edit link per row; add form gains an IsAdmin checkbox; new `memberForm` view (mirrors `readingForm`)
- 17 new tests across Core, Web.Tests (handlers + views); `TestHost.contextWithMembers` added for multi-member scenarios