### PR TITLE
♻️ refactor: extract withRouteMember combinator to collapse route-id → member lookup scaffold

### DIFF
--- a/code/BpMonitor.Web/AuthHandlers.fs
+++ b/code/BpMonitor.Web/AuthHandlers.fs
@@ -153,39 +153,28 @@ module AuthHandlers =
       :> Task
 
   let loginMember: HttpContext -> Task =
-    fun ctx ->
-      match routeInt ctx "id" with
-      | None -> badRequest ctx
-      | Some id ->
-        match (memberRepo ctx).GetById(id) with
-        | None -> notFound ctx
-        | Some m ->
-          if not m.IsActive then
-            ctx.Response.StatusCode <- 403
-            ctx.Response.WriteAsync("This account is inactive")
-          else
-            htmlResponse (LoginViews.loginMember m []) ctx
+    withRouteMember "loginMember" (fun m ctx ->
+      if not m.IsActive then
+        ctx.Response.StatusCode <- 403
+        ctx.Response.WriteAsync("This account is inactive")
+      else
+        htmlResponse (LoginViews.loginMember m []) ctx)
 
   let loginSubmit: HttpContext -> Task =
-    fun ctx ->
+    withRouteMember "loginSubmit" (fun m ctx ->
       task {
-        match routeInt ctx "id" with
-        | None -> do! badRequest ctx
-        | Some id ->
-          match (memberRepo ctx).GetById(id) with
-          | None -> do! notFound ctx
-          | Some m when not m.IsActive ->
-            ctx.Response.StatusCode <- 403
-            do! ctx.Response.WriteAsync("This account is inactive")
-          | Some m ->
-            let! form = ctx.Request.ReadFormAsync()
-            let password = form["Password"].ToString()
+        if not m.IsActive then
+          ctx.Response.StatusCode <- 403
+          do! ctx.Response.WriteAsync("This account is inactive")
+        else
+          let! form = ctx.Request.ReadFormAsync()
+          let password = form["Password"].ToString()
 
-            match m.PasswordHash with
-            | Some hash -> do! claimedLogin m password hash (LoginViews.loginMember m [ "Incorrect password" ]) ctx
-            | None -> do! unclaimedLogin m password (form["PasswordConfirm"].ToString()) ctx
+          match m.PasswordHash with
+          | Some hash -> do! claimedLogin m password hash (LoginViews.loginMember m [ "Incorrect password" ]) ctx
+          | None -> do! unclaimedLogin m password (form["PasswordConfirm"].ToString()) ctx
       }
-      :> Task
+      :> Task)
 
   let logout: HttpContext -> Task =
     fun ctx ->

--- a/code/BpMonitor.Web/HandlerHelpers.fs
+++ b/code/BpMonitor.Web/HandlerHelpers.fs
@@ -77,3 +77,25 @@ module HandlerHelpers =
 
   let sortedReadings (memberId: int) (ctx: HttpContext) =
     (repo ctx).GetAll(memberId) |> List.sortByDescending _.Timestamp
+
+  /// Resolves the "id" route segment to a FamilyMember, logging and returning
+  /// 400 for a non-integer id or 404 when no member with that id exists.
+  let withRouteMember (handlerName: string) (handler: FamilyMember -> HttpContext -> Task) : HttpContext -> Task =
+    fun ctx ->
+      let log = logger ctx
+
+      match routeInt ctx "id" with
+      | None ->
+        log.LogWarning(
+          "{Handler}: bad route value for {RouteId}",
+          handlerName,
+          routeStr ctx "id" |> Option.defaultValue "<missing>"
+        )
+
+        badRequest ctx
+      | Some id ->
+        match (memberRepo ctx).GetById(id) with
+        | None ->
+          log.LogWarning("{Handler}: member {Id} not found", handlerName, id)
+          notFound ctx
+        | Some m -> handler m ctx

--- a/code/BpMonitor.Web/MemberHandlers.fs
+++ b/code/BpMonitor.Web/MemberHandlers.fs
@@ -33,27 +33,11 @@ module MemberHandlers =
       :> Task)
 
   let editMember: HttpContext -> Task =
