### PR TITLE
🐛 fix: render Serilog console output as plain text with substituted values

### DIFF
--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -110,7 +110,10 @@ let main args =
     app.UseStaticFiles().UseRouting().UseAuthentication().UseAuthorization().UseFalco(endpoints)
     |> ignore
 
-    Log.Information("BpMonitor.Web {Version} starting on {Urls}", Version.current, app.Urls)
+    app.Lifetime.ApplicationStarted.Register(fun () ->
+      Log.Information("BpMonitor.Web {Version} starting on {Urls}", Version.current, app.Urls))
+    |> ignore
+
     app.Run()
     0
   with ex ->

--- a/code/BpMonitor.Web/appsettings.json
+++ b/code/BpMonitor.Web/appsettings.json
@@ -27,7 +27,7 @@
       {
         "Name": "Console",
         "Args": {
-          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
         }
       }
     ],


### PR DESCRIPTION
## Summary
- Switch Serilog console sink from `CompactJsonFormatter` (CLEF) to a plain `outputTemplate` so message placeholders are rendered inline instead of stored as separate JSON properties
- Move the startup log message into `ApplicationStarted` so `app.Urls` is populated when it fires (previously always logged `[]`)