### PR TITLE
✨ feat: add cut-release skill with annotated-tag summary above changelog

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: cut-release
+description: Cut a BpMonitor release — gather changes since the last tag, propose an end-user summary, confirm it, then create an annotated tag whose message renders above the auto-generated changelog. Invoke when creating/cutting a release or pushing a version tag.
+argument-hint: [version, e.g. v1.4.0]
+model: claude-sonnet-4-6
+---
+
+# Cut Release
+
+Guide the user through a safe, repeatable BpMonitor release. The tag annotation
+message becomes the end-user summary displayed **above** the auto-generated
+changelog on the GitHub release page.
+
+## Step 1 — Preflight
+
+Run these checks and **abort if any fails**:
+
+```bash
+git branch --show-current               # must be main
+git status --short                      # must be empty (clean tree)
+git fetch origin main
+git log HEAD..origin/main --oneline     # must be empty (up to date)
+gh run list --branch main --limit 3    # latest CI run must show ✓ completed/success
+```
+
+Inform the user of any failures before proceeding.
+
+## Step 2 — Determine version
+
+```bash
+git tag --sort=-v:refname | head -5    # inspect recent tags
+```
+
+Calculate the three candidate versions from the latest tag, then **ask the user
+which version to use** — even if `$ARGUMENTS` already contains one (treat it as
+a default pre-selection, not a skip). Present the options like this:
+
+> Current version: **vX.Y.Z**
+>
+> Which version bump?
+>
+> | Option | Next version | When to use |
+> | --- | --- | --- |
+> | patch | vX.Y.(Z+1) | bug fixes only |
+> | minor | vX.(Y+1).0 | new user-facing features |
+> | major | v(X+1).0.0 | breaking changes |
+> | pre-release | vX.Y.Z-rc1 | release candidate (won't become `/releases/latest`) |
+>
+> Recommendation: **minor** ← (or whichever fits the changes; justify briefly)
+>
+> Enter a version or press Enter to accept the recommendation:
+
+Pre-release suffix `-rcN` is allowed — the workflow automatically marks
+`-`-tags as GitHub prereleases so `/releases/latest` stays on the stable release.
+
+## Step 3 — Gather changes
+
+```bash
+LAST_TAG=$(git tag --sort=-v:refname | head -1)
+git log "${LAST_TAG}..HEAD" --oneline
+```
+
+Optionally cross-reference merged PRs for richer descriptions:
+
+```bash
+gh pr list --state merged --base main --limit 30 --json number,title,mergedAt \
+  | jq --arg since "$(git log -1 --format=%aI "${LAST_TAG}")" \
+       '[.[] | select(.mergedAt > $since)]'
+```
+
+## Step 4 — Draft the end-user summary
+
+Write concise markdown covering **only what matters to end users and operators**.
+
+**Include:**
+- New user-facing features
+- Deployment notes: breaking changes, schema/data migrations, new required env
+  vars or config keys, renamed artifacts or changed URLs
+
+**Exclude:** refactors, test-only changes, internal chores, CI tweaks, doc fixes,
+dependency bumps (unless they change runtime behaviour).
+
+Suggested shape (omit "Deployment notes" if there is nothing actionable):
+
+```markdown
+### Highlights
+
+- <new feature visible to the user>
+- <another feature>
+
+### Deployment notes
+
+- <something the operator must do or know before upgrading — only if applicable>
+```
+
+Keep it short. Two or three bullet points is better than an essay.
+
+## Step 5 — Confirm
+
+Present the proposed **version** and **summary** to the user. Wait for explicit
+approval or edits. Do **not** proceed to tagging until confirmed.
+
+## Step 6 — Create annotated tag and push
+
+Write the approved summary to a temp file (avoids shell quoting issues), then tag:
+
+```bash
+SUMMARY_FILE=$(mktemp)
+cat > "$SUMMARY_FILE" << 'SUMMARY_EOF'
+<paste approved summary here>
+SUMMARY_EOF
+
+git tag -a vX.Y.Z -F "$SUMMARY_FILE"
+rm "$SUMMARY_FILE"
+```
+
+Confirm once more before pushing — pushing the tag starts a public release:
+
+```bash
+git push origin vX.Y.Z
+```
+
+`release.yml` picks up the tag, reads its annotation as the release body, and
+appends the auto-generated changelog beneath it.
+
+## Step 7 — Verify
+
+After pushing, share:
+
+- The Actions run URL: `https://github.com/draptik/BpMonitor/actions`
+- The draft release (appears once the workflow completes): `https://github.com/draptik/BpMonitor/releases`
+
+Note: if the tag has a `-` suffix it will be marked as a **prerelease** and will
+not become `/releases/latest` — correct behaviour for RCs.
+
+## Rules
+
+- NEVER push a tag without explicit user confirmation in Step 5 and Step 6.
+- NEVER include internal/technical changes in the summary — end users and
+  operators are the audience.
+- NEVER create a release from a branch other than `main`.
+- NEVER skip the preflight; failing CI on `main` means the release isn't ready.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -41,11 +44,21 @@ jobs:
           tar -czf code/bpmonitor-web-linux-x64.tar.gz
           -C code/publish-web bpmonitor-web appsettings.json wwwroot
 
+      - name: Read tag annotation
+        id: notes
+        run: |
+          {
+            echo 'body<<RELEASE_EOF'
+            git tag -l --format='%(contents)' "${GITHUB_REF_NAME}"
+            echo 'RELEASE_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
           files: |
             code/bpmonitor-web-linux-x64.tar.gz
+          body: ${{ steps.notes.outputs.body }}
           generate_release_notes: true
           # Treat tags carrying a pre-release suffix (e.g. v0.1.11-rc1) as
           # prereleases so the /releases/latest API keeps pointing at the last

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,10 +111,32 @@ See [AGENTS.md](AGENTS.md) for the full git workflow rules.
 
 ## Creating a release
 
-Push a version tag on `main` to trigger the release workflow:
+Use the `/cut-release` skill, which walks through the full flow (preflight, change
+summary, confirmation, tag, push). The quickest path is:
 
 ```bash
-git tag v1.2.3
+# inside Claude Code
+/cut-release v1.2.3
+```
+
+The skill creates an **annotated** tag whose message becomes the end-user summary
+displayed above the auto-generated changelog on the GitHub release page. It pauses
+for confirmation before pushing anything.
+
+If you prefer to tag manually, create an annotated tag — the message will appear
+as the release summary:
+
+```bash
+git tag -a v1.2.3 -m "$(cat <<'EOF'
+### Highlights
+
+- <new feature>
+
+### Deployment notes
+
+- <anything the operator must know — omit if nothing actionable>
+EOF
+)"
 git push origin v1.2.3
 ```
 


### PR DESCRIPTION
## Summary

- Adds a new `/cut-release` skill that guides through the full release flow: preflight checks, version bump prompt (patch/minor/major/pre-release), end-user summary draft, confirmation, annotated tag creation, and push
- The annotated tag message becomes a human-written summary displayed **above** the auto-generated changelog on the GitHub release page
- Updates `release.yml` to read the tag annotation and pass it as the release `body` alongside `generate_release_notes: true`; sets `fetch-depth: 0` + `fetch-tags: true` on checkout so the annotation is available in the runner
- Updates `CONTRIBUTING.md` "Creating a release" section to document the new skill-based flow and the manual annotated-tag fallback