### PR TITLE
🔧 chore: remove unused open statements

### DIFF
--- a/code/BpMonitor.Core/TrendPeriod.fs
+++ b/code/BpMonitor.Core/TrendPeriod.fs
@@ -33,8 +33,6 @@ module IsoWeek =
 
 module TrendPeriod =
   open System
-  open System.Globalization
-
   // ── private helpers ─────────────────────────────────────────────────────────
 
   let private localMidnight (date: DateTime) : DateTimeOffset =

--- a/code/BpMonitor.Export.Tests/CsvExportTests.fs
+++ b/code/BpMonitor.Export.Tests/CsvExportTests.fs
@@ -1,6 +1,5 @@
 module CsvExportTests
 
-open System
 open System.IO
 open System.Threading.Tasks
 open BpMonitor.Core

--- a/code/BpMonitor.Export.Tests/JsonExportTests.fs
+++ b/code/BpMonitor.Export.Tests/JsonExportTests.fs
@@ -1,6 +1,5 @@
 module JsonExportTests
 
-open System
 open System.IO
 open System.Text.Json
 open System.Threading.Tasks

--- a/code/BpMonitor.Export/CsvExport.fs
+++ b/code/BpMonitor.Export/CsvExport.fs
@@ -1,6 +1,5 @@
 module BpMonitor.Export.CsvExport
 
-open System
 open System.Text
 open BpMonitor.Core
 

--- a/code/BpMonitor.Web.Tests/BindingTests.fs
+++ b/code/BpMonitor.Web.Tests/BindingTests.fs
@@ -1,7 +1,6 @@
 module BindingTests
 
 open Xunit
-open FsCheck
 open FsCheck.Xunit
 open Swensen.Unquote
 open BpMonitor.Web

--- a/code/BpMonitor.Web.Tests/MemberHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/MemberHandlerTests.fs
@@ -5,7 +5,6 @@ open Xunit
 open Swensen.Unquote
 open Microsoft.Extensions.DependencyInjection
 open BpMonitor.Core
-open BpMonitor.Data
 open BpMonitor.Web
 open HandlerTestHelpers
 

--- a/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
@@ -1,6 +1,5 @@
 module ReadingHandlerTests
 
-open System
 open Xunit
 open Swensen.Unquote
 open Microsoft.Extensions.Time.Testing

--- a/code/BpMonitor.Web.Tests/TestHost.fs
+++ b/code/BpMonitor.Web.Tests/TestHost.fs
@@ -8,9 +8,7 @@ open Microsoft.AspNetCore.Authentication.Cookies
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
-open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Primitives
-open Microsoft.Extensions.Time.Testing
 open BpMonitor.Core
 open BpMonitor.Data
 

--- a/code/BpMonitor.Web.Tests/VersionPropertyTests.fs
+++ b/code/BpMonitor.Web.Tests/VersionPropertyTests.fs
@@ -1,7 +1,6 @@
 module VersionPropertyTests
 
 open System
-open FsCheck
 open FsCheck.FSharp
 open FsCheck.Xunit
 open BpMonitor.Web


### PR DESCRIPTION
## Summary
- Remove 11 unused `open` statements across 9 files, identified and cleaned up via IDE (Ionide)