### PR TITLE
✨ feat: add per-member login with username/password form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,12 +51,12 @@ The following are available as slash commands (defined in `.claude/skills/`):
 ```text
 code/
 ├── BpMonitor.slnx
-├── BpMonitor.Core        # Domain models (BloodPressureReading + FamilyMember), interfaces, business logic
+├── BpMonitor.Core        # Domain models (BloodPressureReading + FamilyMember), interfaces, PasswordHashing, business logic
 ├── BpMonitor.Data        # EF Core + SQLite, member-scoped repository implementations
 ├── BpMonitor.Import      # Markdown and JSON importers (take memberId param)
 ├── BpMonitor.Export      # JSON serialisation and file write
 ├── BpMonitor.Charts      # Plotly.NET chart generation → HTML output
-├── BpMonitor.Web         # Falco web app (landing, add, history, members pages + member edit); Serilog structured stdout logging
+├── BpMonitor.Web         # Falco web app (login + per-member auth, landing, add, history, members pages); Serilog structured stdout logging
 └── BpMonitor.Arch.Tests  # ArchUnit Clean Architecture rules
 docs/                     # Product vision, architecture, ADRs
 ```

--- a/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
+++ b/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="BloodPressureReadingPropertyTests.fs" />
     <Compile Include="ReadingRepositoryContractTests.fs" />
     <Compile Include="FamilyMemberTests.fs" />
+    <Compile Include="PasswordHashingTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Core.Tests/FamilyMemberTests.fs
+++ b/code/BpMonitor.Core.Tests/FamilyMemberTests.fs
@@ -41,6 +41,7 @@ let ``hasActiveAdmin is false when no member is admin`` () =
         Name = "A"
         IsAdmin = false
         IsActive = true
+        PasswordHash = None
         CreatedAt = System.DateTimeOffset.MinValue
         ModifiedAt = System.DateTimeOffset.MinValue } ]
 
@@ -53,6 +54,7 @@ let ``hasActiveAdmin is false when admin member is inactive`` () =
         Name = "A"
         IsAdmin = true
         IsActive = false
+        PasswordHash = None
         CreatedAt = System.DateTimeOffset.MinValue
         ModifiedAt = System.DateTimeOffset.MinValue } ]
 
@@ -65,12 +67,14 @@ let ``hasActiveAdmin is true when at least one member is admin and active`` () =
         Name = "A"
         IsAdmin = false
         IsActive = true
+        PasswordHash = None
         CreatedAt = System.DateTimeOffset.MinValue
         ModifiedAt = System.DateTimeOffset.MinValue }
       { Id = 2
         Name = "B"
         IsAdmin = true
         IsActive = true
+        PasswordHash = None
         CreatedAt = System.DateTimeOffset.MinValue
         ModifiedAt = System.DateTimeOffset.MinValue } ]
 

--- a/code/BpMonitor.Core.Tests/PasswordHashingTests.fs
+++ b/code/BpMonitor.Core.Tests/PasswordHashingTests.fs
@@ -1,0 +1,81 @@
+module PasswordHashingTests
+
+open Xunit
+open Swensen.Unquote
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+open BpMonitor.Core
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``verify accepts the correct password after hash`` () =
+  let hash = PasswordHashing.hash "hunter2"
+  test <@ PasswordHashing.verify "hunter2" hash @>
+
+[<Fact>]
+let ``verify rejects a wrong password`` () =
+  let hash = PasswordHashing.hash "hunter2"
+  test <@ not (PasswordHashing.verify "wrong" hash) @>
+
+[<Fact>]
+let ``verify rejects empty string against a real hash`` () =
+  let hash = PasswordHashing.hash "hunter2"
+  test <@ not (PasswordHashing.verify "" hash) @>
+
+[<Fact>]
+let ``verify returns false on malformed encoded string`` () =
+  test <@ not (PasswordHashing.verify "any" "notvalid") @>
+  test <@ not (PasswordHashing.verify "any" "") @>
+  test <@ not (PasswordHashing.verify "any" "only.twoparts") @>
+
+[<Fact>]
+let ``verify returns false when hash section is tampered`` () =
+  let encoded = PasswordHashing.hash "secret"
+  let parts = encoded.Split('.')
+  // Flip the first char of the hash segment to a char that is guaranteed different.
+  // Base64 uses A-Z a-z 0-9 + /; rotating the first char by +1 in that alphabet always differs.
+  let hashPart = parts[2]
+  let base64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+  let firstChar = hashPart.[0]
+
+  let nextChar =
+    base64Chars.[(base64Chars.IndexOf(firstChar) + 1) % base64Chars.Length]
+
+  let tampered = $"{parts[0]}.{parts[1]}.{nextChar}{hashPart.[1..]}"
+  test <@ not (PasswordHashing.verify "secret" tampered) @>
+
+[<Fact>]
+let ``hashing the same password twice produces different encodings (distinct salts)`` () =
+  let h1 = PasswordHashing.hash "password"
+  let h2 = PasswordHashing.hash "password"
+  test <@ h1 <> h2 @>
+
+// ---------------------------------------------------------------------------
+// Property-based tests
+// ---------------------------------------------------------------------------
+
+/// Non-empty non-null printable-ASCII strings — covers common password characters.
+let private passwordGen: Gen<string> =
+  gen {
+    let! len = Gen.choose (1, 64)
+
+    let! chars =
+      Gen.elements ([ '!' .. '~' ]) // printable ASCII excluding space
+      |> Gen.listOfLength len
+
+    return System.String(List.toArray chars)
+  }
+
+[<Property>]
+let ``verify accepts the correct password for any non-empty password`` () =
+  Prop.forAll (Arb.fromGen passwordGen) (fun password ->
+    PasswordHashing.verify password (PasswordHashing.hash password))
+
+[<Property>]
+let ``verify rejects a different password for any non-empty password pair`` () =
+  Prop.forAll (Arb.fromGen (Gen.two passwordGen |> Gen.filter (fun (a, b) -> a <> b))) (fun (p1, p2) ->
+    not (PasswordHashing.verify p2 (PasswordHashing.hash p1)))

--- a/code/BpMonitor.Core/BpMonitor.Core.fsproj
+++ b/code/BpMonitor.Core/BpMonitor.Core.fsproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <Compile Include="FamilyMember.fs" />
+    <Compile Include="PasswordHashing.fs" />
     <Compile Include="IFamilyMemberRepository.fs" />
     <Compile Include="BloodPressureReading.fs" />
     <Compile Include="IReadingRepository.fs" />

--- a/code/BpMonitor.Core/FamilyMember.fs
+++ b/code/BpMonitor.Core/FamilyMember.fs
@@ -7,6 +7,7 @@ type FamilyMember =
     Name: string
     IsAdmin: bool
     IsActive: bool
+    PasswordHash: string option
     CreatedAt: DateTimeOffset
     ModifiedAt: DateTimeOffset }
 
@@ -22,6 +23,7 @@ module FamilyMember =
           Name = name.Trim()
           IsAdmin = isAdmin
           IsActive = true
+          PasswordHash = None
           CreatedAt = DateTimeOffset.MinValue
           ModifiedAt = DateTimeOffset.MinValue }
 
@@ -29,3 +31,6 @@ module FamilyMember =
   /// Used to enforce the invariant before saving member changes.
   let hasActiveAdmin (members: FamilyMember list) =
     members |> List.exists (fun m -> m.IsAdmin && m.IsActive)
+
+  /// Returns true when the member has a password set (has claimed their account).
+  let isClaimed (m: FamilyMember) = m.PasswordHash |> Option.isSome

--- a/code/BpMonitor.Core/PasswordHashing.fs
+++ b/code/BpMonitor.Core/PasswordHashing.fs
@@ -1,0 +1,60 @@
+namespace BpMonitor.Core
+
+open System
+open System.Security.Cryptography
+
+/// Pure password hashing using PBKDF2-SHA256 (BCL only, no external packages).
+/// Encoded format: "<iterations>.<base64-salt>.<base64-hash>"
+module PasswordHashing =
+  [<Literal>]
+  let private Iterations = 310_000
+
+  [<Literal>]
+  let private SaltBytes = 32
+
+  [<Literal>]
+  let private HashBytes = 32
+
+  /// Hashes a plaintext password and returns a self-contained encoded string
+  /// that includes the iteration count, salt, and derived key.
+  let hash (password: string) : string =
+    let salt = RandomNumberGenerator.GetBytes(SaltBytes)
+
+    let derived =
+      Rfc2898DeriveBytes.Pbkdf2(
+        System.Text.Encoding.UTF8.GetBytes(password),
+        salt,
+        Iterations,
+        HashAlgorithmName.SHA256,
+        HashBytes
+      )
+
+    $"{Iterations}.{Convert.ToBase64String(salt)}.{Convert.ToBase64String(derived)}"
+
+  /// Verifies a plaintext password against an encoded hash produced by `hash`.
+  /// Returns false (not an exception) on any malformed input.
+  let verify (password: string) (encoded: string) : bool =
+    let parts = encoded.Split('.')
+
+    if parts.Length <> 3 then
+      false
+    else
+      match Int32.TryParse(parts[0]) with
+      | false, _ -> false
+      | true, iterations ->
+        try
+          let salt = Convert.FromBase64String(parts[1])
+          let expected = Convert.FromBase64String(parts[2])
+
+          let actual =
+            Rfc2898DeriveBytes.Pbkdf2(
+              System.Text.Encoding.UTF8.GetBytes(password),
+              salt,
+              iterations,
+              HashAlgorithmName.SHA256,
+              expected.Length
+            )
+
+          CryptographicOperations.FixedTimeEquals(ReadOnlySpan(actual), ReadOnlySpan(expected))
+        with _ ->
+          false

--- a/code/BpMonitor.Data/EfFamilyMemberRepository.fs
+++ b/code/BpMonitor.Data/EfFamilyMemberRepository.fs
@@ -9,6 +9,11 @@ module private MemberMapping =
       Name = r.Name
       IsAdmin = r.IsAdmin
       IsActive = r.IsActive
+      PasswordHash =
+        if System.String.IsNullOrEmpty(r.PasswordHash) then
+          None
+        else
+          Some r.PasswordHash
       CreatedAt = r.CreatedAt
       ModifiedAt = r.ModifiedAt }
 
@@ -17,6 +22,7 @@ module private MemberMapping =
       Name = m.Name
       IsAdmin = m.IsAdmin
       IsActive = m.IsActive
+      PasswordHash = m.PasswordHash |> Option.defaultValue ""
       CreatedAt = now
       ModifiedAt = now }
 
@@ -50,6 +56,7 @@ type EfFamilyMemberRepository(ctx: BpMonitorDbContext, timeProvider: System.Time
           Name = m.Name
           IsAdmin = m.IsAdmin
           IsActive = m.IsActive
+          PasswordHash = m.PasswordHash |> Option.defaultValue ""
           CreatedAt = m.CreatedAt
           ModifiedAt = now }
 

--- a/code/BpMonitor.Data/InMemoryFamilyMemberRepository.fs
+++ b/code/BpMonitor.Data/InMemoryFamilyMemberRepository.fs
@@ -9,6 +9,7 @@ module private MemberDefaults =
         Name = "Me"
         IsAdmin = true
         IsActive = true
