### PR TITLE
✨ feat: add Simpson-family demo dataset with config-gated seed-on-empty

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,25 @@ dotnet test
 dotnet run --project code/BpMonitor.Web
 ```
 
+## Demo data (Simpson family)
+
+For developer onboarding and demos, a pre-built Simpson-family dataset can be
+seeded into a fresh database. It covers ~5 years of readings with per-member
+personalities so all features render richly out of the box:
+
+```bash
+# Remove any existing DB and start fresh with the Simpson family
+rm -f code/BpMonitor.Web/bpmonitor.db*
+BpMonitor__SeedDemoData=true dotnet run --project code/BpMonitor.Web
+```
+
+The flag is **off by default** — production databases are never touched. Seeding
+only runs when the database is empty, so a second run with the flag is a no-op.
+
+Members are seeded **unclaimed** (no password). Use the first-login flow at
+`http://localhost:5000/login` to claim a member and set a password. Marge
+Simpson is the admin.
+
 ## Project structure
 
 The solution is split into focused projects under `code/` — Core domain, Data

--- a/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
+++ b/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="TrendPeriodTests.fs" />
     <Compile Include="ReadingStatsTests.fs" />
     <Compile Include="PasswordHashingTests.fs" />
+    <Compile Include="DemoDataTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Core.Tests/DemoDataTests.fs
+++ b/code/BpMonitor.Core.Tests/DemoDataTests.fs
@@ -1,0 +1,104 @@
+module DemoDataTests
+
+open System
+open Xunit
+open Swensen.Unquote
+open BpMonitor.Core
+
+let private ranges = ReadingRanges.defaults
+let private now = DateTimeOffset(2026, 6, 14, 12, 0, 0, TimeSpan.Zero)
+
+// ── member shape ─────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``simpsons produces exactly 5 member entries`` () =
+  let result = DemoData.simpsons ranges now
+  test <@ result.Length = 5 @>
+
+[<Fact>]
+let ``simpsons has exactly one admin member`` () =
+  let result = DemoData.simpsons ranges now
+  let admins = result |> List.filter (fun (spec, _) -> spec.IsAdmin)
+  test <@ admins.Length = 1 @>
+
+[<Fact>]
+let ``simpsons admin is Marge Simpson`` () =
+  let result = DemoData.simpsons ranges now
+  let (spec, _) = result |> List.find (fun (spec, _) -> spec.IsAdmin)
+  test <@ spec.Name = "Marge Simpson" @>
+
+// ── reading validity ──────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``all generated readings are in range (no parse errors)`` () =
+  let result = DemoData.simpsons ranges now
+
+  for (spec, readings) in result do
+    for r in readings do
+      test
+        <@
+          r.Systolic >= ranges.SystolicMin
+          && r.Systolic <= ranges.SystolicMax
+          && r.Diastolic >= ranges.DiastolicMin
+          && r.Diastolic <= ranges.DiastolicMax
+          && r.HeartRate >= ranges.HeartRateMin
+          && r.HeartRate <= ranges.HeartRateMax
+        @>
+
+// ── timestamp span ────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``readings span roughly 5 years`` () =
+  let result = DemoData.simpsons ranges now
+  let allReadings = result |> List.collect snd
+  let earliest = allReadings |> List.map _.Timestamp |> List.min
+  let latest = allReadings |> List.map _.Timestamp |> List.max
+  let spanDays = (latest - earliest).TotalDays
+  // Expect at least 4 years of spread across all members
+  test <@ spanDays >= 4.0 * 365.0 @>
+
+[<Fact>]
+let ``readings end at or before the anchor time`` () =
+  let result = DemoData.simpsons ranges now
+  let allReadings = result |> List.collect snd
+  let latest = allReadings |> List.map _.Timestamp |> List.max
+  test <@ latest <= now @>
+
+// ── determinism ──────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``same anchor produces identical results (deterministic)`` () =
+  let r1 = DemoData.simpsons ranges now
+  let r2 = DemoData.simpsons ranges now
+  let counts1 = r1 |> List.map (fun (s, rs) -> s.Name, rs.Length)
+  let counts2 = r2 |> List.map (fun (s, rs) -> s.Name, rs.Length)
+  test <@ counts1 = counts2 @>
+
+// ── member profiles are distinct ──────────────────────────────────────────────
+
+[<Fact>]
+let ``Homer mean systolic is higher than Marge mean systolic`` () =
+  let result = DemoData.simpsons ranges now
+
+  let meanSys name =
+    let (_, readings) = result |> List.find (fun (s, _) -> s.Name = name)
+    readings |> List.averageBy (fun r -> float r.Systolic)
+
+  test <@ meanSys "Homer Simpson" > meanSys "Marge Simpson" @>
+
+[<Fact>]
+let ``Marge mean systolic is higher than Bart mean systolic`` () =
+  let result = DemoData.simpsons ranges now
+
+  let meanSys name =
+    let (_, readings) = result |> List.find (fun (s, _) -> s.Name = name)
+    readings |> List.averageBy (fun r -> float r.Systolic)
+
+  test <@ meanSys "Marge Simpson" > meanSys "Bart Simpson" @>
+
+[<Fact>]
+let ``each member has enough readings for trend granularities`` () =
+  let result = DemoData.simpsons ranges now
+  // Minimum: expect at least 52 readings per member (roughly 1 per week for a year)
+  for (spec, readings) in result do
+    test <@ readings.Length >= 52 @>

