### PR TITLE
🔧 chore: tooling and build consistency fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 *.verified.txt text eol=lf
 *.verified.xml text eol=lf
 *.verified.json text eol=lf

--- a/code/BpMonitor.Charts.Tests/BpMonitor.Charts.Tests.fsproj
+++ b/code/BpMonitor.Charts.Tests/BpMonitor.Charts.Tests.fsproj
@@ -1,7 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -10,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Unquote" />
     <PackageReference Include="Verify.XunitV3" />

--- a/code/BpMonitor.Charts/BpMonitor.Charts.fsproj
+++ b/code/BpMonitor.Charts/BpMonitor.Charts.fsproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <Compile Include="Charts.fs" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Plotly.NET" />
   </ItemGroup>
 

--- a/code/BpMonitor.Core/BpMonitor.Core.fsproj
+++ b/code/BpMonitor.Core/BpMonitor.Core.fsproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" />
     <PackageReference Include="FsToolkit.ErrorHandling" />
   </ItemGroup>
 

--- a/code/BpMonitor.Data/BpMonitor.Data.fsproj
+++ b/code/BpMonitor.Data/BpMonitor.Data.fsproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -24,9 +24,6 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
   </ItemGroup>
-  <ItemGroup Label="Configuration">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-  </ItemGroup>
   <ItemGroup Label="Test">
     <PackageVersion Include="Unquote" Version="7.0.1" />
     <PackageVersion Include="TngTech.ArchUnitNET.xUnit" Version="0.13.3" />


### PR DESCRIPTION
## Summary
- Strip UTF-8 BOM from `BpMonitor.Charts.fsproj` and `BpMonitor.Charts.Tests.fsproj` (violated `.editorconfig` `charset=utf-8` without BOM)
- Add `FSharp.Core` `PackageReference` to `BpMonitor.Core`, `BpMonitor.Data`, `BpMonitor.Charts`, `BpMonitor.Charts.Tests` — all 13 projects now declare it explicitly; version pinned centrally in `Directory.Packages.props`
- Remove redundant `<TargetFramework>net10.0</TargetFramework>` from `BpMonitor.Charts.Tests.fsproj` — already set globally in `Directory.Build.props`; no other test project restates it
- Add `* text=auto eol=lf` baseline rule to `.gitattributes` to match `.editorconfig` `end_of_line=lf`
- Remove unused `Microsoft.Extensions.Configuration.Json` entry from `Directory.Packages.props` — confirmed unreferenced in any project file