### PR TITLE
🔧 chore: enable parallel test execution via Microsoft.Testing.Platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,13 @@ jobs:
         working-directory: code
 
       - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./TestResults
+        run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura
         working-directory: code
 
       - name: Generate coverage report
         uses: danielpalme/ReportGenerator-GitHub-Action@5
         with:
-          reports: "code/TestResults/**/coverage.cobertura.xml"
+          reports: "code/TestResults/**/*.cobertura.xml"
           targetdir: "code/CoverageReport"
           reporttypes: "MarkdownSummaryGithub;Badges"
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,9 @@ bpmonitor.db-shm
 bpmonitor.db-wal
 bpmonitor.json
 
+# Test output
+TestResults/
+CoverageReport/
+
 # Verify
 *.received.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,24 @@ Never start work on `main`. Creating the branch is the first step, not an aftert
 - `CONTRIBUTING.md` — developer setup, linting, testing, release process
 - `.claude/skills/` — skill definitions (git-workflow, review-tests, setup-tooling, model-advisor, status-bar)
 
+## Testing
+
+Tests run on **Microsoft.Testing.Platform (MTP)** — all 8 test projects execute in parallel (default: CPU count concurrent modules):
+
+```bash
+# Run all tests in parallel (local dev)
+dotnet test --configuration Release
+
+# Run with coverage (matches CI)
+dotnet test --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura
+# → produces one GUID-named *.cobertura.xml per project under TestResults/
+
+# Limit parallelism (e.g. on a 2-core machine)
+dotnet test --configuration Release --max-parallel-test-modules 2
+```
+
+`BpMonitor.Arch.Tests` uses `DoNotResideInNamespaceMatching("Microsoft\\.CodeCoverage.*")` in its type filters to exclude coverage-injected tracker types from ArchUnitNET dependency checks.
+
 ## Dev Tooling
 
 All non-dotnet linter versions are pinned in `mise.toml` (repo root). Run `mise install` once after cloning.

--- a/code/BpMonitor.Arch.Tests/ArchitectureTests.fs
+++ b/code/BpMonitor.Arch.Tests/ArchitectureTests.fs
@@ -25,23 +25,24 @@ let private architecture =
     )
     .Build()
 
-let private coreTypes =
-  ArchRuleDefinition.Types().That().ResideInAssembly(typeof<BloodPressureReading>.Assembly)
+// When running under MTP code coverage, a StaticManagedTrackerTemplate type gets
+// injected into every instrumented assembly. ArchUnitNET sees the same tracker type
+// across multiple assemblies and incorrectly reports cross-assembly dependencies.
+// Filter out Microsoft.CodeCoverage types to prevent these false positives.
+let private appTypes (assembly: System.Reflection.Assembly) =
+  ArchRuleDefinition
+    .Types()
+    .That()
+    .ResideInAssembly(assembly)
+    .And()
+    .DoNotResideInNamespaceMatching("Microsoft\\.CodeCoverage.*")
 
-let private dataTypes =
-  ArchRuleDefinition.Types().That().ResideInAssembly(typeof<EfReadingRepository>.Assembly)
-
-let private importTypes =
-  ArchRuleDefinition.Types().That().ResideInAssembly(typeof<ImportSummary>.Assembly)
-
-let private chartsTypes =
-  ArchRuleDefinition.Types().That().ResideInAssembly(chartsAssembly)
-
-let private exportTypes =
-  ArchRuleDefinition.Types().That().ResideInAssembly(exportAssembly)
-
-let private webTypes =
-  ArchRuleDefinition.Types().That().ResideInAssembly(webAssembly)
+let private coreTypes = appTypes typeof<BloodPressureReading>.Assembly
+let private dataTypes = appTypes typeof<EfReadingRepository>.Assembly
+let private importTypes = appTypes typeof<ImportSummary>.Assembly
+let private chartsTypes = appTypes chartsAssembly
+let private exportTypes = appTypes exportAssembly
+let private webTypes = appTypes webAssembly
 
 [<Fact>]
 let ``Core should not depend on Data`` () =

--- a/code/Directory.Build.props
+++ b/code/Directory.Build.props
@@ -3,10 +3,13 @@
     <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(IsPackable)' == 'false' and $(MSBuildProjectName.Contains('Tests'))">
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
   <ItemGroup Condition="'$(IsPackable)' == 'false' and $(MSBuildProjectName.Contains('Tests'))">
-    <PackageReference Include="coverlet.collector">
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -36,7 +36,7 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
   </ItemGroup>
   <ItemGroup Label="Test - PBT">
     <PackageVersion Include="FsCheck" Version="3.3.3" />

--- a/code/global.json
+++ b/code/global.json
@@ -3,5 +3,8 @@
     "version": "10.0.300",
     "rollForward": "latestMajor",
     "allowPrerelease": true
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,8 @@ code/
 | Validation | `FsToolkit.ErrorHandling` — applicative validation with `Validation<'ok, 'err>` |
 | Architecture | Clean Architecture (Core has zero dependencies on other projects) |
 | Architecture tests | ArchUnit (via `BpMonitor.Arch.Tests`) |
+| Test runner | xUnit v3 on Microsoft.Testing.Platform (MTP) — all 8 test projects run in parallel via `dotnet test` (default `--max-parallel-test-modules` = CPU count) |
+| Test coverage | `Microsoft.Testing.Extensions.CodeCoverage` (18.0.6); run with `dotnet test -- --coverage --coverage-output-format cobertura`; outputs one GUID-named `.cobertura.xml` per project into `TestResults/` |
 
 ## Data Model
 


### PR DESCRIPTION
## Summary

- Switch xUnit v3 from the legacy VSTest bridge to its built-in **Microsoft.Testing.Platform (MTP)** runner — all 8 test projects now run concurrently (`--max-parallel-test-modules` defaults to CPU count; measured ~209% CPU locally)
- Swap `coverlet.collector` for `Microsoft.Testing.Extensions.CodeCoverage` 18.0.6 (last version compatible with `xunit.v3` 3.2.2 / MTP 1.9.1); update CI coverage flags and ReportGenerator glob accordingly (`**/*.cobertura.xml` — MTP emits one GUID-named file per project)
- Fix `BpMonitor.Arch.Tests`: MTP static instrumentation injects a `StaticManagedTrackerTemplate` type into every loaded assembly; ArchUnitNET reported false cross-assembly dependency failures as a result — filter out `Microsoft.CodeCoverage.*` types via `DoNotResideInNamespaceMatching` in the type definitions
- Add `TestResults/` and `CoverageReport/` to `.gitignore`