--- a/code/BpMonitor.Core/BpMonitor.Core.fsproj
+++ b/code/BpMonitor.Core/BpMonitor.Core.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="PasswordHashing.fs" />
     <Compile Include="IFamilyMemberRepository.fs" />
     <Compile Include="BloodPressureReading.fs" />
+    <Compile Include="DemoData.fs" />
     <Compile Include="TrendPeriod.fs" />
     <Compile Include="ReadingStats.fs" />
     <Compile Include="IReadingRepository.fs" />

--- a/code/BpMonitor.Core/DemoData.fs
+++ b/code/BpMonitor.Core/DemoData.fs
@@ -1,0 +1,176 @@
+namespace BpMonitor.Core
+
+open System
+
+/// A lightweight descriptor for a family member used by the demo-data generator.
+/// The seeder (BpMonitor.Data.DemoSeeder) converts these into real FamilyMember records.
+type MemberSpec = { Name: string; IsAdmin: bool }
+
+/// Deterministic demo-data generator — the Simpson family.
+///
+/// All generation is pure (no I/O). A per-member fixed Random seed ensures
+/// identical output for the same `now` value across multiple calls.
+module DemoData =
+
+  // ── internal profile definition ──────────────────────────────────────────
+
+  [<NoComparison; NoEquality>]
+  type private Profile =
+    {
+      Spec: MemberSpec
+      SysBase: int
+      SysJitter: int
+      DiaBase: int
+      DiaJitter: int
+      HrBase: int
+      HrJitter: int
+      /// Average readings emitted per week.
+      ReadingsPerWeek: float
+      /// Rotating comment pool; None entries produce no comment.
+      Comments: string option list
+      /// Fixed seed so generation is reproducible.
+      RandomSeed: int
+    }
+
+  let private profiles =
+    [ { Spec =
+          { Name = "Marge Simpson"
+            IsAdmin = true }
+        SysBase = 118
+        SysJitter = 6
+        DiaBase = 76
+        DiaJitter = 4
+        HrBase = 68
+        HrJitter = 5
+        ReadingsPerWeek = 3.5
+        Comments = [ None; Some "morning"; Some "after yoga"; None; Some "calm day"; None ]
+        RandomSeed = 1 }
+      { Spec =
+          { Name = "Homer Simpson"
+            IsAdmin = false }
+        SysBase = 152
+        SysJitter = 12
+        DiaBase = 96
+        DiaJitter = 8
+        HrBase = 82
+        HrJitter = 8
+        ReadingsPerWeek = 5.0
+        Comments =
+          [ None
+            Some "after donuts"
+            Some "Duff o'clock"
+            None
+            Some "stressful day at work"
+            Some "mmm beer"
+            None
+            None ]
+        RandomSeed = 2 }
+      { Spec =
+          { Name = "Bart Simpson"
+            IsAdmin = false }
+        SysBase = 108
+        SysJitter = 5
+        DiaBase = 68
+        DiaJitter = 4
+        HrBase = 74
+        HrJitter = 6
+        ReadingsPerWeek = 1.5
+        Comments = [ None; None; Some "after skateboarding"; None ]
+        RandomSeed = 3 }
+      { Spec =
+          { Name = "Lisa Simpson"
+            IsAdmin = false }
+        SysBase = 110
+        SysJitter = 4
+        DiaBase = 70
+        DiaJitter = 3
+        HrBase = 67
+        HrJitter = 5
+        ReadingsPerWeek = 1.5
+        Comments = [ None; Some "before recital"; None; Some "morning meditation"; None ]
+        RandomSeed = 4 }
+      { Spec =
+          { Name = "Abe Simpson"
+            IsAdmin = false }
+        SysBase = 145
+        SysJitter = 14
+        DiaBase = 88
+        DiaJitter = 9
+        HrBase = 63
+        HrJitter = 7
+        ReadingsPerWeek = 2.0
+        Comments = [ None; None; Some "after nap"; Some "feeling dizzy"; None; None ]
+        RandomSeed = 5 } ]
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  let private clamp lo hi v = max lo (min hi v)
+
+  // ── reading generation ────────────────────────────────────────────────────
+
+  let private generateReadings (ranges: ReadingRanges) (now: DateTimeOffset) (profile: Profile) =
+    let rng = Random(profile.RandomSeed)
+    let spanDays = int (365.25 * 5.0) // ≈ 1826 days
+    let startDate = now.AddDays(float -spanDays)
+    let probPerDay = profile.ReadingsPerWeek / 7.0
+
+    [ 0 .. spanDays - 1 ]
+    |> List.choose (fun dayOffset ->
+      if rng.NextDouble() >= probPerDay then
+        None
+      else
+        let date = startDate.AddDays(float dayOffset)
+
+        // Guard: skip if the date/time arithmetic would exceed now (edge of window).
+        if date > now then
+          None
+        else
+          let hour = rng.Next(6, 21)
+          let minute = rng.Next(0, 60)
+
+          // Use UTC so readings are timezone-neutral.
+          let ts =
+            DateTimeOffset(date.Year, date.Month, date.Day, hour, minute, 0, TimeSpan.Zero)
+
+          let sys =
+            clamp
+              ranges.SystolicMin
+              ranges.SystolicMax
+              (profile.SysBase + rng.Next(-profile.SysJitter, profile.SysJitter + 1))
+
+          let dia =
+            clamp
+              ranges.DiastolicMin
+              ranges.DiastolicMax
+              (profile.DiaBase + rng.Next(-profile.DiaJitter, profile.DiaJitter + 1))
+
+          let hr =
+            clamp
+              ranges.HeartRateMin
+              ranges.HeartRateMax
+              (profile.HrBase + rng.Next(-profile.HrJitter, profile.HrJitter + 1))
+
+          let commentIdx = rng.Next(0, profile.Comments.Length)
+          let comment = profile.Comments[commentIdx]
+
+          let unvalidated =
+            { Systolic = sys
+              Diastolic = dia
+              HeartRate = hr
+              Timestamp = ts
+              Comments = comment }
+
+          match BloodPressureReading.parse ranges unvalidated with
+          | Ok r -> Some r
+          | Error _ -> None // never reached: values are clamped into range
+    )
+
+  // ── public API ────────────────────────────────────────────────────────────
+
+  /// Returns the Simpson family as a list of (MemberSpec, readings) pairs.
+  ///
+  /// Generation is deterministic: given the same `ranges` and `now`, the result
+  /// is always identical. `now` anchors the 5-year window so trend charts look
+  /// current when the demo data is first seeded.
+  let simpsons (ranges: ReadingRanges) (now: DateTimeOffset) : (MemberSpec * BloodPressureReading list) list =
+    profiles |> List.map (fun p -> p.Spec, generateReadings ranges now p)

