### PR TITLE
🔧 chore: enable --warnon:1182 and fix unused bindings

### DIFF
--- a/code/BpMonitor.Core.Tests/DemoDataTests.fs
+++ b/code/BpMonitor.Core.Tests/DemoDataTests.fs
@@ -33,7 +33,7 @@ let ``simpsons admin is Marge Simpson`` () =
 let ``all generated readings are in range (no parse errors)`` () =
   let result = DemoData.simpsons ranges now
 
-  for (spec, readings) in result do
+  for (_, readings) in result do
     for r in readings do
       test
         <@
@@ -100,5 +100,5 @@ let ``Marge mean systolic is higher than Bart mean systolic`` () =
 let ``each member has enough readings for trend granularities`` () =
   let result = DemoData.simpsons ranges now
   // Minimum: expect at least 52 readings per member (roughly 1 per week for a year)
-  for (spec, readings) in result do
+  for (_, readings) in result do
     test <@ readings.Length >= 52 @>

--- a/code/Directory.Build.props
+++ b/code/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsPackable)' == 'false' and $(MSBuildProjectName.Contains('Tests'))">
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>


### PR DESCRIPTION
## Summary
- Enable F# compiler warning FS1182 (unused values) globally via `--warnon:1182` in `Directory.Build.props`; combined with the existing `TreatWarningsAsErrors`, unused bindings now fail the build
- Fix two unused `spec` destructures in `DemoDataTests.fs` (loop variables replaced with `_`)