### PR TITLE
🔧 chore: sync docs and fix .[n] indexer style violations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,14 +51,20 @@ The following are available as slash commands (defined in `.claude/skills/`):
 ```text
 code/
 ├── BpMonitor.slnx
-├── BpMonitor.Core        # Domain models (BloodPressureReading + FamilyMember), interfaces, PasswordHashing, business logic
-├── BpMonitor.Data        # EF Core + SQLite, member-scoped repository implementations
-├── BpMonitor.Import      # Markdown and JSON importers (take memberId param)
-├── BpMonitor.Export      # JSON serialisation and file write
-├── BpMonitor.Charts      # Plotly.NET chart generation → HTML output
-├── BpMonitor.Web         # Falco web app (login + per-member auth, landing, add, history, members pages); Serilog structured stdout logging
-└── BpMonitor.Arch.Tests  # ArchUnit Clean Architecture rules
-docs/                     # Product vision, architecture, ADRs
+├── BpMonitor.Core              # Domain models (BloodPressureReading + FamilyMember), interfaces, PasswordHashing, business logic
+├── BpMonitor.Core.Tests
+├── BpMonitor.Data              # EF Core + SQLite, member-scoped repository implementations
+├── BpMonitor.Data.Tests
+├── BpMonitor.Import            # Markdown and JSON importers (standalone reusable library; not wired into Web)
+├── BpMonitor.Import.Tests
+├── BpMonitor.Export            # JSON serialisation and file write (standalone reusable library; not wired into Web)
+├── BpMonitor.Export.Tests
+├── BpMonitor.Charts            # Plotly.NET chart generation → HTML output
+├── BpMonitor.Charts.Tests
+├── BpMonitor.Web               # Falco web app (login + per-member auth, landing, add, history, members pages); Serilog structured stdout logging
+├── BpMonitor.Web.Tests
+└── BpMonitor.Arch.Tests        # ArchUnit Clean Architecture rules
+docs/                           # Product vision, architecture, ADRs
 ```
 
 ## Documentation
@@ -98,7 +104,7 @@ Never start work on `main`. Creating the branch is the first step, not an aftert
 
 ## Testing
 
