### PR TITLE
🔧 chore: disable Renovate updates for Microsoft Testing Platform packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,8 @@
         "Microsoft.NET.Test.Sdk",
         "Microsoft.Testing.Extensions.CodeCoverage"
       ],
-      "groupName": "Microsoft Testing Platform",
-      "description": "CodeCoverage and Test.Sdk must update together — they share a Microsoft.Testing.Platform transitive dep that must version-match"
+      "enabled": false,
+      "description": "Pinned: these share a Microsoft.Testing.Platform transitive dep that must version-match; update manually and together"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Replaces the `groupName` approach (which only grouped PRs) with `"enabled": false`, which actually suppresses Renovate PRs
- `Microsoft.NET.Test.Sdk` and `Microsoft.Testing.Extensions.CodeCoverage` must be updated manually and together — they share a `Microsoft.Testing.Platform` transitive dep that must version-match