### PR TITLE
🔧 chore: fix release summary template to avoid blank line between bullets

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -80,17 +80,15 @@ Write concise markdown covering **only what matters to end users and operators**
 **Exclude:** refactors, test-only changes, internal chores, CI tweaks, doc fixes,
 dependency bumps (unless they change runtime behaviour).
 
-Suggested shape (omit "Deployment notes" if there is nothing actionable):
+Suggested shape — a single flat list so bullets render without gaps. Prefix
+operator items with `**Deployment:**` (omit if nothing actionable):
 
 ```markdown
-### Highlights
+### What's new
 
 - <new feature visible to the user>
 - <another feature>
-
-### Deployment notes
-
-- <something the operator must do or know before upgrading — only if applicable>
+- **Deployment:** <something the operator must do or know — only if applicable>
 ```
 
 Keep it short. Two or three bullet points is better than an essay.


### PR DESCRIPTION
## Summary

- The two-section `### Highlights` / `### Deployment notes` shape caused a visible blank line between bullets on the GitHub release page
- Replaced with a single `### What's new` flat list; operator items use a `**Deployment:**` inline prefix instead of a separate heading