--- a/code/BpMonitor.Data.Tests/BpMonitor.Data.Tests.fsproj
+++ b/code/BpMonitor.Data.Tests/BpMonitor.Data.Tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="EfReadingRepositoryTests.fs" />
     <Compile Include="EfFamilyMemberRepositoryTests.fs" />
     <Compile Include="SchemaMigrationsTests.fs" />
+    <Compile Include="DemoSeederTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Data.Tests/DemoSeederTests.fs
+++ b/code/BpMonitor.Data.Tests/DemoSeederTests.fs
@@ -1,0 +1,86 @@
+module DemoSeederTests
+
+open System
+open Xunit
+open Swensen.Unquote
+open BpMonitor.Core
+open BpMonitor.Data
+
+let private ranges = ReadingRanges.defaults
+let private now = DateTimeOffset(2026, 6, 14, 12, 0, 0, TimeSpan.Zero)
+
+let private tp =
+  new Microsoft.Extensions.Time.Testing.FakeTimeProvider(now) :> TimeProvider
+
+let private emptyStore () =
+  InMemoryFamilyMemberRepository(None) :> IFamilyMemberRepository,
+  InMemoryReadingRepository(Some []) :> IReadingRepository
+
+// ── disabled seeder ───────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``disabled flag leaves the store untouched`` () =
+  let members, readings = emptyStore ()
+  DemoSeeder.seedIfEmpty members readings ranges tp false
+  // Only the default "Me" member from InMemoryFamilyMemberRepository
+  test <@ members.GetAll().Length = 1 @>
+  test <@ (members.GetAll() |> List.head).Name = "Me" @>
+
+// ── enabled seeder ────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``enabled seeder on empty store creates exactly 5 members`` () =
+  let members, readings = emptyStore ()
+  DemoSeeder.seedIfEmpty members readings ranges tp true
+  test <@ members.GetAll().Length = 5 @>
+
+[<Fact>]
+let ``enabled seeder renames the default Me member (no sixth member)`` () =
+  let members, readings = emptyStore ()
+  DemoSeeder.seedIfEmpty members readings ranges tp true
+  let names = members.GetAll() |> List.map _.Name
+  test <@ names |> List.contains "Me" |> not @>
+
+[<Fact>]
+let ``enabled seeder: Marge Simpson is the admin`` () =
+  let members, readings = emptyStore ()
+  DemoSeeder.seedIfEmpty members readings ranges tp true
+  let admins = members.GetAll() |> List.filter _.IsAdmin
+  test <@ admins.Length = 1 @>
+  test <@ (admins |> List.head).Name = "Marge Simpson" @>
+
+[<Fact>]
+let ``enabled seeder: each member has readings scoped to their own Id`` () =
+  let members, readings = emptyStore ()
+  DemoSeeder.seedIfEmpty members readings ranges tp true
+
+  for m in members.GetAll() do
+    test <@ readings.GetAll(m.Id).Length > 0 @>
+
+[<Fact>]
+let ``enabled seeder: members are seeded unclaimed (no password)`` () =
+  let members, readings = emptyStore ()
+  DemoSeeder.seedIfEmpty members readings ranges tp true
+
+  for m in members.GetAll() do
+    test <@ m.PasswordHash = None @>
+
+// ── idempotence ───────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``second call on populated store is a no-op`` () =
+  let members, readings = emptyStore ()
+  DemoSeeder.seedIfEmpty members readings ranges tp true
+  let memberCountAfterFirst = members.GetAll().Length
+
+  let totalAfterFirst =
+    members.GetAll() |> List.sumBy (fun m -> readings.GetAll(m.Id).Length)
+
+  DemoSeeder.seedIfEmpty members readings ranges tp true
+
+  test <@ members.GetAll().Length = memberCountAfterFirst @>
+
+  let totalAfterSecond =
+    members.GetAll() |> List.sumBy (fun m -> readings.GetAll(m.Id).Length)
+
+  test <@ totalAfterSecond = totalAfterFirst @>

