### PR TITLE
✅ test: inject TimeProvider into newReading handler and test local time prefill

### DIFF
--- a/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
+++ b/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
@@ -21,6 +21,7 @@
     <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Unquote" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FsCheck.Xunit.v3" />

--- a/code/BpMonitor.Web.Tests/HandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerTests.fs
@@ -4,6 +4,7 @@ open System
 open Xunit
 open Swensen.Unquote
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Time.Testing
 open BpMonitor.Core
 open BpMonitor.Data
 open BpMonitor.Web
@@ -43,6 +44,17 @@ let ``history renders a row per reading`` () =
 
   test <@ ctx.Response.StatusCode = 200 @>
   test <@ (TestHost.readBody ctx).Contains "/readings/1/edit" @>
+
+[<Fact>]
+let ``newReading returns 200 and prefills timestamp with local time`` () =
+  let tp = FakeTimeProvider(Timestamp.utc 2026 6 9 8 0 0)
+  let ctx = TestHost.contextWithProvider (repoWith []) tp
+
+  TestHost.run Handlers.newReading ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  let expected = tp.GetLocalNow().ToString(Formats.timestamp)
+  test <@ (TestHost.readBody ctx).Contains $"value=\"{expected}\"" @>
 
 [<Fact>]
 let ``createReading persists a valid reading and redirects`` () =

--- a/code/BpMonitor.Web.Tests/TestHost.fs
+++ b/code/BpMonitor.Web.Tests/TestHost.fs
@@ -1,5 +1,6 @@
 module TestHost
 
+open System
 open System.Collections.Generic
 open System.IO
 open Microsoft.AspNetCore.Http
@@ -7,8 +8,18 @@ open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Primitives
+open Microsoft.Extensions.Time.Testing
 open BpMonitor.Core
 open BpMonitor.Data
+
+let private buildServices (repo: IReadingRepository) (memberRepo: IFamilyMemberRepository) (tp: TimeProvider) =
+  let services = ServiceCollection()
+  services.AddLogging() |> ignore
+  services.AddSingleton<IReadingRepository>(repo) |> ignore
+  services.AddSingleton<IFamilyMemberRepository>(memberRepo) |> ignore
+  services.AddSingleton<IConfiguration>(ConfigurationBuilder().Build()) |> ignore
+  services.AddSingleton<TimeProvider>(tp) |> ignore
+  services
 
 /// Builds a DefaultHttpContext wired with the given reading repository (and default
 /// ranges + a single in-memory family member) so the real Falco handlers can be
@@ -16,17 +27,19 @@ open BpMonitor.Data
 /// is pre-set so activeMember resolves to it without needing a DB.
 let context (repo: IReadingRepository) : HttpContext =
   let memberRepo = InMemoryFamilyMemberRepository(None) :> IFamilyMemberRepository
-
-  let services = ServiceCollection()
-  services.AddLogging() |> ignore
-  services.AddSingleton<IReadingRepository>(repo) |> ignore
-  services.AddSingleton<IFamilyMemberRepository>(memberRepo) |> ignore
-  services.AddSingleton<IConfiguration>(ConfigurationBuilder().Build()) |> ignore
-
   let ctx = DefaultHttpContext()
-  ctx.RequestServices <- services.BuildServiceProvider()
+  ctx.RequestServices <- (buildServices repo memberRepo TimeProvider.System).BuildServiceProvider()
   ctx.Response.Body <- new MemoryStream()
   // No cookie set: activeMember falls back to the first member (Id=1) from InMemoryFamilyMemberRepository.
+  ctx
+
+/// Variant of `context` that injects a custom TimeProvider — useful for testing
+/// handlers that read the current time (e.g. newReading timestamp prefill).
+let contextWithProvider (repo: IReadingRepository) (tp: TimeProvider) : HttpContext =
+  let memberRepo = InMemoryFamilyMemberRepository(None) :> IFamilyMemberRepository
+  let ctx = DefaultHttpContext()
+  ctx.RequestServices <- (buildServices repo memberRepo tp).BuildServiceProvider()
+  ctx.Response.Body <- new MemoryStream()
   ctx
 
 /// Variant of `context` that uses a custom list of family members. Useful for
@@ -35,14 +48,8 @@ let contextWithMembers (repo: IReadingRepository) (members: FamilyMember list) :
   let memberRepo =
     InMemoryFamilyMemberRepository(Some members) :> IFamilyMemberRepository
 
-  let services = ServiceCollection()
-  services.AddLogging() |> ignore
-  services.AddSingleton<IReadingRepository>(repo) |> ignore
-  services.AddSingleton<IFamilyMemberRepository>(memberRepo) |> ignore
-  services.AddSingleton<IConfiguration>(ConfigurationBuilder().Build()) |> ignore
-
   let ctx = DefaultHttpContext()
-  ctx.RequestServices <- services.BuildServiceProvider()
+  ctx.RequestServices <- (buildServices repo memberRepo TimeProvider.System).BuildServiceProvider()
   ctx.Response.Body <- new MemoryStream()
   ctx
 

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -22,6 +22,9 @@ module Handlers =
   let private ranges (ctx: HttpContext) =
     Config.readRanges (ctx.RequestServices.GetRequiredService<IConfiguration>())
 
+  let private timeProvider (ctx: HttpContext) =
+    ctx.RequestServices.GetRequiredService<TimeProvider>()
+
   let private logger (ctx: HttpContext) =
     ctx.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger("BpMonitor.Web.Handlers")
 
@@ -130,7 +133,7 @@ module Handlers =
     fun ctx ->
       let prefill =
         { Binding.empty with
-            Binding.Timestamp = DateTimeOffset.Now.ToString(Formats.timestamp) }
+            Binding.Timestamp = (timeProvider ctx).GetLocalNow().ToString(Formats.timestamp) }
 
       htmlResponse (Views.readingForm "/add" "Add reading" "/readings" [] prefill) ctx
 

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -45,6 +45,8 @@ let main args =
     builder.Services.AddDbContext<BpMonitorDbContext>(fun opts -> opts.UseSqlite(connectionString) |> ignore)
     |> ignore
 
+    builder.Services.AddSingleton<TimeProvider>(TimeProvider.System) |> ignore
+
     builder.Services.AddScoped<IReadingRepository>(fun sp ->
       EfReadingRepository(sp.GetRequiredService<BpMonitorDbContext>(), TimeProvider.System))
     |> ignore


### PR DESCRIPTION
## Summary
- Registers `TimeProvider.System` in the DI container (`Program.fs`) so handlers can resolve it
- Refactors `Handlers.newReading` to use `timeProvider.GetLocalNow()` instead of `DateTimeOffset.Now`, making the timestamp source injectable and testable
- Adds `contextWithProvider` to `TestHost` for tests that need a controlled clock
- Extracts `buildServices` helper in `TestHost` to avoid duplication across context builders
- Adds test asserting `newReading` pre-fills the timestamp with local time from the injected provider, verifying the `TZ` env var is respected at runtime