### PR TITLE
♻️ refactor: Theme DU, collapse aggregation functions, drop dead _readings param

### DIFF
--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -56,14 +56,14 @@ let private readings =
 [<Fact>]
 let ``toHtml renders timestamps in ascending order regardless of input order`` () =
   let reversed = List.rev readings
-  let html = BpChart.toHtml "light" reversed
+  let html = BpChart.toHtml Light reversed
   let pos1 = html.IndexOf("2026-01-01")
   let pos30 = html.IndexOf("2026-01-30")
   test <@ pos1 < pos30 @>
 
 [<Fact>]
 let ``toHtml includes comment text as hover info for commented readings`` () =
-  let html = BpChart.toHtml "light" readings
+  let html = BpChart.toHtml Light readings
   test <@ html.Contains("After coffee") @>
   test <@ html.Contains("Stressful day") @>
   test <@ html.Contains("After walk") @>
@@ -72,17 +72,17 @@ let ``toHtml includes comment text as hover info for commented readings`` () =
 [<Fact>]
 let ``toHtml does not include None comment readings in comments trace`` () =
   let noCommentOnly = [ reading 1 120 80 70 1 9 None ]
-  let html = BpChart.toHtml "light" noCommentOnly
+  let html = BpChart.toHtml Light noCommentOnly
   test <@ not (html.Contains("Comments")) @>
 
 [<Fact>]
 let ``toHtml dark theme output contains dark background color`` () =
-  let html = BpChart.toHtml "dark" readings
+  let html = BpChart.toHtml Dark readings
   test <@ html.Contains("#11191f") @>
 
 [<Fact>]
 let ``toHtml matches snapshot`` () : Task =
-  let html: string = BpChart.toHtml "light" readings
+  let html: string = BpChart.toHtml Light readings
   let settings = VerifyTests.VerifySettings()
   settings.ScrubInlineGuids()
 
@@ -107,7 +107,7 @@ let private asAggregated (rs: BloodPressureReading list) =
 
 [<Fact>]
 let ``toHtmlDashed matches snapshot`` () : Task =
-  let html: string = BpChart.toHtmlDashed Weekly "light" (asAggregated readings)
+  let html: string = BpChart.toHtmlDashed Weekly Light (asAggregated readings)
   let settings = VerifyTests.VerifySettings()
   settings.ScrubInlineGuids()
 
@@ -130,7 +130,7 @@ let ``toHtmlDashed: multi-reading period uses diamond marker (size 11) and 'read
         MinDiastolic = readings[0].Diastolic - 5
         MaxDiastolic = readings[0].Diastolic + 5 } ]
 
-  let html = BpChart.toHtmlDashed Weekly "light" aggregated
+  let html = BpChart.toHtmlDashed Weekly Light aggregated
   test <@ html.Contains("readings") @>
   test <@ html.Contains("\"size\":[11]") @> // diamond is rendered larger than circle
   test <@ html.Contains("\"symbol\":[\"2\"]") @> // Plotly numeric code for Diamond
@@ -146,7 +146,7 @@ let ``toHtmlDashed: single-reading period uses circle marker (size 8) and '1 rea
         MinDiastolic = readings[0].Diastolic
         MaxDiastolic = readings[0].Diastolic } ]
 
-  let html = BpChart.toHtmlDashed Weekly "light" aggregated
+  let html = BpChart.toHtmlDashed Weekly Light aggregated
   test <@ html.Contains("1 reading") @>
   test <@ html.Contains("\"size\":[8]") @> // circle is smaller than diamond
   test <@ html.Contains("\"symbol\":[\"0\"]") @> // Plotly numeric code for Circle
@@ -162,7 +162,7 @@ let ``toHtmlDashed: multi-reading period renders error_y with non-zero spread`` 
         MinDiastolic = 75
         MaxDiastolic = 90 } ]
 
-  let html = BpChart.toHtmlDashed Weekly "light" aggregated
+  let html = BpChart.toHtmlDashed Weekly Light aggregated
   test <@ html.Contains("\"error_y\"") @>
   test <@ html.Contains("\"type\":\"data\"") @>
   test <@ html.Contains("\"symmetric\":false") @>
