### PR TITLE
✅ test: add tests for SchemaMigrations and EfFamilyMemberRepository

### DIFF
--- a/code/BpMonitor.Data.Tests/BpMonitor.Data.Tests.fsproj
+++ b/code/BpMonitor.Data.Tests/BpMonitor.Data.Tests.fsproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <Compile Include="InMemoryReadingRepositoryTests.fs" />
     <Compile Include="EfReadingRepositoryTests.fs" />
+    <Compile Include="EfFamilyMemberRepositoryTests.fs" />
+    <Compile Include="SchemaMigrationsTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Data.Tests/EfFamilyMemberRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/EfFamilyMemberRepositoryTests.fs
@@ -1,0 +1,134 @@
+module EfFamilyMemberRepositoryTests
+
+open System
+open Xunit
+open Swensen.Unquote
+open Microsoft.Data.Sqlite
+open Microsoft.EntityFrameworkCore
+open Microsoft.Extensions.Time.Testing
+open BpMonitor.Core
+open BpMonitor.Data
+
+let private createContext () =
+  let connection = new SqliteConnection("DataSource=:memory:")
+  connection.Open()
+
+  let options =
+    DbContextOptionsBuilder<BpMonitorDbContext>().UseSqlite(connection).Options
+
+  let ctx = new BpMonitorDbContext(options)
+  ctx.Database.EnsureCreated() |> ignore
+  ctx
+
+let private newMember name isAdmin =
+  FamilyMember.create name isAdmin
+  |> Result.defaultWith (fun _ -> failwith "invalid member")
+
+[<Fact>]
+let ``GetAll returns empty list when database is empty`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfFamilyMemberRepository(ctx, TimeProvider.System) :> IFamilyMemberRepository
+
+  test <@ repo.GetAll() = [] @>
+
+[<Fact>]
+let ``GetAll returns all members`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfFamilyMemberRepository(ctx, TimeProvider.System) :> IFamilyMemberRepository
+
+  repo.Add(newMember "Alice" true) |> ignore
+  repo.Add(newMember "Bob" false) |> ignore
+  test <@ repo.GetAll().Length = 2 @>
+
+[<Fact>]
+let ``GetById returns Some when member exists`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfFamilyMemberRepository(ctx, TimeProvider.System) :> IFamilyMemberRepository
+
+  let added = repo.Add(newMember "Alice" true)
+  test <@ repo.GetById(added.Id) = Some added @>
+
+[<Fact>]
+let ``GetById returns None when member does not exist`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfFamilyMemberRepository(ctx, TimeProvider.System) :> IFamilyMemberRepository
+
+  test <@ repo.GetById(999) = None @>
+
+[<Fact>]
+let ``Add persists a member and assigns a non-zero Id`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfFamilyMemberRepository(ctx, TimeProvider.System) :> IFamilyMemberRepository
+
+  let added = repo.Add(newMember "Alice" true)
+  test <@ added.Id > 0 @>
+  test <@ repo.GetAll().Length = 1 @>
+
+[<Fact>]
+let ``Add maps empty PasswordHash to None`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfFamilyMemberRepository(ctx, TimeProvider.System) :> IFamilyMemberRepository
+
+  let added = repo.Add(newMember "Alice" true)
+  test <@ added.PasswordHash = None @>
+
+[<Fact>]
+let ``Add maps non-empty PasswordHash to Some`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfFamilyMemberRepository(ctx, TimeProvider.System) :> IFamilyMemberRepository
+
+  let m =
+    { newMember "Alice" true with
+        PasswordHash = Some "hashed" }
+
+  let added = repo.Add m
+  test <@ added.PasswordHash = Some "hashed" @>
+
+[<Fact>]
+let ``Add sets CreatedAt and ModifiedAt to current time`` () =
+  let now = DateTimeOffset(2026, 3, 11, 10, 0, 0, TimeSpan.Zero)
+  let timeProvider = FakeTimeProvider(now)
+  use ctx = createContext ()
+  let repo = EfFamilyMemberRepository(ctx, timeProvider) :> IFamilyMemberRepository
+  let added = repo.Add(newMember "Alice" true)
+  test <@ added.CreatedAt = now @>
+  test <@ added.ModifiedAt = now @>
+
+[<Fact>]
+let ``Update modifies the stored member`` () =
+  use ctx = createContext ()
+
+  let repo =
+    EfFamilyMemberRepository(ctx, TimeProvider.System) :> IFamilyMemberRepository
+
+  let added = repo.Add(newMember "Alice" true)
+  repo.Update { added with Name = "Alicia" }
+  test <@ (repo.GetById added.Id).Value.Name = "Alicia" @>
+
+[<Fact>]
+let ``Update sets ModifiedAt to current time and preserves CreatedAt`` () =
+  let createdAt = DateTimeOffset(2026, 1, 1, 9, 0, 0, TimeSpan.Zero)
+  let updatedAt = DateTimeOffset(2026, 3, 11, 10, 0, 0, TimeSpan.Zero)
+  let timeProvider = FakeTimeProvider(createdAt)
+  use ctx = createContext ()
+  let repo = EfFamilyMemberRepository(ctx, timeProvider) :> IFamilyMemberRepository
+  let added = repo.Add(newMember "Alice" true)
+  timeProvider.SetUtcNow(updatedAt)
+  repo.Update { added with Name = "Alicia" }
+  let result = (repo.GetById added.Id).Value
+  test <@ result.CreatedAt = createdAt @>
+  test <@ result.ModifiedAt = updatedAt @>

--- a/code/BpMonitor.Data.Tests/SchemaMigrationsTests.fs
+++ b/code/BpMonitor.Data.Tests/SchemaMigrationsTests.fs
@@ -1,0 +1,117 @@
+module SchemaMigrationsTests
+
+open Xunit
+open Swensen.Unquote
+open Microsoft.Data.Sqlite
+open Microsoft.EntityFrameworkCore
+open BpMonitor.Data
+
+/// Creates a fresh in-memory connection + context WITHOUT calling EnsureCreated,
+/// so SchemaMigrations.apply can drive the full setup from scratch.
+let private createRawContext () =
+  let connection = new SqliteConnection("DataSource=:memory:")
+  connection.Open()
+
+  let options =
+    DbContextOptionsBuilder<BpMonitorDbContext>().UseSqlite(connection).Options
+
+  new BpMonitorDbContext(options)
+
+let private scalarInt64 (conn: System.Data.IDbConnection) (sql: string) : int64 =
+  use cmd = conn.CreateCommand()
+  cmd.CommandText <- sql
+  cmd.ExecuteScalar() :?> int64
+
+[<Fact>]
+let ``apply on a fresh database creates the Members table`` () =
+  use ctx = createRawContext ()
+  SchemaMigrations.apply ctx
+
+  let conn = ctx.Database.GetDbConnection()
+
+  let tableCount =
+    scalarInt64 conn "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='Members'"
+
+  test <@ tableCount = 1L @>
+
+[<Fact>]
+let ``apply seeds a default member named Me with admin rights`` () =
+  use ctx = createRawContext ()
+  SchemaMigrations.apply ctx
+
+  let members = ctx.Members |> Seq.toList
+  test <@ members.Length = 1 @>
+  test <@ members[0].Name = "Me" @>
+  test <@ members[0].IsAdmin = true @>
+  test <@ members[0].IsActive = true @>
+
+[<Fact>]
+let ``apply is idempotent - calling it twice does not create duplicate members`` () =
+  use ctx = createRawContext ()
+  SchemaMigrations.apply ctx
+  SchemaMigrations.apply ctx
+
+  let members = ctx.Members |> Seq.toList
+  test <@ members.Length = 1 @>
+
+[<Fact>]
+let ``apply adds missing columns to an existing Readings table without MemberId`` () =
+  let connection = new SqliteConnection("DataSource=:memory:")
+  connection.Open()
+
+  // Simulate a legacy DB: Readings table without MemberId, CreatedAt, or ModifiedAt.
+  use setupCmd = connection.CreateCommand()
+
+  setupCmd.CommandText <-
+    """CREATE TABLE "Readings" (
+         "Id" INTEGER NOT NULL CONSTRAINT "PK_Readings" PRIMARY KEY AUTOINCREMENT,
+         "Systolic" INTEGER NOT NULL,
+         "Diastolic" INTEGER NOT NULL,
+         "HeartRate" INTEGER NOT NULL,
+         "Timestamp" TEXT NOT NULL,
+         "Comments" TEXT
+       )"""
+
+  setupCmd.ExecuteNonQuery() |> ignore
+
+  use insertCmd = connection.CreateCommand()
+
+  insertCmd.CommandText <-
+    "INSERT INTO \"Readings\" (Systolic, Diastolic, HeartRate, Timestamp) VALUES (120, 80, 70, '2026-01-01 09:00:00 +00:00')"
+
+  insertCmd.ExecuteNonQuery() |> ignore
+
+  let options =
+    DbContextOptionsBuilder<BpMonitorDbContext>().UseSqlite(connection).Options
+
+  use ctx = new BpMonitorDbContext(options)
+  SchemaMigrations.apply ctx
+
+  // After apply the reading should have MemberId set to the default member's Id (1).
+  let memberId =
+    scalarInt64 connection "SELECT \"MemberId\" FROM \"Readings\" LIMIT 1"
+
+  test <@ memberId > 0L @>
+
+[<Fact>]
+let ``apply promotes lowest-Id member to active admin when no active admin exists`` () =
+  use ctx = createRawContext ()
+  SchemaMigrations.apply ctx
+
+  // Demote the seeded member to non-admin via raw SQL (bypasses domain invariant).
+  ctx.Database.ExecuteSqlRaw("UPDATE \"Members\" SET \"IsAdmin\" = 0") |> ignore
+
+  // Verify there is no active admin now.
+  let conn = ctx.Database.GetDbConnection()
+
+  let adminCount =
+    scalarInt64 conn "SELECT COUNT(*) FROM \"Members\" WHERE \"IsAdmin\" = 1 AND \"IsActive\" = 1"
+
+  test <@ adminCount = 0L @>
+
+  // Re-apply — ensureActiveAdmin should promote the lowest-Id member.
+  SchemaMigrations.apply ctx
+
+  let promoted = ctx.Members |> Seq.minBy _.Id
+  test <@ promoted.IsAdmin = true @>
+  test <@ promoted.IsActive = true @>


### PR DESCRIPTION
## Summary

- Add `SchemaMigrationsTests.fs`: fresh DB creates `Members` table and seeds a default admin member; idempotence (double-apply leaves exactly one member); legacy `Readings` backfill (old schema without `MemberId` gets the column added with the default member's Id); `ensureActiveAdmin` promotes the lowest-Id member when no active admin exists
- Add `EfFamilyMemberRepositoryTests.fs`: `GetAll`/`GetById` CRUD, `Add` assigns Id and stamps timestamps via `FakeTimeProvider`, `PasswordHash` empty-string→`None` / non-empty→`Some` mapping, `Update` modifies the member and sets `ModifiedAt` while preserving `CreatedAt`
- Wire both files into `BpMonitor.Data.Tests.fsproj`

Covers the two highest-risk untested areas: manual migration code on health data and the EF family-member repository.