-    fun ctx ->
-      let log = logger ctx
-
+    withRouteMember "editMember" (fun m ctx ->
       let adminName =
         authenticatedMember ctx |> Option.map _.Name |> Option.defaultValue ""
 
-      match routeInt ctx "id" with
-      | None ->
-        log.LogWarning(
-          "editMember: bad route value for {RouteId}",
-          routeStr ctx "id" |> Option.defaultValue "<missing>"
-        )
-
-        badRequest ctx
-      | Some id ->
-        match (memberRepo ctx).GetById(id) with
-        | Some m ->
-          htmlResponse (MemberViews.memberForm Routes.members adminName true "Edit member" $"/members/{id}" [] m) ctx
-        | None ->
-          log.LogWarning("editMember: member {Id} not found", id)
-          notFound ctx
+      htmlResponse (MemberViews.memberForm Routes.members adminName true "Edit member" $"/members/{m.Id}" [] m) ctx)
 
   let private renderMemberEditError
     (id: int)
@@ -104,63 +88,30 @@ module MemberHandlers =
     :> Task
 
   let updateMember: HttpContext -> Task =
-    fun ctx ->
+    withRouteMember "updateMember" (fun existing ctx ->
       task {
-        let log = logger ctx
-
         let adminName =
           authenticatedMember ctx |> Option.map _.Name |> Option.defaultValue ""
 
-        match routeInt ctx "id" with
-        | None ->
-          log.LogWarning(
-            "updateMember: bad route value for {RouteId}",
-            routeStr ctx "id" |> Option.defaultValue "<missing>"
-          )
+        let! form = ctx.Request.ReadFormAsync()
 
-          do! badRequest ctx
-        | Some id ->
-          match (memberRepo ctx).GetById(id) with
-          | None ->
-            log.LogWarning("updateMember: member {Id} not found", id)
-            do! notFound ctx
-          | Some existing ->
-            let! form = ctx.Request.ReadFormAsync()
-
-            do!
-              applyMemberEdit
-                id
-                adminName
-                existing
-                (form["Name"].ToString())
-                (form.ContainsKey("IsAdmin"))
-                (form.ContainsKey("IsActive"))
-                ctx
+        do!
+          applyMemberEdit
+            existing.Id
+            adminName
+            existing
+            (form["Name"].ToString())
+            (form.ContainsKey("IsAdmin"))
+            (form.ContainsKey("IsActive"))
+            ctx
       }
-      :> Task
+      :> Task)
 
   /// Resets a member's password to unclaimed (admin-only).
   let resetPassword: HttpContext -> Task =
-    fun ctx ->
-      task {
-        let log = logger ctx
-
-        match routeInt ctx "id" with
-        | None ->
-          log.LogWarning(
-            "resetPassword: bad route value for {RouteId}",
-            routeStr ctx "id" |> Option.defaultValue "<missing>"
-          )
-
-          do! badRequest ctx
-        | Some id ->
-          match (memberRepo ctx).GetById(id) with
-          | None ->
-            log.LogWarning("resetPassword: member {Id} not found", id)
-            do! notFound ctx
-          | Some m ->
-            (memberRepo ctx).Update({ m with PasswordHash = None })
-            log.LogInformation("Admin reset password for member {Name} (Id={Id})", m.Name, m.Id)
-            ctx.Response.Redirect Routes.members
-      }
-      :> Task
+    withRouteMember "resetPassword" (fun m ctx ->
+      let log = logger ctx
+      (memberRepo ctx).Update({ m with PasswordHash = None })
+      log.LogInformation("Admin reset password for member {Name} (Id={Id})", m.Name, m.Id)
+      ctx.Response.Redirect Routes.members
+      System.Threading.Tasks.Task.CompletedTask)


### PR DESCRIPTION
## Summary
- Added `withRouteMember` to `HandlerHelpers` — resolves the `"id"` route segment to a `FamilyMember`, returning 400 on a non-integer id or 404 when no member exists, with structured log warnings in both cases
- Applied to 5 handlers: `loginMember`, `loginSubmit`, `editMember`, `updateMember`, `resetPassword`
- Side effect: `loginMember` and `loginSubmit` now log bad-route and not-found cases consistently with the admin handlers (they were previously silent)
- Net: −38 lines