--- a/code/BpMonitor.Data/BpMonitor.Data.fsproj
+++ b/code/BpMonitor.Data/BpMonitor.Data.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="SchemaMigrations.fs" />
     <Compile Include="EfReadingRepository.fs" />
     <Compile Include="ReadingRepositoryFactory.fs" />
+    <Compile Include="DemoSeeder.fs" />
   </ItemGroup>
 
 </Project>

--- a/code/BpMonitor.Data/DemoSeeder.fs
+++ b/code/BpMonitor.Data/DemoSeeder.fs
@@ -1,0 +1,63 @@
+namespace BpMonitor.Data
+
+open System
+open BpMonitor.Core
+
+/// Seeds the Simpson-family demo dataset into an empty store.
+///
+/// Intended for developer onboarding and demo runs only. Call once at startup,
+/// gated behind the BpMonitor:SeedDemoData configuration flag (default: false).
+module DemoSeeder =
+
+  /// Returns true when the store is considered "empty":
+  /// no readings exist for any of the currently known members.
+  let private isEmpty (members: IFamilyMemberRepository) (readings: IReadingRepository) =
+    members.GetAll() |> List.forall (fun m -> readings.GetAll(m.Id).IsEmpty)
+
+  /// Seeds the Simpson family iff `enabled` is true and the store is empty.
+  ///
+  /// The lone auto-seeded "Me" member (created by SchemaMigrations) is repurposed
+  /// as Marge Simpson so the final member count is exactly 5, not 6.
+  let seedIfEmpty
+    (members: IFamilyMemberRepository)
+    (readings: IReadingRepository)
+    (ranges: ReadingRanges)
+    (timeProvider: TimeProvider)
+    (enabled: bool)
+    : unit =
+
+    if not enabled then
+      ()
+    elif not (isEmpty members readings) then
+      ()
+    else
+      let now = timeProvider.GetUtcNow()
+      let simpsons = DemoData.simpsons ranges now
+
+      // The auto-seeded default member list (usually just "Me", id=1).
+      let existingMembers = members.GetAll()
+
+      // Assign a created FamilyMember for each MemberSpec, reusing the lone
+      // existing default member for the first Simpson (Marge) if there is one.
+      simpsons
+      |> List.iteri (fun i (spec, memberReadings) ->
+        let member_ =
+          match i, existingMembers with
+          | 0, [ existing ] ->
+            // Repurpose the lone existing "Me" member as Marge.
+            let updated =
+              { existing with
+                  Name = spec.Name
+                  IsAdmin = spec.IsAdmin
+                  IsActive = true
+                  PasswordHash = None
+                  ModifiedAt = now }
+
+            members.Update(updated)
+            updated
+          | _ ->
+            match FamilyMember.create spec.Name spec.IsAdmin with
+            | Ok m -> members.Add(m)
+            | Error NameIsEmpty -> failwith $"DemoSeeder: could not create member '{spec.Name}'"
+
+        readings.AddMany member_.Id memberReadings)

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -87,7 +87,22 @@ let main args =
     // Apply schema migrations once at startup against a transient scope.
     Log.Information("Applying schema migrations…")
     use scope = app.Services.CreateScope()
