### PR TITLE
✅ test: add arch rules and standardize test module naming

### DIFF
--- a/code/BpMonitor.Arch.Tests/ArchitectureTests.fs
+++ b/code/BpMonitor.Arch.Tests/ArchitectureTests.fs
@@ -108,3 +108,28 @@ let ``Import should not depend on Web`` () =
 let ``Export should not depend on Web`` () =
   let rule = exportTypes.Should().NotDependOnAny(webTypes)
   ArchRuleAssert.CheckRule(architecture, rule)
+
+[<Fact>]
+let ``Web should not depend on Import`` () =
+  let rule = webTypes.Should().NotDependOnAny(importTypes)
+  ArchRuleAssert.CheckRule(architecture, rule)
+
+[<Fact>]
+let ``Web should not depend on Export`` () =
+  let rule = webTypes.Should().NotDependOnAny(exportTypes)
+  ArchRuleAssert.CheckRule(architecture, rule)
+
+[<Fact>]
+let ``Core should not depend on Charts`` () =
+  let rule = coreTypes.Should().NotDependOnAny(chartsTypes)
+  ArchRuleAssert.CheckRule(architecture, rule)
+
+[<Fact>]
+let ``Core should not depend on Import`` () =
+  let rule = coreTypes.Should().NotDependOnAny(importTypes)
+  ArchRuleAssert.CheckRule(architecture, rule)
+
+[<Fact>]
+let ``Core should not depend on Export`` () =
+  let rule = coreTypes.Should().NotDependOnAny(exportTypes)
+  ArchRuleAssert.CheckRule(architecture, rule)

--- a/code/BpMonitor.Core.Tests/BloodPressureReadingPropertyTests.fs
+++ b/code/BpMonitor.Core.Tests/BloodPressureReadingPropertyTests.fs
@@ -1,10 +1,10 @@
-module BpMonitor.Core.Tests.BloodPressureReadingPropertyTests
+module BloodPressureReadingPropertyTests
 
 open System
 open FsCheck.FSharp
 open FsCheck.Xunit
 open BpMonitor.Core
-open BpMonitor.Core.Tests.Generators
+open Generators
 
 let private inRange lo hi v = v >= lo && v <= hi
 

--- a/code/BpMonitor.Core.Tests/Generators.fs
+++ b/code/BpMonitor.Core.Tests/Generators.fs
@@ -1,4 +1,4 @@
-module BpMonitor.Core.Tests.Generators
+module Generators
 
 open System
 open FsCheck

--- a/code/BpMonitor.Core.Tests/TrendPeriodTests.fs
+++ b/code/BpMonitor.Core.Tests/TrendPeriodTests.fs
@@ -8,17 +8,6 @@ open BpMonitor.Core
 // Fixed "now" = Tuesday 2026-06-09 12:00 UTC (ISO week 24 of 2026, June, 2026)
 let private now = DateTimeOffset(2026, 6, 9, 12, 0, 0, TimeSpan.Zero)
 
-let private mkReading id (ts: DateTimeOffset) =
-  { Id = id
-    MemberId = 1
-    Systolic = 120
-    Diastolic = 80
-    HeartRate = 70
-    Timestamp = ts
-    Comments = None
-    CreatedAt = DateTimeOffset.MinValue
-    ModifiedAt = DateTimeOffset.MinValue }
-
 // ── slug / parseGranularity ────────────────────────────────────────────────────
 
 [<Fact>]

--- a/code/BpMonitor.Export.Tests/JsonExportTests.fs
+++ b/code/BpMonitor.Export.Tests/JsonExportTests.fs
@@ -1,4 +1,4 @@
-module BpMonitor.Export.Tests.JsonExportTests
+module JsonExportTests
 
 open System
 open System.IO

--- a/code/BpMonitor.Import.Tests/Generators.fs
+++ b/code/BpMonitor.Import.Tests/Generators.fs
@@ -1,4 +1,4 @@
-module BpMonitor.Import.Tests.Generators
+module Generators
 
 open System
 open FsCheck

