### PR TITLE
📝 docs: remove outdated single-user and TUI references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A personal blood pressure monitoring application built with F# on .NET. Ships a web frontend (Falco) backed by a shared SQLite database.
+A blood pressure monitoring application for families and households, built with F# on .NET. Ships a multi-user web frontend (Falco) backed by a SQLite database.
 
 ## Docs
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@ BpMonitor Web ships as a self-contained Linux binary — no .NET runtime require
 ## Quick install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -t web
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
 ```
 
 This installs the latest release to `~/.local/bin/bpweb/bpmonitor-web`. Run it
@@ -28,14 +28,14 @@ Use flags to override defaults:
 | `-n NAME` | `bpmonitor-web` | Executable name |
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -t web -b /usr/local/bin -d bpweb
+curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -b /usr/local/bin -d bpweb
 ```
 
 Or via environment variables:
 
 ```bash
 BASE_PATH=/usr/local/bin INSTALL_DIR_NAME=bpweb \
-  curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash -s -- -t web
+  curl -fsSL https://raw.githubusercontent.com/draptik/BpMonitor/main/install.sh | bash
 ```
 
 ## Configuration

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -32,23 +32,14 @@ A personal health tracking tool to log and visualize blood pressure data over ti
 
 ## Usage
 
-- Primary user: personal use only, single user
+- Users: family / household members, each with their own readings
 - Logging frequency: sporadic (multiple times/day or gaps of several days)
-- Devices: phone (input) and desktop TUI (input + viewing) — both talk to the API
+- Devices: any browser (phone or desktop)
 
 ## Hosting
 
-- No central server — each client is self-sufficient with its own local database
+- Self-hosted web server with a single SQLite database
 - Data stays on personal infrastructure; no cloud dependency
-- Nextcloud is the transport layer for syncing between clients (via desktop sync client on TUI side, WebDAV API on PWA side)
-
-## Architecture (high-level, idea stage)
-
-- **TUI** — local SQLite; exports readings to a JSON file in a Nextcloud-watched folder on open/close or manual trigger
-- **PWA (phone)** — local IndexedDB; reads/writes JSON via Nextcloud WebDAV API; installable, works offline
-  — _spike abandoned: see [ADR-0001](adr/0001-pwa-phone-client-spike.md)_
-- **Sync** — append-only merge: each client imports readings it hasn't seen before from other clients' JSON files; no conflict resolution needed
-- **Nextcloud** — file transport only; no custom API required
 
 ## Success Criteria
 


### PR DESCRIPTION
## Summary
- README: drop "shared" and "personal" — app is now multi-user/family
- `docs/install.md`: remove stale `-t web` flag (TUI dropped in PR #151)
- `docs/vision.md`: update Usage/Hosting to reflect web + multi-user; drop TUI, PWA, and Nextcloud sync sections