@@ -178,7 +178,7 @@ let ``toHtmlDashed: single-reading period has zero-spread error_y`` () =
         MinDiastolic = readings[0].Diastolic
         MaxDiastolic = readings[0].Diastolic } ]
 
-  let html = BpChart.toHtmlDashed Weekly "light" aggregated
+  let html = BpChart.toHtmlDashed Weekly Light aggregated
   // error_y present but array values are all 0
   test <@ html.Contains("\"error_y\"") @>
   test <@ html.Contains("\"array\":[0]") @>
@@ -194,7 +194,7 @@ let ``toHtmlDashed: multi-reading systolic tooltip shows count and range`` () =
         MinDiastolic = 75
         MaxDiastolic = 85 } ]
 
-  let html = BpChart.toHtmlDashed Weekly "light" aggregated
+  let html = BpChart.toHtmlDashed Weekly Light aggregated
   // Systolic trace hover: "2 readings · 110–130"
   test <@ html.Contains("2 readings") @>
   test <@ html.Contains("110") @>

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -5,6 +5,10 @@ open Plotly.NET
 open Plotly.NET.LayoutObjects
 open BpMonitor.Core
 
+type Theme =
+  | Dark
+  | Light
+
 module BpChart =
   // ── palette ──────────────────────────────────────────────────────────────
   let private darkBgHex = "#11191f"
@@ -15,11 +19,11 @@ module BpChart =
   let private lightGridLine = Color.fromString "rgba(0,0,0,0.08)"
   let private systolicColor = Color.fromString "rgba(99,110,250,1)"
 
-  let private layout (theme: string) =
-    let bg = if theme = "dark" then darkBg else transparent
+  let private layout (theme: Theme) =
+    let bg = if theme = Dark then darkBg else transparent
 
     let font =
-      if theme = "dark" then
+      if theme = Dark then
         Font.init (Color = darkFont)
       else
         Font.init ()
@@ -28,19 +32,19 @@ module BpChart =
 
   let private xAxis = LinearAxis.init (ShowGrid = false)
 
-  let private yAxis (theme: string) =
-    let gridColor = if theme = "dark" then darkGridLine else lightGridLine
+  let private yAxis (theme: Theme) =
+    let gridColor = if theme = Dark then darkGridLine else lightGridLine
     LinearAxis.init (GridColor = gridColor)
 
   // The chart is rendered inside an iframe (separate document), so the iframe body
   // background must be set explicitly — it does not inherit the parent page theme.
-  let private injectBodyStyle (theme: string) (html: string) =
-    if theme = "dark" then
+  let private injectBodyStyle (theme: Theme) (html: string) =
+    if theme = Dark then
       html.Replace("</head>", $"<style>body{{background:{darkBgHex};margin:0}}</style></head>")
     else
       html.Replace("</head>", "<style>body{margin:0}</style></head>")
 
-  let private finish (theme: string) (chart: GenericChart) =
+  let private finish (theme: Theme) (chart: GenericChart) =
     chart
     |> Chart.withLayout (layout theme)
     |> Chart.withXAxis xAxis
@@ -56,11 +60,11 @@ module BpChart =
   // - Horizontal centred legend avoids stealing horizontal width.
   // - DisplayModeBar=false: no floating toolbar (awkward on touch).
   // - ScrollZoom=NoZoom: wheel/pinch won't fight page scroll.
-  let private trendsLayout (theme: string) =
-    let bg = if theme = "dark" then darkBg else transparent
+  let private trendsLayout (theme: Theme) =
+    let bg = if theme = Dark then darkBg else transparent
 
     let font =
-      if theme = "dark" then
+      if theme = Dark then
         Font.init (Color = darkFont)
       else
         Font.init ()
@@ -80,7 +84,7 @@ module BpChart =
   let private trendsConfig =
     Config.init (Responsive = true, DisplayModeBar = false, ScrollZoom = StyleParam.ScrollZoom.NoZoom)
 
-  let private finishTrends (theme: string) (chart: GenericChart) =
+  let private finishTrends (theme: Theme) (chart: GenericChart) =
     chart
     |> Chart.withLayout (trendsLayout theme)
     |> Chart.withXAxis trendsXAxis
