### PR TITLE
✨ feat: add JSON export endpoint to web UI

### DIFF
--- a/code/BpMonitor.Arch.Tests/ArchitectureTests.fs
+++ b/code/BpMonitor.Arch.Tests/ArchitectureTests.fs
@@ -115,11 +115,6 @@ let ``Web should not depend on Import`` () =
   ArchRuleAssert.CheckRule(architecture, rule)
 
 [<Fact>]
-let ``Web should not depend on Export`` () =
-  let rule = webTypes.Should().NotDependOnAny(exportTypes)
-  ArchRuleAssert.CheckRule(architecture, rule)
-
-[<Fact>]
 let ``Core should not depend on Charts`` () =
   let rule = coreTypes.Should().NotDependOnAny(chartsTypes)
   ArchRuleAssert.CheckRule(architecture, rule)

--- a/code/BpMonitor.Web.Tests/HandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerTests.fs
@@ -649,3 +649,43 @@ let ``trendsPanel with invalid gran string returns 400`` () =
   TestHost.run Handlers.trendsPanel ctx
 
   test <@ ctx.Response.StatusCode = 400 @>
+
+// ─── Export handler tests ─────────────────────────────────────────────────────
+
+[<Fact>]
+let ``exportJson returns 200 with application/json content type`` () =
+  let ctx = TestHost.context (repoWith [ sample ])
+  TestHost.run Handlers.exportJson ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  test <@ ctx.Response.ContentType = "application/json; charset=utf-8" @>
+
+[<Fact>]
+let ``exportJson sets Content-Disposition to attachment with correct filename`` () =
+  let ctx = TestHost.context (repoWith [ sample ])
+  TestHost.run Handlers.exportJson ctx
+
+  let disposition = ctx.Response.Headers["Content-Disposition"].ToString()
+  test <@ disposition = "attachment; filename=\"bpmonitor-export.json\"" @>
+
+[<Fact>]
+let ``exportJson body contains the seeded reading's fields`` () =
+  let ctx = TestHost.context (repoWith [ sample ])
+  TestHost.run Handlers.exportJson ctx
+
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "\"systolic\":120" @>
+  test <@ body.Contains "\"diastolic\":80" @>
+  test <@ body.Contains "\"heartRate\":66" @>
+
+[<Fact>]
+let ``exportJson returns only the active member's readings`` () =
+  let otherMemberReading = { sample with Id = 2; MemberId = 999 }
+
+  let repo = repoWith [ sample; otherMemberReading ]
+  let ctx = TestHost.context repo
+  TestHost.run Handlers.exportJson ctx
+
+  let body = TestHost.readBody ctx
+  // Only one object in the array — the repo filters by memberId
+  test <@ body.StartsWith "[{" && body.EndsWith "}]" @>

--- a/code/BpMonitor.Web/BpMonitor.Web.fsproj
+++ b/code/BpMonitor.Web/BpMonitor.Web.fsproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\BpMonitor.Charts\BpMonitor.Charts.fsproj" />
     <ProjectReference Include="..\BpMonitor.Core\BpMonitor.Core.fsproj" />
     <ProjectReference Include="..\BpMonitor.Data\BpMonitor.Data.fsproj" />
+    <ProjectReference Include="..\BpMonitor.Export\BpMonitor.Export.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/code/BpMonitor.Web/Handlers.fs
+++ b/code/BpMonitor.Web/Handlers.fs
@@ -12,6 +12,7 @@ open Microsoft.Extensions.Logging
 open Falco.Markup
 open BpMonitor.Core
 open BpMonitor.Charts
+open BpMonitor.Export
 
 /// Falco HttpHandlers. Each resolves the per-request scoped repository from DI,
 /// reuses Core validation, and renders Falco.Markup views.
@@ -220,7 +221,7 @@ module Handlers =
       if PasswordHashing.verify password hash then
         log.LogInformation("Member {Name} (Id={Id}) logged in", m.Name, m.Id)
         do! ctx.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, claimsPrincipal m)
-        ctx.Response.Redirect "/"
+        ctx.Response.Redirect Routes.home
       else
         log.LogWarning("Failed login attempt for member {Name} (Id={Id})", m.Name, m.Id)
         ctx.Response.StatusCode <- 401
@@ -244,7 +245,7 @@ module Handlers =
         (memberRepo ctx).Update(claimed)
         log.LogInformation("Member {Name} (Id={Id}) claimed their account", m.Name, m.Id)
         do! ctx.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, claimsPrincipal claimed)
-        ctx.Response.Redirect "/"
+        ctx.Response.Redirect Routes.home
     }
     :> Task
 
@@ -401,17 +402,17 @@ module Handlers =
 
       htmlResponse
         (ReadingViews.readingForm
-          "/add"
+          Routes.add
           (m |> Option.map _.Name |> Option.defaultValue "")
           (m |> Option.exists _.IsAdmin)
           "Add reading"
-          "/readings"
+          Routes.readings
           []
           prefill)
         ctx
 
   let createReading: HttpContext -> Task =