-    SchemaMigrations.apply (scope.ServiceProvider.GetRequiredService<BpMonitorDbContext>())
+    let sp = scope.ServiceProvider
+    SchemaMigrations.apply (sp.GetRequiredService<BpMonitorDbContext>())
+
+    // Optionally seed the Simpson-family demo dataset (off by default).
+    let seedDemo = builder.Configuration.GetValue<bool>("BpMonitor:SeedDemoData")
+
+    if seedDemo then
+      Log.Information("Seeding Simpson-family demo data…")
+      let ranges = Config.readRanges builder.Configuration
+
+      DemoSeeder.seedIfEmpty
+        (sp.GetRequiredService<IFamilyMemberRepository>())
+        (sp.GetRequiredService<IReadingRepository>())
+        ranges
+        TimeProvider.System
+        true
 
     // One structured log line per request (method, path, status, elapsed ms).
     app.UseSerilogRequestLogging() |> ignore

--- a/code/BpMonitor.Web/appsettings.json
+++ b/code/BpMonitor.Web/appsettings.json
@@ -1,5 +1,8 @@
 {
   "Urls": "http://0.0.0.0:5000",
+  "BpMonitor": {
+    "SeedDemoData": false
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=bpmonitor.db"
   },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,7 @@ graph TD
 - `FamilyMember.isClaimed m` — true when `PasswordHash` is `Some`
 - `PasswordHashing` module — pure PBKDF2-SHA256 hashing via BCL (`Rfc2898DeriveBytes`); `hash password → encoded` (iterations.base64salt.base64hash), `verify password encoded → bool` (constant-time compare)
 - `ReadingStats` module — pure statistics/filtering helpers: `since now days readings` (date-window filter), `classify avgSys avgDia → BloodPressureCategory` (AHA 2017 thresholds: Normal/Elevated/Stage1/Stage2), `summarize now days readings → WindowSummary` (count + integer averages + category). Used by the `/trends` page and `/chart?window=` route.
+- `DemoData` module — pure, deterministic demo-data generator: `DemoData.simpsons ranges now` returns the Simpson family (5 members with personalities: Marge normal/admin, Homer hypertensive/frequent, Bart+Lisa kids/sparse, Abe elderly/irregular) plus ~5 years of realistic `BloodPressureReading` values anchored to `now`. Fixed `Random` seed makes output reproducible across calls. Used by `DemoSeeder` in Data and can be used directly in tests for realistic fixtures.
 - Business logic: applicative validation via `FsToolkit.ErrorHandling`
 - No dependencies on other projects
 
@@ -123,6 +124,7 @@ graph TD
 - `IReadingRepository` implementations: `EfReadingRepository` (filters by `MemberId`), `InMemoryReadingRepository`
 - `IFamilyMemberRepository` implementations: `EfFamilyMemberRepository`, `InMemoryFamilyMemberRepository`
 - Manual schema migrations via `SchemaMigrations.apply` (EF Core migrations do not support F#); handles `Members` table creation, default-member seeding, `MemberId` backfill for existing rows, `IsAdmin`/`IsActive` column additions, and `PasswordHash TEXT DEFAULT ''` column addition; `ensureActiveAdmin` promotes the lowest-Id member when no active admin exists (upgrade path for pre-PR#157 DBs)
+- `DemoSeeder.seedIfEmpty` — seeds the Simpson-family demo dataset (from `DemoData` in Core) when `BpMonitor:SeedDemoData=true` and the store is empty; called once at startup in `Program.fs` after `SchemaMigrations.apply`; repurposes the auto-seeded "Me" member as Marge so the family count is exactly 5; members are seeded unclaimed (no password) so the normal first-login claim flow applies; idempotent (no-op if readings already exist)
 - `ReadingRepositoryFactory` / `FamilyMemberRepository` factory wiring
 
 ### BpMonitor.Import


### PR DESCRIPTION
## Summary

- Add `BpMonitor.Core/DemoData.fs` — pure, deterministic generator returning the Simpson family (5 members with distinct BP personalities) plus ~5 years of `BloodPressureReading` values anchored to `now`; fixed `Random` seed makes output reproducible across calls
- Add `BpMonitor.Data/DemoSeeder.fs` — `seedIfEmpty` orchestrates member + reading insertion using the generator; repurposes the auto-seeded "Me" member as Marge (no leftover sixth member); idempotent (no-op on non-empty store); members are seeded unclaimed so the normal first-login claim flow applies
- Wire `BpMonitor:SeedDemoData` flag (default `false`) in `appsettings.json` and call `DemoSeeder.seedIfEmpty` in `Program.fs` right after `SchemaMigrations.apply`
- 16 new tests (9 generator, 7 seeder) covering member count/admin shape, range validity, 5-year span, determinism, profile distinctness, unclaimed state, and idempotence
- Document the `BpMonitor__SeedDemoData=true dotnet run …` onboarding command in `CONTRIBUTING.md` and `docs/architecture.md`