@@ -96,7 +100,7 @@ module BpChart =
     |> injectBodyStyle theme
 
   /// Classic x/y plot — one point per reading. Used by /history.
-  let private renderIndividual (theme: string) (readings: BloodPressureReading list) : string =
+  let private renderIndividual (theme: Theme) (readings: BloodPressureReading list) : string =
     let readings = readings |> List.sortBy _.Timestamp
     let timestamps = readings |> List.map (_.Timestamp >> Formats.formatLocal)
     let systolic = readings |> List.map _.Systolic
@@ -138,7 +142,7 @@ module BpChart =
   /// Circle marker = single reading in that period; Diamond marker = average of multiple readings.
   /// X-axis labels adapt to granularity: Weekly → date, Monthly → ISO week, Yearly → month name.
   /// Used by /trends for all granularities.
-  let private renderDashed (gran: Granularity) (theme: string) (aggregated: AggregatedReading list) : string =
+  let private renderDashed (gran: Granularity) (theme: Theme) (aggregated: AggregatedReading list) : string =
     let aggregated = aggregated |> List.sortBy _.Reading.Timestamp
 
     let xLabel (r: BloodPressureReading) =
@@ -246,5 +250,5 @@ module BpChart =
     |> Chart.combine
     |> finishTrends theme
 
-  let toHtml (theme: string) = renderIndividual theme
-  let toHtmlDashed (gran: Granularity) (theme: string) = renderDashed gran theme
+  let toHtml (theme: Theme) = renderIndividual theme
+  let toHtmlDashed (gran: Granularity) (theme: Theme) = renderDashed gran theme

--- a/code/BpMonitor.Core.Tests/TrendPeriodTests.fs
+++ b/code/BpMonitor.Core.Tests/TrendPeriodTests.fs
@@ -231,55 +231,55 @@ let ``ofKey Yearly: invalid key returns None`` () =
 
 [<Fact>]
 let ``available Weekly: returns 12 periods`` () =
-  let result = TrendPeriod.available Weekly now []
+  let result = TrendPeriod.available Weekly now
   let len = result.Length
   test <@ len = 12 @>
 
 [<Fact>]
 let ``available Monthly: returns 12 periods`` () =
-  let result = TrendPeriod.available Monthly now []
+  let result = TrendPeriod.available Monthly now
   let len = result.Length
   test <@ len = 12 @>
 
 [<Fact>]
 let ``available Yearly: returns 5 periods`` () =
-  let result = TrendPeriod.available Yearly now []
+  let result = TrendPeriod.available Yearly now
   let len = result.Length
   test <@ len = 5 @>
 
 [<Fact>]
 let ``available Weekly: current (This Week) is last`` () =
-  let result = TrendPeriod.available Weekly now []
+  let result = TrendPeriod.available Weekly now
   let last = result |> List.last |> _.Label
   test <@ last = "This Week" @>
 
 [<Fact>]
 let ``available Monthly: current (This Month) is last`` () =
-  let result = TrendPeriod.available Monthly now []
+  let result = TrendPeriod.available Monthly now
   let last = result |> List.last |> _.Label
   test <@ last = "This Month" @>
 
 [<Fact>]
 let ``available Yearly: current (This Year) is last`` () =
-  let result = TrendPeriod.available Yearly now []
+  let result = TrendPeriod.available Yearly now
   let last = result |> List.last |> _.Label
   test <@ last = "This Year" @>
 
 [<Fact>]
 let ``available Weekly: second-to-last is Last Week`` () =
-  let result = TrendPeriod.available Weekly now []
+  let result = TrendPeriod.available Weekly now
   let secondLast = result |> List.item (result.Length - 2) |> _.Label
   test <@ secondLast = "Last Week" @>
 
 [<Fact>]
 let ``available Monthly: second-to-last is Last Month`` () =
-  let result = TrendPeriod.available Monthly now []
+  let result = TrendPeriod.available Monthly now
   let secondLast = result |> List.item (result.Length - 2) |> _.Label
   test <@ secondLast = "Last Month" @>
 
 [<Fact>]
 let ``available Weekly: periods are in chronological order`` () =
-  let result = TrendPeriod.available Weekly now []
+  let result = TrendPeriod.available Weekly now
 
   let isAscending =
     result |> List.pairwise |> List.forall (fun (a, b) -> a.Start < b.Start)