-    withMember (fun m ctx -> submit ctx "/add" m.Name m.IsAdmin "Add reading" "/readings" ((repo ctx).Add m.Id))
+    withMember (fun m ctx -> submit ctx Routes.add m.Name m.IsAdmin "Add reading" Routes.readings ((repo ctx).Add m.Id))
 
   let editReading: HttpContext -> Task =
     withMember (fun m ctx ->
@@ -442,6 +443,13 @@ module Handlers =
       | Some id ->
         submit ctx "" m.Name m.IsAdmin "Edit reading" $"/readings/{id}" (fun r ->
           (repo ctx).Update { r with Id = id; MemberId = m.Id }))
+
+  let exportJson: HttpContext -> Task =
+    withMember (fun m ctx ->
+      let json = JsonExport.serialize ((repo ctx).GetAll(m.Id))
+      ctx.Response.ContentType <- "application/json; charset=utf-8"
+      ctx.Response.Headers.Append("Content-Disposition", "attachment; filename=\"bpmonitor-export.json\"")
+      ctx.Response.WriteAsync json)
 
   // ---------------------------------------------------------------------------
   // Member management (all protectAdmin — must be admin)

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -16,25 +16,26 @@ open BpMonitor.Web
 
 let private endpoints =
   [ // Anonymous: login/logout
-    get "/login" Handlers.loginPage
-    post "/login" Handlers.loginWithCredentials
+    get Routes.login Handlers.loginPage
+    post Routes.login Handlers.loginWithCredentials
     get "/login/{id:int}" Handlers.loginMember
     post "/login/{id:int}" Handlers.loginSubmit
-    post "/logout" Handlers.logout
+    post Routes.logout Handlers.logout
     // Authenticated: reading CRUD + app pages
-    get "/" (Handlers.protect Handlers.landing)
-    get "/add" (Handlers.protect Handlers.newReading)
-    get "/history" (Handlers.protect Handlers.history)
-    get "/chart" (Handlers.protect Handlers.chart)
-    get "/trends" (Handlers.protect Handlers.trends)
+    get Routes.home (Handlers.protect Handlers.landing)
+    get Routes.add (Handlers.protect Handlers.newReading)
+    get Routes.history (Handlers.protect Handlers.history)
+    get Routes.chart (Handlers.protect Handlers.chart)
+    get Routes.trends (Handlers.protect Handlers.trends)
     get "/trends/{gran}" (Handlers.protect Handlers.trendsPanel)
     get "/trends/{gran}/{key}" (Handlers.protect Handlers.trendsPanel)
-    post "/readings" (Handlers.protect Handlers.createReading)
+    get Routes.export (Handlers.protect Handlers.exportJson)
+    post Routes.readings (Handlers.protect Handlers.createReading)
     get "/readings/{id:int}/edit" (Handlers.protect Handlers.editReading)
     post "/readings/{id:int}" (Handlers.protect Handlers.updateReading)
     // Admin-only: member management
-    get "/members" (Handlers.protectAdmin Handlers.members)
-    post "/members" (Handlers.protectAdmin Handlers.createMember)
+    get Routes.members (Handlers.protectAdmin Handlers.members)
+    post Routes.members (Handlers.protectAdmin Handlers.createMember)
     get "/members/{id:int}/edit" (Handlers.protectAdmin Handlers.editMember)
     post "/members/{id:int}" (Handlers.protectAdmin Handlers.updateMember)
     post "/members/{id:int}/reset-password" (Handlers.protectAdmin Handlers.resetPassword) ]

--- a/code/BpMonitor.Web/Routes.fs
+++ b/code/BpMonitor.Web/Routes.fs
@@ -2,6 +2,13 @@ namespace BpMonitor.Web
 
 /// Navigation targets used in redirects and links — single source of truth.
 module Routes =
+  let home = "/"
   let login = "/login"
+  let logout = "/logout"
+  let add = "/add"
   let history = "/history"
+  let chart = "/chart"
+  let trends = "/trends"
+  let readings = "/readings"
   let members = "/members"
+  let export = "/export"

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -42,10 +42,14 @@ module ViewLayout =
               [ Elem.ul
                   []
                   [ Elem.li [] [ Elem.strong [] [ Text.raw "BpMonitor" ] ]
-                    navLink active "/" "Home"
-                    navLink active "/add" "Add"
+                    navLink active Routes.home "Home"
+                    navLink active Routes.add "Add"
                     navLink active Routes.history "History"
-                    navLink active "/trends" "Trends"
+                    navLink active Routes.trends "Trends"
+                    // hx-boost="false" prevents htmx from AJAX-swapping the download response.
+                    Elem.li
+                      []
+                      [ Elem.a [ Attr.href Routes.export; Attr.create "hx-boost" "false" ] [ Text.raw "Export" ] ]
                     if isAdmin then
                       navLink active Routes.members "Members" ]
                 Elem.ul


### PR DESCRIPTION
## Summary
- Adds `GET /export` — downloads the active member's readings as `bpmonitor-export.json` using the existing `JsonExport.serialize` from `BpMonitor.Export`
- Adds an **Export** nav link with `hx-boost="false"` so htmx does not intercept the file download
- Extends `Routes` module to cover all simple routes, replacing hardcoded string literals throughout `Program.fs`, `Handlers.fs`, and `ViewLayout.fs`
- Removes the `Web should not depend on Export` arch rule, which guarded against accidental coupling (now intentional)
- 4 new handler tests: Content-Type, Content-Disposition attachment header, body shape, and member scoping