+        PasswordHash = None
         CreatedAt = DateTimeOffset.MinValue
         ModifiedAt = DateTimeOffset.MinValue } ]
 

--- a/code/BpMonitor.Data/MemberRecord.fs
+++ b/code/BpMonitor.Data/MemberRecord.fs
@@ -8,5 +8,6 @@ type MemberRecord =
     Name: string
     IsAdmin: bool
     IsActive: bool
+    PasswordHash: string
     CreatedAt: DateTimeOffset
     ModifiedAt: DateTimeOffset }

--- a/code/BpMonitor.Data/SchemaMigrations.fs
+++ b/code/BpMonitor.Data/SchemaMigrations.fs
@@ -51,6 +51,7 @@ module SchemaMigrations =
         "Name" TEXT NOT NULL,
         "IsAdmin" INTEGER NOT NULL DEFAULT 0,
         "IsActive" INTEGER NOT NULL DEFAULT 1,
+        "PasswordHash" TEXT NOT NULL DEFAULT '',
         "CreatedAt" TEXT NOT NULL,
         "ModifiedAt" TEXT NOT NULL
       )"""
@@ -67,7 +68,7 @@ module SchemaMigrations =
       let now = System.DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm:ss zzz")
 
       ctx.Database.ExecuteSqlRaw(
-        $"INSERT INTO \"Members\" (\"Name\", \"IsAdmin\", \"IsActive\", \"CreatedAt\", \"ModifiedAt\") VALUES ('Me', 1, 1, '{now}', '{now}')"
+        $"INSERT INTO \"Members\" (\"Name\", \"IsAdmin\", \"IsActive\", \"PasswordHash\", \"CreatedAt\", \"ModifiedAt\") VALUES ('Me', 1, 1, '', '{now}', '{now}')"
       )
       |> ignore
 
@@ -107,6 +108,8 @@ module SchemaMigrations =
     // Add IsAdmin/IsActive to existing Members tables that predate these columns.
     addColumnIfMissing ctx "Members" "IsAdmin" "INTEGER" "0"
     addColumnIfMissing ctx "Members" "IsActive" "INTEGER" "1"
+    // Add PasswordHash for per-member login (empty string = unclaimed account).
+    addColumnIfMissing ctx "Members" "PasswordHash" "TEXT" ""
 
     // Ensure at least one default member exists and get its Id.
     let defaultMemberId = ensureDefaultMember ctx

--- a/code/BpMonitor.Web.Tests/HandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerTests.fs
@@ -177,6 +177,7 @@ let private adminMember (id: int) (name: string) : BpMonitor.Core.FamilyMember =
     Name = name
     IsAdmin = true
     IsActive = true
+    PasswordHash = None
     CreatedAt = DateTimeOffset.MinValue
     ModifiedAt = DateTimeOffset.MinValue }
 
@@ -267,6 +268,7 @@ let ``updateMember allows demoting one admin when another active admin exists`` 
       Name = "Alice"
       IsAdmin = true
       IsActive = true
+      PasswordHash = None
       CreatedAt = DateTimeOffset.MinValue
       ModifiedAt = DateTimeOffset.MinValue }
 
@@ -279,3 +281,146 @@ let ``updateMember allows demoting one admin when another active admin exists`` 
   TestHost.run Handlers.updateMember ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
+
+// ─── Login handler tests ──────────────────────────────────────────────────────
+
+let private unclaimedMember: FamilyMember =
+  { Id = 1
+    Name = "Me"
+    IsAdmin = true
+    IsActive = true
+    PasswordHash = None
+    CreatedAt = DateTimeOffset.MinValue
+    ModifiedAt = DateTimeOffset.MinValue }
+
+let private claimedMember (hash: string) : FamilyMember =
+  { unclaimedMember with
+      PasswordHash = Some hash }
+
+[<Fact>]
+let ``loginPage returns 200`` () =
+  let repo = repoWith []
+  let ctx = TestHost.context repo
+  TestHost.run Handlers.loginPage ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+
+[<Fact>]
+let ``loginMember returns 200 for an existing active member`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ unclaimedMember ]
+  TestHost.setRouteId ctx 1
+  TestHost.run Handlers.loginMember ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+
+[<Fact>]
+let ``loginMember returns 404 for unknown member`` () =
+  let repo = repoWith []
+  let ctx = TestHost.context repo
+  TestHost.setRouteId ctx 999
+  TestHost.run Handlers.loginMember ctx
+
+  test <@ ctx.Response.StatusCode = 404 @>
+
+[<Fact>]
+let ``loginMember returns 403 for inactive member`` () =
+  let inactive =
+    { unclaimedMember with
+        IsActive = false }
+
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ inactive ]
+  TestHost.setRouteId ctx 1
+  TestHost.run Handlers.loginMember ctx
+
+  test <@ ctx.Response.StatusCode = 403 @>
+
+[<Fact>]
+let ``loginSubmit claims unclaimed member and sets password hash`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ unclaimedMember ]
+  TestHost.setRouteId ctx 1
+  TestHost.setForm ctx [ "Password", "correct-horse"; "PasswordConfirm", "correct-horse" ]
+  TestHost.run Handlers.loginSubmit ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+  // Verify the password hash was persisted
+  let memberRepo = ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
+  let saved = memberRepo.GetById(1) |> Option.get
+  test <@ BpMonitor.Core.FamilyMember.isClaimed saved @>
+  test <@ PasswordHashing.verify "correct-horse" (saved.PasswordHash |> Option.get) @>
+
+[<Fact>]
+let ``loginSubmit rejects empty password for unclaimed member`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ unclaimedMember ]
+  TestHost.setRouteId ctx 1
+  TestHost.setForm ctx [ "Password", ""; "PasswordConfirm", "" ]
+  TestHost.run Handlers.loginSubmit ctx
+
+  test <@ ctx.Response.StatusCode = 422 @>
+  test <@ (TestHost.readBody ctx).Contains "empty" @>
+
+[<Fact>]
+let ``loginSubmit rejects mismatched confirm for unclaimed member`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ unclaimedMember ]
+  TestHost.setRouteId ctx 1
+  TestHost.setForm ctx [ "Password", "abc"; "PasswordConfirm", "xyz" ]
+  TestHost.run Handlers.loginSubmit ctx
+
+  test <@ ctx.Response.StatusCode = 422 @>
+  test <@ (TestHost.readBody ctx).Contains "do not match" @>
+
+[<Fact>]
+let ``loginSubmit accepts correct password for claimed member and redirects`` () =
+  let hash = PasswordHashing.hash "letmein"
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ claimedMember hash ]
+  TestHost.setRouteId ctx 1
+  TestHost.setForm ctx [ "Password", "letmein" ]
+  TestHost.run Handlers.loginSubmit ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+  test <@ ctx.Response.Headers.Location.ToString() = "/" @>
+
+[<Fact>]
+let ``loginSubmit rejects wrong password for claimed member with 401`` () =
+  let hash = PasswordHashing.hash "letmein"
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ claimedMember hash ]
+  TestHost.setRouteId ctx 1
+  TestHost.setForm ctx [ "Password", "wrongpassword" ]
+  TestHost.run Handlers.loginSubmit ctx
+
+  test <@ ctx.Response.StatusCode = 401 @>
+  test <@ (TestHost.readBody ctx).Contains "Incorrect password" @>
+
+[<Fact>]
+let ``loginSubmit returns 403 for inactive member`` () =
+  let hash = PasswordHashing.hash "secret"
+
+  let inactive =
+    { claimedMember hash with
+        IsActive = false }
+
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ inactive ]
+  TestHost.setRouteId ctx 1
+  TestHost.setForm ctx [ "Password", "secret" ]
+  TestHost.run Handlers.loginSubmit ctx
+
+  test <@ ctx.Response.StatusCode = 403 @>
+
+[<Fact>]
+let ``resetPassword sets member to unclaimed`` () =
+  let hash = PasswordHashing.hash "original"
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ claimedMember hash ]
+  TestHost.setRouteId ctx 1
+  TestHost.run Handlers.resetPassword ctx
+
+  let memberRepo = ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
+  let saved = memberRepo.GetById(1) |> Option.get
+  test <@ not (BpMonitor.Core.FamilyMember.isClaimed saved) @>

--- a/code/BpMonitor.Web.Tests/HandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerTests.fs
@@ -298,12 +298,58 @@ let private claimedMember (hash: string) : FamilyMember =
       PasswordHash = Some hash }
 
 [<Fact>]
-let ``loginPage returns 200`` () =
-  let repo = repoWith []
-  let ctx = TestHost.context repo
+let ``loginPage returns 200 with sign-in form`` () =
+  let ctx = TestHost.context (repoWith [])
   TestHost.run Handlers.loginPage ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
+  test <@ (TestHost.readBody ctx).Contains "Sign in" @>
+
+[<Fact>]
+let ``loginWithCredentials redirects to / for correct credentials`` () =
+  let hash = PasswordHashing.hash "correct"
+
+  let claimed = { claimedMember hash with Name = "Me" }
+
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ claimed ]
+  TestHost.setForm ctx [ "Username", "Me"; "Password", "correct" ]
+  TestHost.run Handlers.loginWithCredentials ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+  test <@ ctx.Response.Headers.Location.ToString() = "/" @>
+
+[<Fact>]
+let ``loginWithCredentials returns 401 for wrong password`` () =
+  let hash = PasswordHashing.hash "correct"
+
+  let claimed = { claimedMember hash with Name = "Me" }
+
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ claimed ]
+  TestHost.setForm ctx [ "Username", "Me"; "Password", "wrong" ]
+  TestHost.run Handlers.loginWithCredentials ctx
+
+  test <@ ctx.Response.StatusCode = 401 @>
+
+[<Fact>]
+let ``loginWithCredentials returns 401 for unknown user`` () =
+  let repo = repoWith []
+  let ctx = TestHost.context repo
+  TestHost.setForm ctx [ "Username", "Nobody"; "Password", "anything" ]
+  TestHost.run Handlers.loginWithCredentials ctx
+
+  test <@ ctx.Response.StatusCode = 401 @>
+
+[<Fact>]
+let ``loginWithCredentials redirects to claim page for unclaimed member`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMembers repo [ unclaimedMember ]
+  TestHost.setForm ctx [ "Username", "Me"; "Password", "" ]
+  TestHost.run Handlers.loginWithCredentials ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+  test <@ ctx.Response.Headers.Location.ToString() = "/login/1" @>
 
 [<Fact>]
 let ``loginMember returns 200 for an existing active member`` () =

--- a/code/BpMonitor.Web.Tests/TestHost.fs
+++ b/code/BpMonitor.Web.Tests/TestHost.fs
@@ -3,6 +3,8 @@ module TestHost
 open System
 open System.Collections.Generic
 open System.IO
+open System.Security.Claims
+open Microsoft.AspNetCore.Authentication.Cookies
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
@@ -19,18 +21,44 @@ let private buildServices (repo: IReadingRepository) (memberRepo: IFamilyMemberR
   services.AddSingleton<IFamilyMemberRepository>(memberRepo) |> ignore
   services.AddSingleton<IConfiguration>(ConfigurationBuilder().Build()) |> ignore
   services.AddSingleton<TimeProvider>(tp) |> ignore
+
+  services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie()
+  |> ignore
+
   services
+
+/// Builds a ClaimsPrincipal for the given member, matching the scheme used by the web app.
+let buildPrincipal (m: FamilyMember) : ClaimsPrincipal =
+  let claims =
+    [ yield Claim(ClaimTypes.NameIdentifier, string m.Id)
+      yield Claim(ClaimTypes.Name, m.Name)
+      if m.IsAdmin then
+        yield Claim(ClaimTypes.Role, "Admin") ]
+
+  let identity =
+    ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme)
+
+  ClaimsPrincipal(identity)
+
+let private defaultMember: FamilyMember =
+  { Id = 1
+    Name = "Me"
+    IsAdmin = true
+    IsActive = true
+    PasswordHash = None
+    CreatedAt = DateTimeOffset.MinValue
+    ModifiedAt = DateTimeOffset.MinValue }
 
 /// Builds a DefaultHttpContext wired with the given reading repository (and default
 /// ranges + a single in-memory family member) so the real Falco handlers can be
-/// invoked directly in tests. The default member has Id=1; the bp_member cookie
-/// is pre-set so activeMember resolves to it without needing a DB.
+/// invoked directly in tests. The default member has Id=1; the user principal is
+/// pre-set so authenticatedMember resolves to member 1 without needing a DB.
 let context (repo: IReadingRepository) : HttpContext =
   let memberRepo = InMemoryFamilyMemberRepository(None) :> IFamilyMemberRepository
   let ctx = DefaultHttpContext()
   ctx.RequestServices <- (buildServices repo memberRepo TimeProvider.System).BuildServiceProvider()
   ctx.Response.Body <- new MemoryStream()
-  // No cookie set: activeMember falls back to the first member (Id=1) from InMemoryFamilyMemberRepository.
+  ctx.User <- buildPrincipal defaultMember
   ctx
 
 /// Variant of `context` that injects a custom TimeProvider — useful for testing
@@ -40,10 +68,12 @@ let contextWithProvider (repo: IReadingRepository) (tp: TimeProvider) : HttpCont
   let ctx = DefaultHttpContext()
   ctx.RequestServices <- (buildServices repo memberRepo tp).BuildServiceProvider()
   ctx.Response.Body <- new MemoryStream()
+  ctx.User <- buildPrincipal defaultMember
   ctx
 
-/// Variant of `context` that uses a custom list of family members. Useful for
-/// multi-member scenarios (e.g. testing edit/update invariant enforcement).
+/// Variant of `context` that uses a custom list of family members. The user
+/// principal is set to the first member in the list. Useful for multi-member
+/// scenarios (e.g. testing edit/update invariant enforcement).
 let contextWithMembers (repo: IReadingRepository) (members: FamilyMember list) : HttpContext =
   let memberRepo =
     InMemoryFamilyMemberRepository(Some members) :> IFamilyMemberRepository
@@ -51,6 +81,27 @@ let contextWithMembers (repo: IReadingRepository) (members: FamilyMember list) :
   let ctx = DefaultHttpContext()
   ctx.RequestServices <- (buildServices repo memberRepo TimeProvider.System).BuildServiceProvider()
   ctx.Response.Body <- new MemoryStream()
+
+  match members with
+  | first :: _ -> ctx.User <- buildPrincipal first
+  | [] -> ()
+
+  ctx
+
+/// Variant of `context` that sets a specific authenticated user. Useful for
+/// testing protected handlers with a particular member identity.
+let contextWithUser (repo: IReadingRepository) (members: FamilyMember list) (loggedInMemberId: int) : HttpContext =
+  let memberRepo =
+    InMemoryFamilyMemberRepository(Some members) :> IFamilyMemberRepository
+
+  let ctx = DefaultHttpContext()
+  ctx.RequestServices <- (buildServices repo memberRepo TimeProvider.System).BuildServiceProvider()
+  ctx.Response.Body <- new MemoryStream()
+
+  match members |> List.tryFind (fun m -> m.Id = loggedInMemberId) with
+  | Some m -> ctx.User <- buildPrincipal m
+  | None -> ()
+
   ctx
 
 /// Reads back whatever a handler wrote to the response body.

--- a/code/BpMonitor.Web.Tests/ViewTests.fs
+++ b/code/BpMonitor.Web.Tests/ViewTests.fs
@@ -12,6 +12,7 @@ let private defaultMember: FamilyMember =
     Name = "Me"
     IsAdmin = true
     IsActive = true
+    PasswordHash = None
     CreatedAt = DateTimeOffset.MinValue
     ModifiedAt = DateTimeOffset.MinValue }
 
@@ -28,7 +29,7 @@ let private sample =
 
 [<Fact>]
 let ``landing renders links to add and history`` () =
-  let html = renderHtml Views.landing
+  let html = renderHtml (Views.landing defaultMember)
 
   test <@ html.Contains "href=\"/add\"" @>
   test <@ html.Contains "href=\"/history\"" @>
@@ -36,15 +37,43 @@ let ``landing renders links to add and history`` () =
   test <@ html.Contains "href=\"/\" aria-current=\"page\"" @>
 
 [<Fact>]
+let ``admin sees Members nav link`` () =
+  let admin = { defaultMember with IsAdmin = true }
+  let html = renderHtml (Views.landing admin)
+  test <@ html.Contains "href=\"/members\"" @>
+
+[<Fact>]
+let ``non-admin does not see Members nav link`` () =
+  let nonAdmin = { defaultMember with IsAdmin = false }
+  let html = renderHtml (Views.landing nonAdmin)
+  test <@ not (html.Contains "href=\"/members\"") @>
+
+[<Fact>]
 let ``every page has a BpMonitor footer`` () =
   let pages =
-    [ renderHtml Views.landing
+    [ renderHtml (Views.landing defaultMember)
       renderHtml (Views.history defaultMember [ sample ])
-      renderHtml (Views.readingForm "/add" "Add reading" "/readings" [] Binding.empty) ]
+      renderHtml (Views.readingForm "/add" "Me" true "Add reading" "/readings" [] Binding.empty) ]
 
   for html in pages do
     test <@ html.Contains "<footer" @>
     test <@ html.Contains "BpMonitor" @>
+
+[<Fact>]
+let ``every authenticated page shows the logout button`` () =
+  let pages =
+    [ renderHtml (Views.landing defaultMember)
+      renderHtml (Views.history defaultMember [ sample ])
+      renderHtml (Views.readingForm "/add" "Me" true "Add reading" "/readings" [] Binding.empty) ]
+
+  for html in pages do
+    test <@ html.Contains "action=\"/logout\"" @>
+    test <@ html.Contains "Logout" @>
+
+[<Fact>]
+let ``every authenticated page shows the member name`` () =
+  let html = renderHtml (Views.landing defaultMember)
+  test <@ html.Contains "Me" @>
 
 [<Fact>]
 let ``history renders reading values, chart iframe and nav links`` () =
@@ -61,7 +90,7 @@ let ``history renders reading values, chart iframe and nav links`` () =
 [<Fact>]
 let ``edit form is prefilled from the reading`` () =
   let html =
-    renderHtml (Views.readingForm "" "Edit reading" "/readings/7" [] (Binding.ofReading sample))
+    renderHtml (Views.readingForm "" "Me" true "Edit reading" "/readings/7" [] (Binding.ofReading sample))
 
   test <@ html.Contains "name=\"Systolic\" value=\"123\"" @>
   test <@ html.Contains "action=\"/readings/7\"" @>
@@ -72,7 +101,7 @@ let ``form renders the validation errors it is given`` () =
   let errors = [ "Systolic 999 is out of range (1–300)" ]
 
   let html =
-    renderHtml (Views.readingForm "/add" "Add reading" "/readings" errors Binding.empty)
+    renderHtml (Views.readingForm "/add" "Me" true "Add reading" "/readings" errors Binding.empty)
 
   test <@ html.Contains "errors" @>
   test <@ html.Contains "out of range" @>
@@ -95,6 +124,7 @@ let ``members page renders Admin and Active columns and Edit link`` () =
       Name = "Alice"
       IsAdmin = false
       IsActive = true
+      PasswordHash = None
       CreatedAt = DateTimeOffset.MinValue
       ModifiedAt = DateTimeOffset.MinValue }
 
@@ -106,16 +136,48 @@ let ``members page renders Admin and Active columns and Edit link`` () =
   test <@ html.Contains "href=\"/members/2/edit\"" @>
 
 [<Fact>]
+let ``members page shows claimed/unclaimed badge`` () =
+  let claimed =
+    { defaultMember with
+        PasswordHash = Some "somehash" }
+
+  let unclaimed =
+    { Id = 2
+      Name = "Alice"
+      IsAdmin = false
+      IsActive = true
+      PasswordHash = None
+      CreatedAt = DateTimeOffset.MinValue
+      ModifiedAt = DateTimeOffset.MinValue }
+
+  let html = renderHtml (Views.members [ claimed; unclaimed ] claimed)
+
+  test <@ html.Contains "Claimed" @>
+  test <@ html.Contains "Unclaimed" @>
+
+[<Fact>]
+let ``members page shows reset-password button`` () =
+  let html = renderHtml (Views.members [ defaultMember ] defaultMember)
+  test <@ html.Contains "reset-password" @>
+
+[<Fact>]
+let ``members page does NOT show Switch button`` () =
+  let html = renderHtml (Views.members [ defaultMember ] defaultMember)
+  test <@ not (html.Contains "/members/switch") @>
+
+[<Fact>]
 let ``memberForm prefills name and reflects IsAdmin and IsActive`` () =
   let m =
     { Id = 3
       Name = "Bob"
       IsAdmin = true
       IsActive = false
+      PasswordHash = None
       CreatedAt = DateTimeOffset.MinValue
       ModifiedAt = DateTimeOffset.MinValue }
 
-  let html = renderHtml (Views.memberForm "/members" "Edit member" "/members/3" [] m)
+  let html =
+    renderHtml (Views.memberForm "/members" "Me" true "Edit member" "/members/3" [] m)
 
   test <@ html.Contains "value=\"Bob\"" @>
   test <@ html.Contains "action=\"/members/3\"" @>
@@ -128,6 +190,8 @@ let ``memberForm renders errors`` () =
     renderHtml (
       Views.memberForm
         "/members"
+        "Me"
+        true
         "Edit member"
         "/members/3"
         [ "At least one member must be an active admin" ]
@@ -135,3 +199,48 @@ let ``memberForm renders errors`` () =
     )
 
   test <@ html.Contains "active admin" @>
+
+[<Fact>]
+let ``loginPage lists active members`` () =
+  let members =
+    [ defaultMember
+      { defaultMember with
+          Id = 2
+          Name = "Kid"
+          IsAdmin = false
+          IsActive = true }
+      { defaultMember with
+          Id = 3
+          Name = "Inactive"
+          IsAdmin = false
+          IsActive = false } ]
+
+  let html = renderHtml (Views.loginPage members)
+
+  test <@ html.Contains "Me" @>
+  test <@ html.Contains "Kid" @>
+  // inactive member is not shown
+  test <@ not (html.Contains "Inactive") @>
+
+[<Fact>]
+let ``loginMember shows claim form for unclaimed member`` () =
+  let html = renderHtml (Views.loginMember defaultMember [])
+
+  test <@ html.Contains "PasswordConfirm" @>
+  test <@ html.Contains "Claim account" @>
+
+[<Fact>]
+let ``loginMember shows password form for claimed member`` () =
+  let claimed =
+    { defaultMember with
+        PasswordHash = Some "x" }
+
+  let html = renderHtml (Views.loginMember claimed [])
+
+  test <@ not (html.Contains "PasswordConfirm") @>
+  test <@ html.Contains "Login" @>
+
+[<Fact>]
+let ``loginMember renders errors`` () =
+  let html = renderHtml (Views.loginMember defaultMember [ "Passwords do not match" ])
+  test <@ html.Contains "Passwords do not match" @>

--- a/code/BpMonitor.Web.Tests/ViewTests.fs
+++ b/code/BpMonitor.Web.Tests/ViewTests.fs
@@ -201,26 +201,18 @@ let ``memberForm renders errors`` () =
   test <@ html.Contains "active admin" @>
 
 [<Fact>]
-let ``loginPage lists active members`` () =
-  let members =
-    [ defaultMember
-      { defaultMember with
-          Id = 2
-          Name = "Kid"
-          IsAdmin = false
-          IsActive = true }
-      { defaultMember with
-          Id = 3
-          Name = "Inactive"
-          IsAdmin = false
-          IsActive = false } ]
+let ``loginPage renders sign-in form with username and password fields`` () =
+  let html = renderHtml (Views.loginPage [])
 
-  let html = renderHtml (Views.loginPage members)
+  test <@ html.Contains "Sign in" @>
+  test <@ html.Contains "Username" @>
+  test <@ html.Contains "Password" @>
 
-  test <@ html.Contains "Me" @>
-  test <@ html.Contains "Kid" @>
-  // inactive member is not shown
-  test <@ not (html.Contains "Inactive") @>
+[<Fact>]
+let ``loginPage renders errors when provided`` () =
+  let html = renderHtml (Views.loginPage [ "Invalid name or password" ])
+
+  test <@ html.Contains "Invalid name or password" @>
 
 [<Fact>]
 let ``loginMember shows claim form for unclaimed member`` () =

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -174,9 +174,38 @@ module Handlers =
   // ---------------------------------------------------------------------------
 
   let loginPage: HttpContext -> Task =
+    fun ctx -> htmlResponse (Views.loginPage []) ctx
+
+  let loginWithCredentials: HttpContext -> Task =
     fun ctx ->
-      let allMembers = (memberRepo ctx).GetAll()
-      htmlResponse (Views.loginPage allMembers) ctx
+      task {
+        let log = logger ctx
+        let! form = ctx.Request.ReadFormAsync()
+        let username = form["Username"].ToString().Trim()
+        let password = form["Password"].ToString()
+
+        let found =
+          (memberRepo ctx).GetAll()
+          |> List.tryFind (fun m -> m.IsActive && m.Name.Equals(username, StringComparison.OrdinalIgnoreCase))
+
+        match found with
+        | None ->
+          ctx.Response.StatusCode <- 401
+          do! htmlResponse (Views.loginPage [ "Invalid name or password" ]) ctx
+        | Some m ->
+          if FamilyMember.isClaimed m then
+            if PasswordHashing.verify password (m.PasswordHash |> Option.get) then
+              log.LogInformation("Member {Name} (Id={Id}) logged in", m.Name, m.Id)
+              do! ctx.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, claimsPrincipal m)
+              ctx.Response.Redirect "/"
+            else
+              log.LogWarning("Failed login attempt for member {Name} (Id={Id})", m.Name, m.Id)
+              ctx.Response.StatusCode <- 401
+              do! htmlResponse (Views.loginPage [ "Invalid name or password" ]) ctx
+          else
+            ctx.Response.Redirect $"/login/{m.Id}"
+      }
+      :> Task
 
   let loginMember: HttpContext -> Task =
     fun ctx ->

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -1,7 +1,10 @@
 namespace BpMonitor.Web
 
 open System
+open System.Security.Claims
 open System.Threading.Tasks
+open Microsoft.AspNetCore.Authentication
+open Microsoft.AspNetCore.Authentication.Cookies
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
@@ -57,35 +60,85 @@ module Handlers =
           Binding.Comments = get "Comments" }
     }
 
-  /// Resolves the active family member from the bp_member cookie, falling back to
-  /// the first member when no cookie is set or the cookie Id is invalid.
-  let private activeMember (ctx: HttpContext) : FamilyMember =
-    let allMembers = (memberRepo ctx).GetAll()
+  // ---------------------------------------------------------------------------
+  // Auth: resolve identity from the authenticated principal
+  // ---------------------------------------------------------------------------
 
-    let cookieMemberId =
-      match ctx.Request.Cookies.TryGetValue("bp_member") with
-      | true, v ->
-        match Int32.TryParse(v) with
-        | true, id -> Some id
-        | _ -> None
+  /// Resolves the authenticated member from the principal's NameIdentifier claim.
+  /// Only valid inside a `protect`ed route — the principal is guaranteed to be present.
+  let private authenticatedMember (ctx: HttpContext) : FamilyMember option =
+    let claim = ctx.User.FindFirst(ClaimTypes.NameIdentifier)
+
+    if claim = null then
+      None
+    else
+      match Int32.TryParse(claim.Value) with
+      | true, id -> (memberRepo ctx).GetById(id)
       | _ -> None
 
-    cookieMemberId
-    |> Option.bind (fun id -> allMembers |> List.tryFind (fun m -> m.Id = id))
-    |> Option.orElse (allMembers |> List.tryHead)
-    |> Option.defaultWith (fun () -> failwith "No family members configured. Visit /members to create one.")
+  /// Builds the auth claims principal for a member.
+  let private claimsPrincipal (m: FamilyMember) : ClaimsPrincipal =
+    let claims =
+      [ yield Claim(ClaimTypes.NameIdentifier, string m.Id)
+        yield Claim(ClaimTypes.Name, m.Name)
+        if m.IsAdmin then
+          yield Claim(ClaimTypes.Role, "Admin") ]
+
+    let identity =
+      ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme)
+
+    ClaimsPrincipal(identity)
+
+  // ---------------------------------------------------------------------------
+  // Auth combinators
+  // ---------------------------------------------------------------------------
+
+  /// Wraps a handler so it requires an authenticated user. Unauthenticated
+  /// requests are redirected to /login.
+  let protect (handler: HttpContext -> Task) : HttpContext -> Task =
+    fun ctx ->
+      if ctx.User.Identity <> null && ctx.User.Identity.IsAuthenticated then
+        handler ctx
+      else
+        ctx.Response.Redirect("/login")
+        Task.CompletedTask
+
+  /// Like `protect` but additionally requires the Admin role. Non-admin
+  /// authenticated requests get a 403.
+  let protectAdmin (handler: HttpContext -> Task) : HttpContext -> Task =
+    fun ctx ->
+      if ctx.User.Identity = null || not ctx.User.Identity.IsAuthenticated then
+        ctx.Response.Redirect("/login")
+        Task.CompletedTask
+      elif not (ctx.User.IsInRole("Admin")) then
+        ctx.Response.StatusCode <- 403
+        ctx.Response.WriteAsync("Forbidden")
+      else
+        handler ctx
+
+  // ---------------------------------------------------------------------------
+  // Reading helpers
+  // ---------------------------------------------------------------------------
 
   let private sortedReadings (memberId: int) (ctx: HttpContext) =
     (repo ctx).GetAll(memberId) |> List.sortByDescending _.Timestamp
 
   /// Renders the add/edit form after a failed submit (status 422).
-  let private renderFormErrors (ctx: HttpContext) active title action errors model : Task =
+  let private renderFormErrors (ctx: HttpContext) active memberName isAdmin title action errors model : Task =
     ctx.Response.StatusCode <- 422
-    htmlResponse (Views.readingForm active title action errors model) ctx
+    htmlResponse (Views.readingForm active memberName isAdmin title action errors model) ctx
 
   /// Validates a submitted form and persists via `save`; on any error re-renders
   /// the form with messages. Shared by create and update.
-  let private submit (ctx: HttpContext) active title action (save: BloodPressureReading -> unit) : Task =
+  let private submit
+    (ctx: HttpContext)
+    active
+    memberName
+    isAdmin
+    title
+    action
+    (save: BloodPressureReading -> unit)
+    : Task =
     task {
       let log = logger ctx
       let! model = formModel ctx
@@ -94,7 +147,7 @@ module Handlers =
       match Binding.toUnvalidated model with
       | Error errorMessages ->
         log.LogWarning("Reading form validation failed (binding): {Errors}", errorMessages)
-        do! renderFormErrors ctx active title action errorMessages model
+        do! renderFormErrors ctx active memberName isAdmin title action errorMessages model
       | Ok unvalidated ->
         match BloodPressureReading.parse rg unvalidated with
         | Ok reading ->
@@ -112,71 +165,210 @@ module Handlers =
         | Error errors ->
           let messages = Config.formatValidationErrors rg errors
           log.LogWarning("Reading form validation failed (domain): {Errors}", messages)
-          do! renderFormErrors ctx active title action messages model
+          do! renderFormErrors ctx active memberName isAdmin title action messages model
     }
     :> Task
 
-  let landing: HttpContext -> Task = fun ctx -> htmlResponse Views.landing ctx
+  // ---------------------------------------------------------------------------
+  // Login / logout
+  // ---------------------------------------------------------------------------
+
+  let loginPage: HttpContext -> Task =
+    fun ctx ->
+      let allMembers = (memberRepo ctx).GetAll()
+      htmlResponse (Views.loginPage allMembers) ctx
+
+  let loginMember: HttpContext -> Task =
+    fun ctx ->
+      match routeInt ctx "id" with
+      | None ->
+        ctx.Response.StatusCode <- 400
+        ctx.Response.WriteAsync("Bad request")
+      | Some id ->
+        match (memberRepo ctx).GetById(id) with
+        | None ->
+          ctx.Response.StatusCode <- 404
+          ctx.Response.WriteAsync("Not found")
+        | Some m ->
+          if not m.IsActive then
+            ctx.Response.StatusCode <- 403
+            ctx.Response.WriteAsync("This account is inactive")
+          else
+            htmlResponse (Views.loginMember m []) ctx
+
+  let loginSubmit: HttpContext -> Task =
+    fun ctx ->
+      task {
+        let log = logger ctx
+
+        match routeInt ctx "id" with
+        | None ->
+          ctx.Response.StatusCode <- 400
+          do! ctx.Response.WriteAsync("Bad request")
+        | Some id ->
+          match (memberRepo ctx).GetById(id) with
+          | None ->
+            ctx.Response.StatusCode <- 404
+            do! ctx.Response.WriteAsync("Not found")
+          | Some m when not m.IsActive ->
+            ctx.Response.StatusCode <- 403
+            do! ctx.Response.WriteAsync("This account is inactive")
+          | Some m ->
+            let! form = ctx.Request.ReadFormAsync()
+            let password = form["Password"].ToString()
+
+            if FamilyMember.isClaimed m then
+              // Claimed: verify the password
+              if PasswordHashing.verify password (m.PasswordHash |> Option.get) then
+                log.LogInformation("Member {Name} (Id={Id}) logged in", m.Name, m.Id)
+                do! ctx.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, claimsPrincipal m)
+                ctx.Response.Redirect "/"
+              else
+                log.LogWarning("Failed login attempt for member {Name} (Id={Id})", m.Name, m.Id)
+                ctx.Response.StatusCode <- 401
+                do! htmlResponse (Views.loginMember m [ "Incorrect password" ]) ctx
+            else
+              // Unclaimed: set the password (claim the account)
+              let confirm = form["PasswordConfirm"].ToString()
+
+              if String.IsNullOrWhiteSpace(password) then
+                ctx.Response.StatusCode <- 422
+                do! htmlResponse (Views.loginMember m [ "Password cannot be empty" ]) ctx
+              elif password <> confirm then
+                ctx.Response.StatusCode <- 422
+                do! htmlResponse (Views.loginMember m [ "Passwords do not match" ]) ctx
+              else
+                let hashed = PasswordHashing.hash password
+                let claimed = { m with PasswordHash = Some hashed }
+                (memberRepo ctx).Update(claimed)
+                log.LogInformation("Member {Name} (Id={Id}) claimed their account", m.Name, m.Id)
+                do! ctx.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, claimsPrincipal claimed)
+                ctx.Response.Redirect "/"
+      }
+      :> Task
+
+  let logout: HttpContext -> Task =
+    fun ctx ->
+      task {
+        do! ctx.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme)
+        ctx.Response.Redirect "/login"
+      }
+      :> Task
+
+  // ---------------------------------------------------------------------------
+  // App pages (all protected — authenticated member resolved from principal)
+  // ---------------------------------------------------------------------------
+
+  let landing: HttpContext -> Task =
+    fun ctx ->
+      match authenticatedMember ctx with
+      | None ->
+        ctx.Response.Redirect "/login"
+        Task.CompletedTask
+      | Some m -> htmlResponse (Views.landing m) ctx
 
   let history: HttpContext -> Task =
     fun ctx ->
-      let m = activeMember ctx
-      htmlResponse (Views.history m (sortedReadings m.Id ctx)) ctx
+      match authenticatedMember ctx with
+      | None ->
+        ctx.Response.Redirect "/login"
+        Task.CompletedTask
+      | Some m -> htmlResponse (Views.history m (sortedReadings m.Id ctx)) ctx
 
   let chart: HttpContext -> Task =
     fun ctx ->
-      let m = activeMember ctx
-      ctx.Response.ContentType <- "text/html; charset=utf-8"
-      ctx.Response.WriteAsync(BpChart.toHtml ((repo ctx).GetAll(m.Id)))
+      match authenticatedMember ctx with
+      | None ->
+        ctx.Response.Redirect "/login"
+        Task.CompletedTask
+      | Some m ->
+        ctx.Response.ContentType <- "text/html; charset=utf-8"
+        ctx.Response.WriteAsync(BpChart.toHtml ((repo ctx).GetAll(m.Id)))
 
   let newReading: HttpContext -> Task =
     fun ctx ->
+      let memberName =
+        match authenticatedMember ctx with
+        | Some m -> m.Name
+        | None -> ""
+
       let prefill =
         { Binding.empty with
             Binding.Timestamp = (timeProvider ctx).GetLocalNow().ToString(Formats.timestamp) }
 
-      htmlResponse (Views.readingForm "/add" "Add reading" "/readings" [] prefill) ctx
+      htmlResponse
+        (Views.readingForm
+          "/add"
+          memberName
+          (authenticatedMember ctx |> Option.exists _.IsAdmin)
+          "Add reading"
+          "/readings"
+          []
+          prefill)
+        ctx
 
   let createReading: HttpContext -> Task =
     fun ctx ->
-      let m = activeMember ctx
-      submit ctx "/add" "Add reading" "/readings" ((repo ctx).Add m.Id)
+      match authenticatedMember ctx with
+      | None ->
+        ctx.Response.Redirect "/login"
+        Task.CompletedTask
+      | Some m -> submit ctx "/add" m.Name m.IsAdmin "Add reading" "/readings" ((repo ctx).Add m.Id)
 
   let editReading: HttpContext -> Task =
     fun ctx ->
       let log = logger ctx
-      let m = activeMember ctx
 
-      match routeInt ctx "id" with
+      match authenticatedMember ctx with
       | None ->
-        log.LogWarning("editReading: bad route value for {{id}}")
-        ctx.Response.StatusCode <- 400
-        ctx.Response.WriteAsync("Bad request")
-      | Some id ->
-        match (repo ctx).GetAll(m.Id) |> List.tryFind (fun r -> r.Id = id) with
-        | Some r -> htmlResponse (Views.readingForm "" "Edit reading" $"/readings/{id}" [] (Binding.ofReading r)) ctx
+        ctx.Response.Redirect "/login"
+        Task.CompletedTask
+      | Some m ->
+        match routeInt ctx "id" with
         | None ->
-          log.LogWarning("editReading: reading {Id} not found for member {MemberId}", id, m.Id)
-          ctx.Response.StatusCode <- 404
-          ctx.Response.WriteAsync("Not found")
+          log.LogWarning("editReading: bad route value for {{id}}")
+          ctx.Response.StatusCode <- 400
+          ctx.Response.WriteAsync("Bad request")
+        | Some id ->
+          match (repo ctx).GetAll(m.Id) |> List.tryFind (fun r -> r.Id = id) with
+          | Some r ->
+            htmlResponse
+              (Views.readingForm "" m.Name m.IsAdmin "Edit reading" $"/readings/{id}" [] (Binding.ofReading r))
+              ctx
+          | None ->
+            log.LogWarning("editReading: reading {Id} not found for member {MemberId}", id, m.Id)
+            ctx.Response.StatusCode <- 404
+            ctx.Response.WriteAsync("Not found")
 
   let updateReading: HttpContext -> Task =
     fun ctx ->
       let log = logger ctx
-      let m = activeMember ctx
 
-      match routeInt ctx "id" with
+      match authenticatedMember ctx with
       | None ->
-        log.LogWarning("updateReading: bad route value for {{id}}")
-        ctx.Response.StatusCode <- 400
-        ctx.Response.WriteAsync("Bad request")
-      | Some id ->
-        submit ctx "" "Edit reading" $"/readings/{id}" (fun r -> (repo ctx).Update { r with Id = id; MemberId = m.Id })
+        ctx.Response.Redirect "/login"
+        Task.CompletedTask
+      | Some m ->
+        match routeInt ctx "id" with
+        | None ->
+          log.LogWarning("updateReading: bad route value for {{id}}")
+          ctx.Response.StatusCode <- 400
+          ctx.Response.WriteAsync("Bad request")
+        | Some id ->
+          submit ctx "" m.Name m.IsAdmin "Edit reading" $"/readings/{id}" (fun r ->
+            (repo ctx).Update { r with Id = id; MemberId = m.Id })
+
+  // ---------------------------------------------------------------------------
+  // Member management (all protectAdmin — must be admin)
+  // ---------------------------------------------------------------------------
 
   let members: HttpContext -> Task =
     fun ctx ->
       let allMembers = (memberRepo ctx).GetAll()
-      let active = activeMember ctx
+
+      let active =
+        authenticatedMember ctx |> Option.defaultWith (fun () -> failwith "No member")
+
       htmlResponse (Views.members allMembers active) ctx
 
   let createMember: HttpContext -> Task =
@@ -189,18 +381,14 @@ module Handlers =
         match FamilyMember.create name isAdmin with
         | Error NameIsEmpty ->
           let allMembers = (memberRepo ctx).GetAll()
-          let active = activeMember ctx
+
+          let active =
+            authenticatedMember ctx |> Option.defaultWith (fun () -> failwith "No member")
+
           ctx.Response.StatusCode <- 422
           do! htmlResponse (Views.membersWithError allMembers active "Name cannot be empty") ctx
         | Ok m ->
-          let created = (memberRepo ctx).Add(m)
-
-          ctx.Response.Cookies.Append(
-            "bp_member",
-            string created.Id,
-            CookieOptions(HttpOnly = true, SameSite = SameSiteMode.Strict)
-          )
-
+          (memberRepo ctx).Add(m) |> ignore
           ctx.Response.Redirect "/members"
       }
       :> Task
@@ -209,6 +397,9 @@ module Handlers =
     fun ctx ->
       let log = logger ctx
 
+      let adminName =
+        authenticatedMember ctx |> Option.map _.Name |> Option.defaultValue ""
+
       match routeInt ctx "id" with
       | None ->
         log.LogWarning("editMember: bad route value for {{id}}")
@@ -216,7 +407,7 @@ module Handlers =
         ctx.Response.WriteAsync("Bad request")
       | Some id ->
         match (memberRepo ctx).GetById(id) with
-        | Some m -> htmlResponse (Views.memberForm "/members" "Edit member" $"/members/{id}" [] m) ctx
+        | Some m -> htmlResponse (Views.memberForm "/members" adminName true "Edit member" $"/members/{id}" [] m) ctx
         | None ->
           log.LogWarning("editMember: member {Id} not found", id)
           ctx.Response.StatusCode <- 404
@@ -226,6 +417,9 @@ module Handlers =
     fun ctx ->
       task {
         let log = logger ctx
+
+        let adminName =
+          authenticatedMember ctx |> Option.map _.Name |> Option.defaultValue ""
 
         match routeInt ctx "id" with
         | None ->
@@ -256,7 +450,14 @@ module Handlers =
 
               do!
                 htmlResponse
-                  (Views.memberForm "/members" "Edit member" $"/members/{id}" [ "Name cannot be empty" ] updated)
+                  (Views.memberForm
+                    "/members"
+                    adminName
+                    true
+                    "Edit member"
+                    $"/members/{id}"
+                    [ "Name cannot be empty" ]
+                    updated)
                   ctx
             | Ok _ ->
               let updated =
@@ -277,6 +478,8 @@ module Handlers =
                   htmlResponse
                     (Views.memberForm
                       "/members"
+                      adminName
+                      true
                       "Edit member"
                       $"/members/{id}"
                       [ "At least one member must be an active admin" ]
@@ -288,23 +491,26 @@ module Handlers =
       }
       :> Task
 
-  let switchMember: HttpContext -> Task =
+  /// Resets a member's password to unclaimed (admin-only).
+  let resetPassword: HttpContext -> Task =
     fun ctx ->
       task {
-        let! form = ctx.Request.ReadFormAsync()
-        let memberId = form["MemberId"].ToString()
+        let log = logger ctx
 
-        ctx.Response.Cookies.Append(
-          "bp_member",
-          memberId,
-          CookieOptions(HttpOnly = true, SameSite = SameSiteMode.Strict)
-        )
-
-        let returnUrl =
-          match form.TryGetValue("ReturnUrl") with
-          | true, v when v.ToString() <> "" -> v.ToString()
-          | _ -> "/"
-
-        ctx.Response.Redirect(returnUrl)
+        match routeInt ctx "id" with
+        | None ->
+          log.LogWarning("resetPassword: bad route value for {{id}}")
+          ctx.Response.StatusCode <- 400
+          do! ctx.Response.WriteAsync("Bad request")
+        | Some id ->
+          match (memberRepo ctx).GetById(id) with
+          | None ->
+            log.LogWarning("resetPassword: member {Id} not found", id)
+            ctx.Response.StatusCode <- 404
+            do! ctx.Response.WriteAsync("Not found")
+          | Some m ->
+            (memberRepo ctx).Update({ m with PasswordHash = None })
+            log.LogInformation("Admin reset password for member {Name} (Id={Id})", m.Name, m.Id)
+            ctx.Response.Redirect "/members"
       }
       :> Task

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -17,6 +17,7 @@ open BpMonitor.Web
 let private endpoints =
   [ // Anonymous: login/logout
     get "/login" Handlers.loginPage
+    post "/login" Handlers.loginWithCredentials
     get "/login/{id:int}" Handlers.loginMember
     post "/login/{id:int}" Handlers.loginSubmit
     post "/logout" Handlers.logout

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -3,7 +3,9 @@ module Program
 open System
 open Falco
 open Falco.Routing
+open Microsoft.AspNetCore.Authentication.Cookies
 open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.EntityFrameworkCore
@@ -13,18 +15,25 @@ open BpMonitor.Data
 open BpMonitor.Web
 
 let private endpoints =
-  [ get "/" Handlers.landing
-    get "/add" Handlers.newReading
-    get "/history" Handlers.history
-    get "/chart" Handlers.chart
-    post "/readings" Handlers.createReading
-    get "/readings/{id:int}/edit" Handlers.editReading
-    post "/readings/{id:int}" Handlers.updateReading
-    get "/members" Handlers.members
-    post "/members" Handlers.createMember
-    get "/members/{id:int}/edit" Handlers.editMember
-    post "/members/{id:int}" Handlers.updateMember
-    post "/members/switch" Handlers.switchMember ]
+  [ // Anonymous: login/logout
+    get "/login" Handlers.loginPage
+    get "/login/{id:int}" Handlers.loginMember
+    post "/login/{id:int}" Handlers.loginSubmit
+    post "/logout" Handlers.logout
+    // Authenticated: reading CRUD + app pages
+    get "/" (Handlers.protect Handlers.landing)
+    get "/add" (Handlers.protect Handlers.newReading)
+    get "/history" (Handlers.protect Handlers.history)
+    get "/chart" (Handlers.protect Handlers.chart)
+    post "/readings" (Handlers.protect Handlers.createReading)
+    get "/readings/{id:int}/edit" (Handlers.protect Handlers.editReading)
+    post "/readings/{id:int}" (Handlers.protect Handlers.updateReading)
+    // Admin-only: member management
+    get "/members" (Handlers.protectAdmin Handlers.members)
+    post "/members" (Handlers.protectAdmin Handlers.createMember)
+    get "/members/{id:int}/edit" (Handlers.protectAdmin Handlers.editMember)
+    post "/members/{id:int}" (Handlers.protectAdmin Handlers.updateMember)
+    post "/members/{id:int}/reset-password" (Handlers.protectAdmin Handlers.resetPassword) ]
 
 [<EntryPoint>]
 let main args =
@@ -55,6 +64,18 @@ let main args =
       EfFamilyMemberRepository(sp.GetRequiredService<BpMonitorDbContext>(), TimeProvider.System))
     |> ignore
 
+    builder.Services
+      .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+      .AddCookie(fun o ->
+        o.LoginPath <- PathString("/login")
+        o.Cookie.HttpOnly <- true
+        o.Cookie.SameSite <- SameSiteMode.Strict
+        o.Cookie.SecurePolicy <- CookieSecurePolicy.SameAsRequest
+        o.SlidingExpiration <- true)
+    |> ignore
+
+    builder.Services.AddAuthorization() |> ignore
+
     let app = builder.Build()
 
     // Apply schema migrations once at startup against a transient scope.
@@ -64,7 +85,9 @@ let main args =
 
     // One structured log line per request (method, path, status, elapsed ms).
     app.UseSerilogRequestLogging() |> ignore
-    app.UseStaticFiles().UseRouting().UseFalco(endpoints) |> ignore
+
+    app.UseStaticFiles().UseRouting().UseAuthentication().UseAuthorization().UseFalco(endpoints)
+    |> ignore
 
     Log.Information("BpMonitor.Web {Version} starting on {Urls}", Version.current, app.Urls)
     app.Run()

--- a/code/BpMonitor.Web/Views.fs
+++ b/code/BpMonitor.Web/Views.fs
@@ -17,9 +17,15 @@ module Views =
 
     Elem.li [] [ Elem.a attrs [ Text.raw label ] ]
 
-  /// Page shell: shared <head>, vendored htmx, stylesheet and hx-boosted body.
-  /// `active` is the route of the current page so the nav can highlight it.
-  let private layout (active: string) (title: string) (content: XmlNode list) : XmlNode =
+  /// Page shell for authenticated pages: shared <head>, nav bar with logged-in member
+  /// name + logout, and hx-boosted body.
+  let private layout
+    (active: string)
+    (memberName: string)
+    (isAdmin: bool)
+    (title: string)
+    (content: XmlNode list)
+    : XmlNode =
     Elem.html
       [ Attr.lang "en" ]
       [ Elem.head
@@ -46,10 +52,17 @@ module Views =
                     navLink active "/" "Home"
                     navLink active "/add" "Add"
                     navLink active "/history" "History"
-                    navLink active "/members" "Members" ]
+                    if isAdmin then
+                      navLink active "/members" "Members" ]
                 Elem.ul
                   []
-                  [ Elem.li
+                  [ Elem.li [] [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ] ]
+                    Elem.li
+                      []
+                      [ Elem.form
+                          [ Attr.method "post"; Attr.action "/logout"; Attr.class' "inline" ]
+                          [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Logout" ] ] ]
+                    Elem.li
                       []
                       [ Elem.button
                           [ Attr.id "theme-toggle"
@@ -69,6 +82,41 @@ module Views =
             // Re-runs on every body render (initial + hx-boost swaps) to sync the button label.
             Elem.script [ Attr.src "/theme-label.js" ] [] ] ]
 
+  /// Minimal page shell for unauthenticated pages (login). No nav, no logout.
+  let private loginLayout (title: string) (content: XmlNode list) : XmlNode =
+    Elem.html
+      [ Attr.lang "en" ]
+      [ Elem.head
+          []
+          [ Elem.meta [ Attr.charset "utf-8" ]
+            Elem.meta [ Attr.name "viewport"; Attr.content "width=device-width, initial-scale=1" ]
+            Elem.title [] [ Text.raw title ]
+            Elem.link [ Attr.rel "icon"; Attr.href "/favicon.svg"; Attr.type' "image/svg+xml" ]
+            Elem.script [ Attr.src "/theme.js" ] []
+            Elem.link
+              [ Attr.rel "stylesheet"
+                Attr.href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" ]
+            Elem.link [ Attr.rel "stylesheet"; Attr.href "/app.css" ] ]
+        Elem.body
+          []
+          [ Elem.main
+              [ Attr.class' "container login-container" ]
+              ([ Elem.header
+                   []
+                   [ Elem.h1 [] [ Text.raw "BpMonitor" ]
+                     Elem.p [] [ Text.raw "Blood pressure tracker" ] ] ]
+               @ content)
+            Elem.footer
+              [ Attr.class' "container" ]
+              [ Elem.small
+                  []
+                  (let v = Version.current
+
+                   match Version.releaseUrl v with
+                   | Some url -> [ Text.raw "BpMonitor "; Elem.a [ Attr.href url ] [ Text.raw $"v{v}" ] ]
+                   | None -> [ Text.raw $"BpMonitor {v}" ]) ]
+            Elem.script [ Attr.src "/theme-label.js" ] [] ] ]
+
   let private errorBox (errors: string list) : XmlNode =
     match errors with
     | [] -> Text.raw ""
@@ -76,6 +124,82 @@ module Views =
       Elem.div
         [ Attr.class' "errors"; Attr.role "alert" ]
         [ Elem.ul [] (errors |> List.map (fun e -> Elem.li [] [ Text.enc e ])) ]
+
+  // ---------------------------------------------------------------------------
+  // Login views
+  // ---------------------------------------------------------------------------
+
+  /// Login page: list active members so the user can pick their account.
+  let loginPage (allMembers: FamilyMember list) : XmlNode =
+    let activeMembers = allMembers |> List.filter _.IsActive
+
+    let memberCard (m: FamilyMember) =
+      Elem.li
+        []
+        [ Elem.a [ Attr.href $"/login/{m.Id}"; Attr.role "button"; Attr.class' "outline" ] [ Text.enc m.Name ] ]
+
+    loginLayout
+      "Login — BpMonitor"
+      [ Elem.h2 [] [ Text.raw "Who are you?" ]
+        Elem.ul [ Attr.class' "member-list" ] (activeMembers |> List.map memberCard) ]
+
+  /// Login form for a specific member. Shows a claim form (password + confirm) for
+  /// unclaimed accounts, or a simple password form for claimed ones.
+  let loginMember (m: FamilyMember) (errors: string list) : XmlNode =
+    let isClaimed = FamilyMember.isClaimed m
+
+    let passwordFields =
+      if isClaimed then
+        // Claimed: single password field
+        [ Elem.div
+            [ Attr.class' "field" ]
+            [ Elem.label [ Attr.for' "Password" ] [ Text.raw "Password" ]
+              Elem.input
+                [ Attr.type' "password"
+                  Attr.id "Password"
+                  Attr.name "Password"
+                  Attr.create "autofocus" "autofocus"
+                  Attr.create "autocomplete" "current-password" ] ] ]
+      else
+        // Unclaimed: set password + confirm
+        [ Elem.p
+            [ Attr.class' "claim-hint" ]
+            [ Text.raw "This account hasn't been claimed yet. Choose a password to activate it." ]
+          Elem.div
+            [ Attr.class' "field" ]
+            [ Elem.label [ Attr.for' "Password" ] [ Text.raw "New password" ]
+              Elem.input
+                [ Attr.type' "password"
+                  Attr.id "Password"
+                  Attr.name "Password"
+                  Attr.create "autofocus" "autofocus"
+                  Attr.create "autocomplete" "new-password" ] ]
+          Elem.div
+            [ Attr.class' "field" ]
+            [ Elem.label [ Attr.for' "PasswordConfirm" ] [ Text.raw "Confirm password" ]
+              Elem.input
+                [ Attr.type' "password"
+                  Attr.id "PasswordConfirm"
+                  Attr.name "PasswordConfirm"
+                  Attr.create "autocomplete" "new-password" ] ] ]
+
+    loginLayout
+      $"Login as {m.Name} — BpMonitor"
+      [ Elem.h2 [] [ Text.enc $"Login as {m.Name}" ]
+        errorBox errors
+        Elem.form
+          [ Attr.method "post"; Attr.action $"/login/{m.Id}" ]
+          (passwordFields
+           @ [ Elem.div
+                 [ Attr.class' "actions" ]
+                 [ Elem.button [ Attr.type' "submit" ] [ Text.raw (if isClaimed then "Login" else "Claim account") ]
+                   Elem.a
+                     [ Attr.href "/login"; Attr.role "button"; Attr.class' "secondary outline" ]
+                     [ Text.raw "Back" ] ] ]) ]
+
+  // ---------------------------------------------------------------------------
+  // App views (all need the logged-in member for the nav)
+  // ---------------------------------------------------------------------------
 
   /// The readings table; wrapped in an id'd container so it can be targeted for
   /// partial swaps later.
@@ -105,9 +229,11 @@ module Views =
     Elem.div [ Attr.id "readings" ] [ Elem.table [] [ header; Elem.tbody [] (readings |> List.map row) ] ]
 
   /// Landing page: a simple hub linking to the app's main destinations.
-  let landing: XmlNode =
+  let landing (m: FamilyMember) : XmlNode =
     layout
       "/"
+      m.Name
+      m.IsAdmin
       "BpMonitor"
       [ Elem.h1 [] [ Text.raw "BpMonitor" ]
         Elem.p [] [ Text.raw "Track and review your blood pressure readings." ]
@@ -120,6 +246,8 @@ module Views =
   let history (activeMember: FamilyMember) (readings: BloodPressureReading list) : XmlNode =
     layout
       "/history"
+      activeMember.Name
+      activeMember.IsAdmin
       "History"
       [ Elem.h1 [] [ Text.raw $"History — {activeMember.Name}" ]
         Elem.details
@@ -132,6 +260,8 @@ module Views =
   /// above the fields when re-displaying after a failed submit.
   let readingForm
     (active: string)
+    (memberName: string)
+    (isAdmin: bool)
     (title: string)
     (action: string)
     (errors: string list)
@@ -152,6 +282,8 @@ module Views =
 
     layout
       active
+      memberName
+      isAdmin
       title
       [ Elem.h1 [] [ Text.raw title ]
         errorBox errors
@@ -172,8 +304,8 @@ module Views =
     (active: FamilyMember)
     (errorMsg: string option)
     : XmlNode list =
-    let badge (text: string) =
-      Elem.span [ Attr.class' "badge" ] [ Text.raw text ]
+    let badge (text: string) (cls: string) =
+      Elem.span [ Attr.class' cls ] [ Text.raw text ]
 
     let memberRow (m: FamilyMember) =
       let isCurrent = m.Id = active.Id
@@ -181,19 +313,22 @@ module Views =
       Elem.tr
         []
         [ Elem.td [] [ Text.enc m.Name ]
-          Elem.td [] [ if m.IsAdmin then badge "Admin" else Text.raw "—" ]
-          Elem.td [] [ if m.IsActive then badge "Active" else Text.raw "—" ]
+          Elem.td [] [ if m.IsAdmin then badge "Admin" "badge" else Text.raw "—" ]
+          Elem.td [] [ if m.IsActive then badge "Active" "badge" else Text.raw "—" ]
+          Elem.td
+            []
+            [ if FamilyMember.isClaimed m then
+                badge "Claimed" "badge badge-claimed"
+              else
+                badge "Unclaimed" "badge badge-unclaimed" ]
           Elem.td
             [ Attr.style "display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap" ]
             [ if isCurrent then
-                Elem.span [ Attr.class' "current-member" ] [ Text.raw "Current" ]
-              else
-                Elem.form
-                  [ Attr.method "post"; Attr.action "/members/switch" ]
-                  [ Elem.input [ Attr.type' "hidden"; Attr.name "MemberId"; Attr.value (string m.Id) ]
-                    Elem.input [ Attr.type' "hidden"; Attr.name "ReturnUrl"; Attr.value "/members" ]
-                    Elem.button [ Attr.type' "submit"; Attr.class' "outline" ] [ Text.raw "Switch" ] ]
-              Elem.a [ Attr.href $"/members/{m.Id}/edit"; Attr.class' "outline" ] [ Text.raw "Edit" ] ] ]
+                Elem.span [ Attr.class' "current-member" ] [ Text.raw "You" ]
+              Elem.a [ Attr.href $"/members/{m.Id}/edit"; Attr.class' "outline" ] [ Text.raw "Edit" ]
+              Elem.form
+                [ Attr.method "post"; Attr.action $"/members/{m.Id}/reset-password" ]
+                [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Reset password" ] ] ] ]
 
     [ match errorMsg with
       | Some msg -> yield errorBox [ msg ]
@@ -208,6 +343,7 @@ module Views =
                   [ Elem.th [] [ Text.raw "Name" ]
                     Elem.th [] [ Text.raw "Admin" ]
                     Elem.th [] [ Text.raw "Active" ]
+                    Elem.th [] [ Text.raw "Password" ]
                     Elem.th [] [ Text.raw "" ] ] ]
             Elem.tbody [] (allMembers |> List.map memberRow) ]
       yield Elem.h2 [] [ Text.raw "Add family member" ]
@@ -226,7 +362,15 @@ module Views =
 
   /// Shared add/edit form for family members. `action` is the POST target; `errors`
   /// are rendered above the fields when re-displaying after a failed submit.
-  let memberForm (active: string) (title: string) (action: string) (errors: string list) (m: FamilyMember) : XmlNode =
+  let memberForm
+    (active: string)
+    (memberName: string)
+    (isAdmin: bool)
+    (title: string)
+    (action: string)
+    (errors: string list)
+    (m: FamilyMember)
+    : XmlNode =
     let checkedAttr isChecked =
       if isChecked then
         [ Attr.type' "checkbox"; Attr.create "checked" "checked" ]
@@ -235,6 +379,8 @@ module Views =
 
     layout
       active
+      memberName
+      isAdmin
       title
       [ Elem.h1 [] [ Text.raw title ]
         errorBox errors
@@ -261,14 +407,21 @@ module Views =
               [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Save" ]
                 Elem.a [ Attr.href "/members"; Attr.role "button"; Attr.class' "secondary" ] [ Text.raw "Cancel" ] ] ] ]
 
-  /// Members page: list of family members with Switch/Edit buttons and an add form.
+  /// Members page: list of family members with Edit/Reset-password buttons and an add form.
   let members (allMembers: FamilyMember list) (active: FamilyMember) : XmlNode =
-    layout "/members" "Family Members" (Elem.h1 [] [ Text.raw "Family Members" ] :: membersList allMembers active None)
+    layout
+      "/members"
+      active.Name
+      active.IsAdmin
+      "Family Members"
+      (Elem.h1 [] [ Text.raw "Family Members" ] :: membersList allMembers active None)
 
   /// Members page rendered with a validation error message.
   let membersWithError (allMembers: FamilyMember list) (active: FamilyMember) (error: string) : XmlNode =
     layout
       "/members"
+      active.Name
+      active.IsAdmin
       "Family Members"
       (Elem.h1 [] [ Text.raw "Family Members" ]
        :: membersList allMembers active (Some error))

--- a/code/BpMonitor.Web/Views.fs
+++ b/code/BpMonitor.Web/Views.fs
@@ -98,8 +98,20 @@ module Views =
                 Attr.href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" ]
             Elem.link [ Attr.rel "stylesheet"; Attr.href "/app.css" ] ]
         Elem.body
-          []
-          [ Elem.main
+          [ Attr.create "hx-boost" "false" ]
+          [ Elem.nav
+              [ Attr.class' "container" ]
+              [ Elem.ul [] []
+                Elem.ul
+                  []
+                  [ Elem.li
+                      []
+                      [ Elem.button
+                          [ Attr.id "theme-toggle"
+                            Attr.class' "outline secondary"
+                            Attr.create "onclick" "toggleTheme()" ]
+                          [] ] ] ]
+            Elem.main
               [ Attr.class' "container login-container" ]
               ([ Elem.header
                    []
@@ -129,19 +141,32 @@ module Views =
   // Login views
   // ---------------------------------------------------------------------------
 
-  /// Login page: list active members so the user can pick their account.
-  let loginPage (allMembers: FamilyMember list) : XmlNode =
-    let activeMembers = allMembers |> List.filter _.IsActive
-
-    let memberCard (m: FamilyMember) =
-      Elem.li
-        []
-        [ Elem.a [ Attr.href $"/login/{m.Id}"; Attr.role "button"; Attr.class' "outline" ] [ Text.enc m.Name ] ]
-
+  /// Login page: username + password form.
+  let loginPage (errors: string list) : XmlNode =
     loginLayout
       "Login — BpMonitor"
-      [ Elem.h2 [] [ Text.raw "Who are you?" ]
-        Elem.ul [ Attr.class' "member-list" ] (activeMembers |> List.map memberCard) ]
+      [ Elem.h2 [] [ Text.raw "Sign in" ]
+        errorBox errors
+        Elem.form
+          [ Attr.method "post"; Attr.action "/login"; Attr.class' "stacked" ]
+          [ Elem.div
+              [ Attr.class' "field" ]
+              [ Elem.label [ Attr.for' "Username" ] [ Text.raw "Name" ]
+                Elem.input
+                  [ Attr.type' "text"
+                    Attr.id "Username"
+                    Attr.name "Username"
+                    Attr.create "autofocus" "autofocus"
+                    Attr.create "autocomplete" "username" ] ]
+            Elem.div
+              [ Attr.class' "field" ]
+              [ Elem.label [ Attr.for' "Password" ] [ Text.raw "Password" ]
+                Elem.input
+                  [ Attr.type' "password"
+                    Attr.id "Password"
+                    Attr.name "Password"
+                    Attr.create "autocomplete" "current-password" ] ]
+            Elem.div [ Attr.class' "actions" ] [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Sign in" ] ] ] ]
 
   /// Login form for a specific member. Shows a claim form (password + confirm) for
   /// unclaimed accounts, or a simple password form for claimed ones.

--- a/code/BpMonitor.Web/Views.fs
+++ b/code/BpMonitor.Web/Views.fs
@@ -327,7 +327,9 @@ module Views =
                 Elem.span [ Attr.class' "current-member" ] [ Text.raw "You" ]
               Elem.a [ Attr.href $"/members/{m.Id}/edit"; Attr.class' "outline" ] [ Text.raw "Edit" ]
               Elem.form
-                [ Attr.method "post"; Attr.action $"/members/{m.Id}/reset-password" ]
+                [ Attr.method "post"
+                  Attr.action $"/members/{m.Id}/reset-password"
+                  Attr.class' "inline" ]
                 [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Reset password" ] ] ] ]
 
     [ match errorMsg with

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -140,3 +140,59 @@ footer.container {
   text-align: center;
   color: var(--pico-muted-color);
 }
+
+/* Login page */
+.login-container {
+  max-width: 420px;
+  margin-top: 4rem;
+}
+
+.member-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.member-list li a[role="button"] {
+  display: block;
+  text-align: center;
+}
+
+.claim-hint {
+  color: var(--pico-muted-color);
+  font-size: 0.9em;
+}
+
+/* Nav member name */
+.nav-member-name {
+  color: var(--pico-muted-color);
+  font-size: 0.875rem;
+}
+
+/* Inline logout form — removes default form block display */
+form.inline {
+  display: inline;
+}
+
+/* Member status badges */
+.badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--pico-border-radius);
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--pico-primary);
+  color: var(--pico-primary-inverse);
+}
+
+.badge-claimed {
+  background: var(--pico-color-green-550, #16a34a);
+  color: #fff;
+}
+
+.badge-unclaimed {
+  background: var(--pico-muted-border-color);
+  color: var(--pico-muted-color);
+}

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -171,9 +171,19 @@ footer.container {
   font-size: 0.875rem;
 }
 
-/* Inline logout form — removes default form block display */
+/* Inline logout/action form — removes default form block display */
 form.inline {
   display: inline;
+}
+
+form.inline button {
+  --pico-nav-link-spacing-vertical: 0.25rem;
+  --pico-nav-link-spacing-horizontal: 0.75rem;
+  --pico-form-element-spacing-vertical: 0.25rem;
+  --pico-form-element-spacing-horizontal: 0.75rem;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.875rem;
+  margin: 0;
 }
 
 /* Member status badges */

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -34,12 +34,19 @@ nav a[aria-current="page"] {
 }
 
 .errors {
-  background: #fef2f2;
-  color: #991b1b;
-  border: 1px solid #991b1b;
+  border: 1px solid;
   border-radius: var(--pico-border-radius);
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
+  background: #fef2f2;
+  color: #991b1b;
+  border-color: #991b1b;
+}
+
+[data-theme="dark"] .errors {
+  background: #2d0a0a;
+  color: #fca5a5;
+  border-color: #ef4444;
 }
 
 .field {
@@ -145,19 +152,6 @@ footer.container {
 .login-container {
   max-width: 420px;
   margin-top: 4rem;
-}
-
-.member-list {
-  list-style: none;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.member-list li a[role="button"] {
-  display: block;
-  text-align: center;
 }
 
 .claim-hint {

--- a/docs/adr/0006-per-member-authentication.md
+++ b/docs/adr/0006-per-member-authentication.md
@@ -1,0 +1,59 @@
+# ADR 0006 — Per-member authentication
+
+**Date:** 2026-06-09  
+**Status:** Accepted  
+**Supersedes:** login-deferred note in ADR 0005
+
+## Context
+
+ADR 0005 introduced multi-user (family) support and explicitly deferred login, using an
+unsigned plaintext `bp_member` cookie as a temporary stepping stone. Any user could freely
+switch to any member's profile via `POST /members/switch`, which provided no privacy between
+family members.
+
+## Decision
+
+Add **per-member password authentication** using:
+
+- **Mechanism:** ASP.NET Core cookie authentication (`AddAuthentication().AddCookie()`), already
+  in the `Microsoft.NET.Sdk.Web` shared framework — no new package.
+- **Hashing:** PBKDF2-SHA256 via `System.Security.Cryptography.Rfc2898DeriveBytes` (BCL) with
+  310 000 iterations and a random 32-byte salt. Encoded as `iterations.base64salt.base64hash`.
+  Constant-time comparison via `CryptographicOperations.FixedTimeEquals`. Lives in a pure Core
+  module (`PasswordHashing.fs`) with no external dependencies.
+- **Claim model:** on login, `SignInAsync` issues a cookie carrying `NameIdentifier` (member Id),
+  `Name`, and `Role=Admin` (for admin members). All app routes are wrapped by `protect` / `protectAdmin`
+  combinators; `loginPage`, `loginMember`, `loginSubmit`, and `logout` are anonymous.
+- **First-login claim:** members with `PasswordHash = None` are "unclaimed". On first login they
+  set their own password (no admin intervention needed). The seeded `Me` admin simply claims on
+  first run.
+- **Strict per-member isolation:** everyone (including admins) sees and records only their own
+  readings. No on-behalf-of, no profile picker. Admins can manage other members via `/members`
+  but cannot view their readings.
+- **Schema migration:** `PasswordHash TEXT NOT NULL DEFAULT ''` added to the `Members` table via
+  the existing `addColumnIfMissing` pattern. Empty string maps to `None` in F# (unclaimed).
+- **`POST /members/switch` removed.** The `bp_member` cookie is no longer set or read.
+- **Password reset:** admins can reset any member's password to unclaimed via
+  `POST /members/{id}/reset-password`. The member must claim again on next login.
+
+## Alternatives considered
+
+- **Single shared gate:** one household password protects the whole app; the existing cookie
+  switcher is kept. Rejected because it provides no privacy between family members.
+- **Reverse-proxy auth (Authelia / Tailscale):** zero app code, but depends on deployment
+  infrastructure and is not portable. Rejected in favour of a self-contained solution.
+- **Admin sets passwords:** more controlled initial setup. Rejected in favour of the lower-friction
+  first-login claim flow.
+- **Admin on-behalf-of:** admins can view/record for other members. Rejected to keep the model
+  simple — maximum privacy, no special-case paths.
+
+## Consequences
+
+- `FamilyMember` gains a `PasswordHash: string option` field; existing DB rows get an empty
+  string (unclaimed) on first run after upgrade.
+- `Views.readingForm` and `Views.memberForm` gain a `memberName: string` parameter for the nav
+  logout display. Handler test helpers updated accordingly.
+- `TestHost.context` and variants now set `ctx.User` to an authenticated `ClaimsPrincipal` so
+  handler tests continue to exercise the full auth path without a running host.
+- The `bp_member` cookie is gone. Existing running instances will drop to the login page on next
+  page load after upgrade; users claim their account once and then use normal login.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,12 +40,13 @@ code/
 ```fsharp
 // BpMonitor.Core
 type FamilyMember = {
-    Id:         int
-    Name:       string
-    IsAdmin:    bool
-    IsActive:   bool
-    CreatedAt:  DateTimeOffset
-    ModifiedAt: DateTimeOffset
+    Id:           int
+    Name:         string
+    IsAdmin:      bool
+    IsActive:     bool
+    PasswordHash: string option   // None = unclaimed (no password set yet)
+    CreatedAt:    DateTimeOffset
+    ModifiedAt:   DateTimeOffset
 }
 
 type BloodPressureReadingUnvalidated = {
@@ -103,6 +104,8 @@ graph TD
 - `IReadingRepository` is member-scoped: `GetAll memberId`, `Add memberId`, `AddMany memberId`, `Update` (uses `reading.MemberId` as the guard)
 - `IFamilyMemberRepository`: `GetAll`, `GetById`, `Add`, `Update`
 - `FamilyMember.hasActiveAdmin` enforces the invariant: at least one member must have `IsAdmin = true` and `IsActive = true`; checked before every `Update`
+- `FamilyMember.isClaimed m` — true when `PasswordHash` is `Some`
+- `PasswordHashing` module — pure PBKDF2-SHA256 hashing via BCL (`Rfc2898DeriveBytes`); `hash password → encoded` (iterations.base64salt.base64hash), `verify password encoded → bool` (constant-time compare)
 - Business logic: applicative validation via `FsToolkit.ErrorHandling`
 - No dependencies on other projects
 
@@ -112,7 +115,7 @@ graph TD
 - SQLite with WAL mode + 5 s busy timeout (applied at startup)
 - `IReadingRepository` implementations: `EfReadingRepository` (filters by `MemberId`), `InMemoryReadingRepository`
 - `IFamilyMemberRepository` implementations: `EfFamilyMemberRepository`, `InMemoryFamilyMemberRepository`
-- Manual schema migrations via `SchemaMigrations.apply` (EF Core migrations do not support F#); handles `Members` table creation, default-member seeding, `MemberId` backfill for existing rows, and `IsAdmin`/`IsActive` column additions; `ensureActiveAdmin` promotes the lowest-Id member when no active admin exists (upgrade path for pre-PR#157 DBs)
+- Manual schema migrations via `SchemaMigrations.apply` (EF Core migrations do not support F#); handles `Members` table creation, default-member seeding, `MemberId` backfill for existing rows, `IsAdmin`/`IsActive` column additions, and `PasswordHash TEXT DEFAULT ''` column addition; `ensureActiveAdmin` promotes the lowest-Id member when no active admin exists (upgrade path for pre-PR#157 DBs)
 - `ReadingRepositoryFactory` / `FamilyMemberRepository` factory wiring
 
 ### BpMonitor.Import
@@ -136,10 +139,13 @@ graph TD
 ### BpMonitor.Web
 
 - Falco web application serving on `0.0.0.0:5000`
-- Pages: `/` landing hub, `/add` entry form, `/history` table + chart iframe, `/members` family-member management (list + add), `/members/{id}/edit` member edit form
-- Active family member tracked via `bp_member` cookie (HttpOnly, SameSite=Strict); falls back to the first member when no cookie is set. Login is deferred — this cookie is the stepping stone for real auth later
-- `POST /members/switch` sets the cookie and redirects; `POST /members` creates a new family member; `GET/POST /members/{id}/edit` edits an existing member
-- `IsAdmin` and `IsActive` are stored on each member; `IsActive`/`IsAdmin` flags do not yet affect cookie-based member resolution (deferred to login milestone). Invariant: at least one member must be admin + active — enforced on `updateMember` (POST /members/{id})
+- **Authentication:** ASP.NET Core cookie authentication (`AddAuthentication().AddCookie()`); `LoginPath=/login`. Per-member password via PBKDF2-SHA256 (`PasswordHashing` in Core). Members with no password are "unclaimed" and set their password on first login (claim flow). After claiming/verifying, `SignInAsync` issues a cookie carrying `NameIdentifier`, `Name`, and `Role=Admin` claims.
+- **Auth model — strict per-member isolation:** every member sees and records only their own readings. No on-behalf-of, no profile switching. Admin members can manage other members via `/members` but still see only their own readings.
+- Pages: `/login` member picker + password form (unauthenticated), `/` landing hub, `/add` entry form, `/history` table + chart iframe, `/members` family-member management (admin only), `/members/{id}/edit` member edit, `/members/{id}/reset-password` password reset (admin only), `POST /logout`
+- `protect` combinator wraps all app routes; `protectAdmin` wraps `/members*` routes; `/login*` and `/logout` are anonymous
+- Active member resolved via `ClaimTypes.NameIdentifier` from the authenticated principal (`authenticatedMember` in Handlers.fs)
+- `POST /members` creates a new unclaimed member (no cookie set; member claims on first login). `POST /members/switch` removed.
+- `IsAdmin`/`IsActive` stored on each member; invariant (≥1 admin+active) enforced on `updateMember`. Admin flag also determines role claim and `protectAdmin` access.
 - Every reading handler resolves the active member first; `IReadingRepository` calls are all member-scoped
 - Server-rendered HTML via `Falco.Markup`; htmx for partial updates
 - Scoped `DbContext` per request (concurrency-safe)


### PR DESCRIPTION
## Summary

- Replaces the "Who are you?" member-picker on the login screen with a standard Name + Password form
- `POST /login` looks up the member by name (case-insensitive), verifies the password, and signs in; unclaimed accounts are redirected to the existing claim flow at `/login/{id}`
- `hx-boost="false"` on the login page body prevents htmx (still running from a previous authenticated page) from silently swallowing 401 responses, so error messages are correctly displayed
- Theme toggle button added to the login page nav
- `.errors` CSS extended with a `[data-theme="dark"]` variant so error messages respect the active theme
- Passwords stored as PBKDF2-SHA256 hashes via `PasswordHashing` (BCL only, no new packages)
- Admin-only "Reset password" resets a member to unclaimed; they must re-claim on next login