@@ -288,7 +288,7 @@ let ``available Weekly: periods are in chronological order`` () =
 
 [<Fact>]
 let ``available Monthly: periods are in chronological order`` () =
-  let result = TrendPeriod.available Monthly now []
+  let result = TrendPeriod.available Monthly now
 
   let isAscending =
     result |> List.pairwise |> List.forall (fun (a, b) -> a.Start < b.Start)
@@ -298,21 +298,13 @@ let ``available Monthly: periods are in chronological order`` () =
 [<Fact>]
 let ``available Yearly: includes 2024 even with no readings`` () =
   // Fixed window of 5 years back from 2026 includes 2022..2026; 2024 must be present
-  let result = TrendPeriod.available Yearly now []
+  let result = TrendPeriod.available Yearly now
   let has2024 = result |> List.exists (fun p -> p.Key = "2024")
   test <@ has2024 @>
 
 [<Fact>]
 let ``available: no duplicate keys`` () =
-  let result = TrendPeriod.available Monthly now []
+  let result = TrendPeriod.available Monthly now
   let keys = result |> List.map _.Key
   let uniqueCount = keys |> List.distinct |> List.length
   test <@ keys.Length = uniqueCount @>
-
-[<Fact>]
-let ``available: readings parameter does not affect result`` () =
-  let r1 = mkReading 1 (DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 (DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero))
-  let withReadings = TrendPeriod.available Monthly now [ r1; r2 ]
-  let noReadings = TrendPeriod.available Monthly now []
-  test <@ withReadings = noReadings @>

--- a/code/BpMonitor.Core/ReadingStats.fs
+++ b/code/BpMonitor.Core/ReadingStats.fs
@@ -42,16 +42,20 @@ module ReadingStats =
 
   // ── aggregation ──────────────────────────────────────────────────────────────
 
-  /// Groups readings by local calendar date and returns one averaged reading per day
-  /// together with the raw reading count, sorted ascending.
-  /// The returned reading's Timestamp is midnight of that local date.
+  /// Groups readings by `keyOf`, sorts by key, and produces one AggregatedReading per
+  /// group. The representative timestamp is `dateOf key` wrapped in the local UTC offset.
   /// Comments are dropped (not meaningful for averages).
