### PR TITLE
✨ feat: show readings table below trends chart

### DIFF
--- a/code/BpMonitor.Web.Tests/HandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerTests.fs
@@ -527,6 +527,59 @@ let ``trendsPanel returns fragment with avg stats and chart iframe`` () =
   test <@ body.Contains "/chart?window=7" @>
 
 [<Fact>]
+let ``trendsPanel includes readings table with in-window readings`` () =
+  let now = Timestamp.utc 2026 6 9 12 0 0
+  let tp = FakeTimeProvider(now)
+
+  let r =
+    { sample with
+        Timestamp = now.AddDays(-3.0)
+        Systolic = 130
+        Diastolic = 85
+        HeartRate = 70 }
+
+  let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
+  setRouteDays ctx 7
+  TestHost.run Handlers.trendsPanel ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  let body = TestHost.readBody ctx
+  // Readings table is rendered
+  test <@ body.Contains "id=\"readings\"" @>
+  // The reading's values appear in the table
+  test <@ body.Contains "130" @>
+  test <@ body.Contains "85" @>
+  test <@ body.Contains "70" @>
+
+[<Fact>]
+let ``trendsPanel excludes readings outside the window from the table`` () =
+  let now = Timestamp.utc 2026 6 9 12 0 0
+  let tp = FakeTimeProvider(now)
+  // One reading inside and one outside the 7-day window
+  let inside =
+    { sample with
+        Timestamp = now.AddDays(-3.0)
+        Systolic = 130 }
+
+  let outside =
+    { sample with
+        Id = 2
+        Timestamp = now.AddDays(-100.0)
+        Systolic = 999 }
+
+  let ctx = TestHost.contextWithProvider (repoWith [ inside; outside ]) tp
+  setRouteDays ctx 7
+  TestHost.run Handlers.trendsPanel ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  let body = TestHost.readBody ctx
+  // Table is present with the in-window reading
+  test <@ body.Contains "id=\"readings\"" @>
+  test <@ body.Contains "130" @>
+  // Out-of-window reading value is absent
+  test <@ body.Contains "999" |> not @>
+
+[<Fact>]
 let ``trendsPanel shows empty state and no iframe when no readings in window`` () =
   let now = Timestamp.utc 2026 6 9 12 0 0
   let tp = FakeTimeProvider(now)

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -341,7 +341,11 @@ module Handlers =
         let now = (timeProvider ctx).GetUtcNow()
         let allReadings = (repo ctx).GetAll(m.Id)
         let summary = ReadingStats.summarize now 7 allReadings
-        htmlResponse (Views.trends m summary) ctx
+
+        let windowed =
+          allReadings |> ReadingStats.since now 7 |> List.sortByDescending _.Timestamp
+
+        htmlResponse (Views.trends m summary windowed) ctx
 
   let trendsPanel: HttpContext -> Task =
     fun ctx ->
@@ -358,7 +362,11 @@ module Handlers =
           let now = (timeProvider ctx).GetUtcNow()
           let allReadings = (repo ctx).GetAll(m.Id)
           let summary = ReadingStats.summarize now days allReadings
-          htmlResponse (Views.trendsPanel summary) ctx
+
+          let windowed =
+            allReadings |> ReadingStats.since now days |> List.sortByDescending _.Timestamp
+
+          htmlResponse (Views.trendsPanel summary windowed) ctx
 
   let newReading: HttpContext -> Task =
     fun ctx ->

--- a/code/BpMonitor.Web/Views.fs
+++ b/code/BpMonitor.Web/Views.fs
@@ -465,7 +465,7 @@ module Views =
   /// The swappable panel: window-toggle buttons + stats + chart iframe.
   /// Rendered as a fragment for htmx swaps (GET /trends/{days}); also used directly
   /// by the full /trends page so the buttons are always inside the swapped region.
-  let trendsPanel (summary: WindowSummary) : XmlNode =
+  let trendsPanel (summary: WindowSummary) (readings: BloodPressureReading list) : XmlNode =
     let windows = [ 7; 14; 30; 90 ]
 
     let windowButton (days: int) =
@@ -511,7 +511,8 @@ module Views =
             [ Attr.create "data-chart-src" $"/chart?window={summary.Days}"
               Attr.class' "chart"
               Attr.title $"Blood Pressure — last {summary.Days} days" ]
-            [] ]
+            []
+          readingsTable readings ]
 
     Elem.div
       [ Attr.id "trends-panel" ]
@@ -519,5 +520,5 @@ module Views =
        :: content)
 
   /// The /trends full page. Pre-renders the 7-day panel (including toggle buttons).
-  let trends (m: FamilyMember) (summary: WindowSummary) : XmlNode =
-    layout "/trends" m.Name m.IsAdmin "Trends" [ Elem.h1 [] [ Text.raw "Trends" ]; trendsPanel summary ]
+  let trends (m: FamilyMember) (summary: WindowSummary) (readings: BloodPressureReading list) : XmlNode =
+    layout "/trends" m.Name m.IsAdmin "Trends" [ Elem.h1 [] [ Text.raw "Trends" ]; trendsPanel summary readings ]


### PR DESCRIPTION
## Summary
- Added a readings table below the chart on `/trends`, showing the individual readings for the currently selected window (7/14/30/90 days)
- Reused the existing `Views.readingsTable` component (same columns and Edit links as `/history`)
- Table re-renders automatically on window switch via the existing htmx `outerHTML` swap on `#trends-panel`
- Added two new handler tests: one asserting in-window readings appear in the table, one asserting out-of-window readings are excluded