### PR TITLE
🐛 fix: trends chart hover count + block commits to main

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,12 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" = "main" ]; then
+  echo "ERROR: direct commits to 'main' are not allowed. Create a feature/fix branch first."
+  exit 1
+fi
+
 ## husky task runner examples -------------------
 ## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
 

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -138,7 +138,7 @@ module BpChart =
             MarkerColor = systolicColor
           ) ]
 
-    let line name y =
+    let line name y text =
       Chart.Line(
         x = timestamps,
         y = y,
@@ -146,12 +146,15 @@ module BpChart =
         LineDash = StyleParam.DrawingStyle.Dash,
         ShowMarkers = true,
         MultiMarkerSymbol = symbols,
-        MultiText = hoverTexts,
+        MultiText = text,
         LineWidth = 1.0
       )
       |> Chart.withMarkerStyle (Size = 8)
 
-    [ line "Systolic" systolic; line "Diastolic" diastolic; yield! commentTraces ]
+    // Reading count only on Systolic — showing it on every trace would multiply the count in hover.
+    [ line "Systolic" systolic hoverTexts
+      line "Diastolic" diastolic (List.replicate diastolic.Length "")
+      yield! commentTraces ]
     |> Chart.combine
     |> Chart.withTitle "Blood Pressure History"
     |> finish theme


### PR DESCRIPTION
## Summary

- Fix hover reading count showing once per trace (Systolic + Diastolic) instead of once per data point — 2 measurements were displaying as 4 readings
- Block direct commits to `main` via pre-commit hook