### PR TITLE
🔧 chore: set TZ=Europe/Berlin in Quadlet unit and docker-compose

### DIFF
--- a/deploy/bpmonitor-web.container
+++ b/deploy/bpmonitor-web.container
@@ -16,6 +16,7 @@ Image=localhost/bpmonitor-web:latest
 PublishPort=5000:5000
 Volume=bpmonitor-data.volume:/data
 Environment=ConnectionStrings__DefaultConnection=Data Source=/data/bpmonitor.db
+Environment=TZ=Europe/Berlin
 
 [Service]
 Restart=always

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -13,4 +13,6 @@ services:
       - "5000:5000"
     volumes:
       - ./data:/data
+    environment:
+      - TZ=Europe/Berlin
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Adds `TZ=Europe/Berlin` env var to the Podman Quadlet unit and docker-compose so the container uses local time instead of UTC
- Fixes timestamp pre-fill on the Add reading form, which uses `DateTimeOffset.Now` and would otherwise show UTC time in the container