### PR TITLE
💄 style: narrow site max-width from 900px to 700px

### DIFF
--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -1,6 +1,6 @@
 main,
 nav.container {
-  max-width: 900px;
+  max-width: 700px;
 }
 
 nav a[aria-current="page"] {
@@ -140,7 +140,7 @@ td.col-center {
 }
 
 footer.container {
-  max-width: 900px;
+  max-width: 700px;
   margin-top: 2rem;
   padding-top: 1rem;
   border-top: 1px solid var(--pico-muted-border-color);


### PR DESCRIPTION
## Summary
- Reduces global content column width from 900px to 700px across all pages
- Affects `main, nav.container` and `footer.container` rules in `wwwroot/app.css`
- Chart iframes on History and Trends scale automatically via `width: 100%`
- Login form width (420px) unchanged