### PR TITLE
🐛 fix: treat bare 1.0.0 as a real version, not the SDK dev sentinel

### DIFF
--- a/code/BpMonitor.Web.Tests/VersionPropertyTests.fs
+++ b/code/BpMonitor.Web.Tests/VersionPropertyTests.fs
@@ -20,7 +20,6 @@ let private stampedVersionGen =
     else
       return base'
   }
-  |> Gen.where (fun s -> s <> "1.0.0")
 
 let private whitespaceGen =
   Gen.nonEmptyListOf (Gen.elements [ ' '; '\t'; '\r'; '\n' ])

--- a/code/BpMonitor.Web.Tests/VersionTests.fs
+++ b/code/BpMonitor.Web.Tests/VersionTests.fs
@@ -16,8 +16,8 @@ let ``parse whitespace returns dev`` () =
   test <@ Version.parse (Some "   ") = "dev" @>
 
 [<Fact>]
-let ``parse default 1.0.0 returns dev`` () =
-  test <@ Version.parse (Some "1.0.0") = "dev" @>
+let ``parse 1.0.0 returns 1.0.0`` () =
+  test <@ Version.parse (Some "1.0.0") = "1.0.0" @>
 
 [<Fact>]
 let ``parse real version returns it unchanged`` () =

--- a/code/BpMonitor.Web/Version.fs
+++ b/code/BpMonitor.Web/Version.fs
@@ -18,7 +18,7 @@ module Version =
         | -1 -> s
         | i -> s.Substring(0, i)
 
-      if String.IsNullOrWhiteSpace base' || base' = "1.0.0" then
+      if String.IsNullOrWhiteSpace base' || (base' = "1.0.0" && s.Contains('+')) then
         "dev"
       else
         s


### PR DESCRIPTION
## Summary
- `Version.parse` was using bare `"1.0.0"` as the sentinel for unversioned dev builds, but the .NET SDK only appends `+<sha>` to its default version in git repos — explicitly stamped releases never carry that suffix
- Change the sentinel condition from `base' = "1.0.0"` to `base' = "1.0.0" && s.Contains('+')` so a tagged v1.0.0 release displays correctly in the web footer
- Update the corresponding unit test and remove the `Gen.where (fun s -> s <> "1.0.0")` exclusion from the property test generator