-  let private dailyAveragesWithCount (readings: BloodPressureReading list) : AggregatedReading list =
+  let private buildAggregated
+    (keyOf: BloodPressureReading -> 'key)
+    (dateOf: 'key -> DateTime)
+    (readings: BloodPressureReading list)
+    : AggregatedReading list =
     readings
-    |> List.groupBy (fun r -> r.Timestamp.ToLocalTime().Date)
+    |> List.groupBy keyOf
     |> List.sortBy fst
-    |> List.map (fun (date, rs) ->
+    |> List.map (fun (key, rs) ->
       let n = List.length rs
+      let date = dateOf key
       let offset = TimeZoneInfo.Local.GetUtcOffset(date)
 
       { Reading =
@@ -70,81 +74,31 @@ module ReadingStats =
         MinDiastolic = rs |> List.minBy _.Diastolic |> _.Diastolic
         MaxDiastolic = rs |> List.maxBy _.Diastolic |> _.Diastolic })
 
-  /// Groups readings by local calendar date and returns one averaged reading per day,
-  /// sorted ascending. The returned reading's Timestamp is midnight of that local date.
-  /// Comments are dropped (not meaningful for averages).
+  let private dailyAveragesWithCount =
+    buildAggregated (fun r -> r.Timestamp.ToLocalTime().Date) id
+
+  /// Groups readings by local calendar date, sorted ascending.
+  /// The returned reading's Timestamp is midnight of that local date. Comments are dropped.
   let dailyAverages (readings: BloodPressureReading list) : BloodPressureReading list =
     dailyAveragesWithCount readings |> List.map _.Reading
 
-  /// Groups readings by ISO week and returns one averaged reading per week
-  /// together with the raw reading count, sorted ascending.
-  /// The returned reading's Timestamp is Monday midnight of that week.
-  /// Comments are dropped.
-  let private weeklyAveragesWithCount (readings: BloodPressureReading list) : AggregatedReading list =
-    readings
-    |> List.groupBy (fun r -> IsoWeek.ofDate (r.Timestamp.ToLocalTime().Date))
-    |> List.sortBy fst
-    |> List.map (fun (w, rs) ->
-      let n = List.length rs
-      let monday = IsoWeek.monday w
-      let offset = TimeZoneInfo.Local.GetUtcOffset(monday)
+  let private weeklyAveragesWithCount =
+    buildAggregated (fun r -> IsoWeek.ofDate (r.Timestamp.ToLocalTime().Date)) IsoWeek.monday
 
-      { Reading =
-          { Id = 0
-            MemberId = 0
-            Systolic = rs |> List.sumBy _.Systolic |> (fun s -> s / n)
-            Diastolic = rs |> List.sumBy _.Diastolic |> (fun s -> s / n)
-            HeartRate = rs |> List.sumBy _.HeartRate |> (fun s -> s / n)
-            Timestamp = DateTimeOffset(monday, offset)
-            Comments = None
-            CreatedAt = DateTimeOffset.MinValue
-            ModifiedAt = DateTimeOffset.MinValue }
-        Count = n
-        MinSystolic = rs |> List.minBy _.Systolic |> _.Systolic
-        MaxSystolic = rs |> List.maxBy _.Systolic |> _.Systolic
-        MinDiastolic = rs |> List.minBy _.Diastolic |> _.Diastolic
-        MaxDiastolic = rs |> List.maxBy _.Diastolic |> _.Diastolic })
-
-  /// Groups readings by ISO week and returns one averaged reading per week,
-  /// sorted ascending. The returned reading's Timestamp is Monday midnight of that week.
-  /// Comments are dropped.
+  /// Groups readings by ISO week, sorted ascending.
+  /// The returned reading's Timestamp is Monday midnight of that week. Comments are dropped.
   let weeklyAverages (readings: BloodPressureReading list) : BloodPressureReading list =
     weeklyAveragesWithCount readings |> List.map _.Reading
 
-  /// Groups readings by calendar month and returns one averaged reading per month
-  /// together with the raw reading count, sorted ascending.
-  /// The returned reading's Timestamp is the 1st of that month midnight.
-  /// Comments are dropped.
-  let private monthlyAveragesWithCount (readings: BloodPressureReading list) : AggregatedReading list =
-    readings
-    |> List.groupBy (fun r ->
-      let d = r.Timestamp.ToLocalTime().Date
-      { Year = d.Year; Month = d.Month })
-    |> List.sortBy fst
-    |> List.map (fun (ym, rs) ->
-      let n = List.length rs
-      let firstOfMonth = DateTime(ym.Year, ym.Month, 1)
-      let offset = TimeZoneInfo.Local.GetUtcOffset(firstOfMonth)
+  let private monthlyAveragesWithCount =
+    buildAggregated
+      (fun r ->
+        let d = r.Timestamp.ToLocalTime().Date
+        { Year = d.Year; Month = d.Month })
+      (fun ym -> DateTime(ym.Year, ym.Month, 1))
 
-      { Reading =
-          { Id = 0
-            MemberId = 0
-            Systolic = rs |> List.sumBy _.Systolic |> (fun s -> s / n)
-            Diastolic = rs |> List.sumBy _.Diastolic |> (fun s -> s / n)
-            HeartRate = rs |> List.sumBy _.HeartRate |> (fun s -> s / n)
-            Timestamp = DateTimeOffset(firstOfMonth, offset)
-            Comments = None
-            CreatedAt = DateTimeOffset.MinValue
-            ModifiedAt = DateTimeOffset.MinValue }
-        Count = n
-        MinSystolic = rs |> List.minBy _.Systolic |> _.Systolic
-        MaxSystolic = rs |> List.maxBy _.Systolic |> _.Systolic
-        MinDiastolic = rs |> List.minBy _.Diastolic |> _.Diastolic
-        MaxDiastolic = rs |> List.maxBy _.Diastolic |> _.Diastolic })
-
-  /// Groups readings by calendar month and returns one averaged reading per month,
-  /// sorted ascending. The returned reading's Timestamp is the 1st of that month midnight.
-  /// Comments are dropped.
+  /// Groups readings by calendar month, sorted ascending.
+  /// The returned reading's Timestamp is the 1st of that month midnight. Comments are dropped.
   let monthlyAverages (readings: BloodPressureReading list) : BloodPressureReading list =
     monthlyAveragesWithCount readings |> List.map _.Reading
 

--- a/code/BpMonitor.Core/TrendPeriod.fs
+++ b/code/BpMonitor.Core/TrendPeriod.fs
@@ -199,18 +199,17 @@ module TrendPeriod =
 
   /// Fixed-window list of periods ending at the current one, in chronological order
   /// (oldest first, newest/current last). Window sizes: Weekly = 12, Monthly = 12, Yearly = 5.
-  let available (gran: Granularity) (now: DateTimeOffset) (_readings: BloodPressureReading list) : TrendPeriod list =
+  let available (gran: Granularity) (now: DateTimeOffset) : TrendPeriod list =
     let windowSize =
       match gran with
       | Weekly -> 12
       | Monthly -> 12
       | Yearly -> 5
 
-    // Collect periods going backwards from current, then reverse for chronological order.
-    // acc head is always the most recently collected period (starts at current).
+    // Walk backwards from current, prepending each older period; result is oldest-first.
     let rec collect (p: TrendPeriod) (remaining: int) (acc: TrendPeriod list) =
       if remaining = 0 then
-        acc // acc = [curr, prev, prev-1, ..., oldest] — reverse below
+        acc
       else
         let prevKey = (current gran (p.Start.AddDays(-1.0))).Key
 
@@ -219,7 +218,4 @@ module TrendPeriod =
         | Some prev -> collect prev (remaining - 1) (prev :: acc)
 
     let curr = current gran now
-    // Build [oldest, ..., prev, curr] — collect walks backwards then we get oldest-first naturally
-    // because each older period is prepended.
-    // acc = [oldest, ..., prev, curr] because each older period is prepended
     collect curr (windowSize - 1) [ curr ]

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -323,8 +323,8 @@ module Handlers =
 
         let theme =
           match ctx.Request.Query.TryGetValue "theme" with
-          | true, v when string v = "dark" -> "dark"
-          | _ -> "light"
+          | true, v when string v = "dark" -> Dark
+          | _ -> Light
 
         let granStr =
           match ctx.Request.Query.TryGetValue "gran" with
@@ -364,7 +364,7 @@ module Handlers =
         let period = TrendPeriod.current Weekly now
         let windowed = allReadings |> ReadingStats.between period.Start period.EndExclusive
         let summary = ReadingStats.summarizeRange period windowed
-        let periods = TrendPeriod.available Weekly now allReadings
+        let periods = TrendPeriod.available Weekly now
 
         let tableReadings = windowed |> List.sortByDescending _.Timestamp
 
@@ -392,7 +392,7 @@ module Handlers =
 
           let windowed = allReadings |> ReadingStats.between period.Start period.EndExclusive
           let summary = ReadingStats.summarizeRange period windowed
-          let periods = TrendPeriod.available gran now allReadings
+          let periods = TrendPeriod.available gran now
           let tableReadings = windowed |> List.sortByDescending _.Timestamp
 
           htmlResponse (Views.trendsPanel summary periods tableReadings) ctx


### PR DESCRIPTION
## Summary

- Add `Theme = Dark | Light` DU to `BpMonitor.Charts` namespace; replace all bare `theme = "dark"` string comparisons in `Charts.fs`; update public `toHtml`/`toHtmlDashed` signatures, the `?theme=` query-param parse in `Handlers.fs`, and `ChartsTests.fs` call sites
- Collapse `dailyAveragesWithCount` / `weeklyAveragesWithCount` / `monthlyAveragesWithCount` in `ReadingStats.fs` into one `buildAggregated` helper parameterised by `keyOf` and `dateOf`, eliminating ~60 lines of duplicated `AggregatedReading` construction
- Drop the dead `_readings: BloodPressureReading list` parameter from `TrendPeriod.available` (the window is purely date-driven); update call sites in `Handlers.fs` and `TrendPeriodTests.fs`; remove the now-redundant "readings parameter does not affect result" test