--- a/code/BpMonitor.Import.Tests/ImportPropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/ImportPropertyTests.fs
@@ -1,11 +1,11 @@
-module BpMonitor.Import.Tests.ImportPropertyTests
+module ImportPropertyTests
 
 open FsCheck.FSharp
 open FsCheck.Xunit
 open BpMonitor.Core
 open BpMonitor.Data
 open BpMonitor.Import
-open BpMonitor.Import.Tests.Generators
+open Generators
 
 let private defaultMemberId = 1
 

--- a/code/BpMonitor.Import.Tests/JsonImportTests.fs
+++ b/code/BpMonitor.Import.Tests/JsonImportTests.fs
@@ -1,4 +1,4 @@
-module BpMonitor.Import.Tests.JsonImportTests
+module JsonImportTests
 
 open System
 open System.IO

--- a/code/BpMonitor.Import.Tests/JsonRoundTripPropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/JsonRoundTripPropertyTests.fs
@@ -1,10 +1,10 @@
-module BpMonitor.Import.Tests.JsonRoundTripPropertyTests
+module JsonRoundTripPropertyTests
 
 open FsCheck.FSharp
 open FsCheck.Xunit
 open BpMonitor.Export
 open BpMonitor.Import
-open BpMonitor.Import.Tests.Generators
+open Generators
 
 [<Property>]
 let ``serialize then parse round-trips a reading list`` () =

--- a/code/BpMonitor.Import.Tests/MarkdownImportTests.fs
+++ b/code/BpMonitor.Import.Tests/MarkdownImportTests.fs
@@ -1,4 +1,4 @@
-module BpMonitor.Import.Tests.MarkdownImportTests
+module MarkdownImportTests
 
 open System
 open BpMonitor.Core

--- a/code/BpMonitor.Import.Tests/MarkdownParseLinePropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/MarkdownParseLinePropertyTests.fs
@@ -1,10 +1,10 @@
-module BpMonitor.Import.Tests.MarkdownParseLinePropertyTests
+module MarkdownParseLinePropertyTests
 
 open FsCheck.FSharp
 open FsCheck.Xunit
 open BpMonitor.Core
 open BpMonitor.Import.MarkdownImport
-open BpMonitor.Import.Tests.Generators
+open Generators
 
 let private renderLine (c: MarkdownLineCase) =
   let suffix =

--- a/code/BpMonitor.Import.Tests/ParseMarkdownPropertyTests.fs
+++ b/code/BpMonitor.Import.Tests/ParseMarkdownPropertyTests.fs
@@ -1,10 +1,10 @@
-module BpMonitor.Import.Tests.ParseMarkdownPropertyTests
+module ParseMarkdownPropertyTests
 
 open FsCheck.FSharp
 open FsCheck.Xunit
 open BpMonitor.Core
 open BpMonitor.Import.MarkdownImport
-open BpMonitor.Import.Tests.Generators
+open Generators
 
 let private render (items: DocItem list) =
   items |> List.map renderDocLine |> String.concat "\n"


### PR DESCRIPTION
## Summary
- Add 5 new architecture rules to `ArchitectureTests.fs`: `Web↛Import`, `Web↛Export`, `Core↛Charts`, `Core↛Import`, `Core↛Export` — enforces intentional isolation that was previously only true by accident; total rules 13 → 18
- Standardize all test module declarations to bare names (was split: Import.Tests and Export.Tests used `module BpMonitor.X.Tests.Y`, Core.Tests mixed bare and qualified within the same project); 10 files updated, consumer `open BpMonitor.*.Tests.Generators` calls updated to `open Generators`
- Remove dead `mkReading` fixture from `TrendPeriodTests.fs` — became unused when the `_readings` parameter was dropped from `TrendPeriod.available` (PR #182)