-Tests run on **Microsoft.Testing.Platform (MTP)** — all 8 test projects execute in parallel (default: CPU count concurrent modules):
+Tests run on **Microsoft.Testing.Platform (MTP)** — all 7 test projects execute in parallel (default: CPU count concurrent modules):
 
 ```bash
 # Run all tests in parallel (local dev)

--- a/code/BpMonitor.Core.Tests/PasswordHashingTests.fs
+++ b/code/BpMonitor.Core.Tests/PasswordHashingTests.fs
@@ -40,12 +40,12 @@ let ``verify returns false when hash section is tampered`` () =
   // Base64 uses A-Z a-z 0-9 + /; rotating the first char by +1 in that alphabet always differs.
   let hashPart = parts[2]
   let base64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-  let firstChar = hashPart.[0]
+  let firstChar = hashPart[0]
 
   let nextChar =
-    base64Chars.[(base64Chars.IndexOf(firstChar) + 1) % base64Chars.Length]
+    base64Chars[(base64Chars.IndexOf(firstChar) + 1) % base64Chars.Length]
 
-  let tampered = $"{parts[0]}.{parts[1]}.{nextChar}{hashPart.[1..]}"
+  let tampered = $"{parts[0]}.{parts[1]}.{nextChar}{hashPart[1..]}"
   test <@ not (PasswordHashing.verify "secret" tampered) @>
 
 [<Fact>]

--- a/code/BpMonitor.Core.Tests/ReadingStatsTests.fs
+++ b/code/BpMonitor.Core.Tests/ReadingStatsTests.fs
@@ -60,7 +60,7 @@ let ``dailyAverages: single reading returns one entry with same values`` () =
   let r = mkReading 1 130 85 68 (now.AddDays(-1.0))
   let result = ReadingStats.dailyAverages [ r ]
   test <@ result.Length = 1 @>
-  let day = result.[0]
+  let day = result[0]
   test <@ day.Systolic = 130 @>
   test <@ day.Diastolic = 85 @>
   test <@ day.HeartRate = 68 @>
@@ -133,7 +133,7 @@ let ``weeklyAverages: result is sorted ascending`` () =
 let ``weeklyAverages: timestamp is Monday midnight of the ISO week`` () =
   let r = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 10, 15, 0, 0, TimeSpan.Zero)) // W24 (Wednesday)
   let result = ReadingStats.weeklyAverages [ r ]
-  let ts = result.[0].Timestamp.ToLocalTime()
+  let ts = result[0].Timestamp.ToLocalTime()
   let y, mo, d = ts.Year, ts.Month, ts.Day
   // 2026-W24 starts on 2026-06-08 (Monday)
   test <@ y = 2026 && mo = 6 && d = 8 @>
@@ -170,7 +170,7 @@ let ``monthlyAverages: result is sorted ascending`` () =
 let ``monthlyAverages: timestamp is first of month midnight`` () =
   let r = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero))
   let result = ReadingStats.monthlyAverages [ r ]
-  let ts = result.[0].Timestamp.ToLocalTime()
+  let ts = result[0].Timestamp.ToLocalTime()
   let y, mo, d = ts.Year, ts.Month, ts.Day
   test <@ y = 2026 && mo = 6 && d = 1 @>
 

--- a/code/BpMonitor.Import.Tests/ParseMarkdownPropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/ParseMarkdownPropertyTests.fs
@@ -49,4 +49,4 @@ let ``parseMarkdown triples reference their source line`` () =
     let lines = items |> List.map renderDocLine
 
     parseMarkdown (String.concat "\n" lines)
-    |> List.forall (fun (n, line, _) -> n >= 1 && n <= lines.Length && lines.[n - 1] = line))
+    |> List.forall (fun (n, line, _) -> n >= 1 && n <= lines.Length && lines[n - 1] = line))

--- a/docs/adr/0003-web-ui-frontend.md
+++ b/docs/adr/0003-web-ui-frontend.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Accepted
+Accepted  
+**Note:** The TUI mentioned throughout this ADR was removed in PR #151. `BpMonitor.Web`
+is now the sole interface. References to "alongside the TUI" and "Two UIs" in the
+Consequences section are historical; the current architecture has one UI only.
 
 ## Context
 

--- a/docs/adr/0004-sqlite-persistence.md
+++ b/docs/adr/0004-sqlite-persistence.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Accepted
+Accepted  
+**Note:** The "single-user application" framing in the Context section was superseded
+by [ADR-0005](0005-multi-user-family-support.md) (multi-user family support) and
+[ADR-0006](0006-per-member-authentication.md) (per-member authentication). SQLite
+remains the correct choice — the WAL + scoped-DbContext arguments still hold for a
+small family group — but the single-writer assumption no longer applies. The TUI
+referenced here was also removed in PR #151.
 
 ## Context
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ code/
 | Validation | `FsToolkit.ErrorHandling` — applicative validation with `Validation<'ok, 'err>` |
 | Architecture | Clean Architecture (Core has zero dependencies on other projects) |
 | Architecture tests | ArchUnit (via `BpMonitor.Arch.Tests`) |
-| Test runner | xUnit v3 on Microsoft.Testing.Platform (MTP) — all 8 test projects run in parallel via `dotnet test` (default `--max-parallel-test-modules` = CPU count) |
+| Test runner | xUnit v3 on Microsoft.Testing.Platform (MTP) — all 7 test projects run in parallel via `dotnet test` (default `--max-parallel-test-modules` = CPU count) |
 | Test coverage | `Microsoft.Testing.Extensions.CodeCoverage` (18.0.6); run with `dotnet test -- --coverage --coverage-output-format cobertura`; outputs one GUID-named `.cobertura.xml` per project into `TestResults/` |
 
 ## Data Model
@@ -97,6 +97,10 @@ graph TD
     Web --> Charts
 ```
 
+> **Note:** `Import` and `Export` are standalone reusable libraries. They depend only
+> on `Core` and are not referenced by `Web` — they are kept for potential future wiring
+> or external tooling use after the TUI was removed (PR #151).
+
 ## Project Responsibilities
 
 ### BpMonitor.Core
@@ -123,6 +127,7 @@ graph TD
 
 ### BpMonitor.Import
 
+- Standalone reusable library — **not referenced by `BpMonitor.Web`**
 - Parses blood pressure readings from Markdown files (`parseMarkdown`, `parseLine`)
 - Upsert import logic with summary (`ImportSummary`: added, updated, failed counts)
 - Imports `BloodPressureReading` lists from JSON (`JsonImport.parse`, `JsonImport.tryReadFromFile`, `JsonImport.import`)
@@ -136,6 +141,7 @@ graph TD
 
 ### BpMonitor.Export
 
+- Standalone reusable library — **not referenced by `BpMonitor.Web`**
 - JSON serialisation of `BloodPressureReading` lists (`serialize`, `tryWriteToFile`)
 - Depends on Core only
 


### PR DESCRIPTION
## Summary

- Fix test-project count 8→7 in `AGENTS.md` and `architecture.md`
- Add all 7 test projects to the `AGENTS.md` structure list (previously only `Arch.Tests` was listed)
- Clarify `Import` and `Export` are standalone reusable libraries not referenced by `Web` — in `AGENTS.md`, the dependency diagram note, and both project descriptions in `architecture.md`
- Add historical status notes to ADR-0003 (TUI removed in PR #151) and ADR-0004 ("single-user" framing superseded by ADR-0005/0006)
- Fix `.[n]` indexer usage outside Unquote quotation expressions in `PasswordHashingTests.fs`, `ReadingStatsTests.fs`, `ParseMarkdownPropertyTests.fs` (violates the style rule in `AGENTS.md:87`)