### PR TITLE
🔧 chore: group Microsoft Testing Platform packages in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["every weekend"],
-  "commitMessagePrefix": "⬆️ chore:"
+  "commitMessagePrefix": "⬆️ chore:",
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "Microsoft.NET.Test.Sdk",
+        "Microsoft.Testing.Extensions.CodeCoverage"
+      ],
+      "groupName": "Microsoft Testing Platform",
+      "description": "CodeCoverage and Test.Sdk must update together — they share a Microsoft.Testing.Platform transitive dep that must version-match"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- `Microsoft.Testing.Extensions.CodeCoverage` and `Microsoft.NET.Test.Sdk` share a `Microsoft.Testing.Platform` transitive dependency that must version-match
- Renovate PR #180 bumped only `CodeCoverage` to `18.8.0`, which requires `Microsoft.Testing.Platform ≥ 2.3.x` — but `Microsoft.NET.Test.Sdk 18.6.0` ships `2.2.3`, causing a `TypeLoadException` at test startup (zero tests ran)
- Added a `packageRules` group so Renovate updates both packages together in a single PR