### PR TITLE
📝 docs: add CHANGELOG.md with full release history

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -93,10 +93,62 @@ operator items with `**Deployment:**` (omit if nothing actionable):
 
 Keep it short. Two or three bullet points is better than an essay.
 
+This same set of bullets will populate `CHANGELOG.md` in Step 5a — author them
+once, reuse for both.
+
 ## Step 5 — Confirm
 
 Present the proposed **version** and **summary** to the user. Wait for explicit
 approval or edits. Do **not** proceed to tagging until confirmed.
+
+## Step 5a — Update CHANGELOG.md
+
+Direct commits to `main` are blocked, so the changelog update must go through a
+branch + PR. Do this **before** creating the tag.
+
+```bash
+git switch -c chore/changelog-vX.Y.Z
+```
+
+Edit `CHANGELOG.md`:
+
+1. Leave `## [Unreleased]` at the top but clear its contents (keep the heading,
+   leave the body empty).
+2. Insert a new version section immediately after it, using the approved summary
+   bullets grouped under `### Added`, `### Changed`, or `### Fixed` as
+   appropriate. Use today's date in ISO format (`YYYY-MM-DD`):
+
+   ```markdown
+   ## [X.Y.Z] - YYYY-MM-DD
+
+   ### Added
+
+   - <bullet from approved summary>
+   ```
+
+3. Update the link-reference block at the bottom of the file:
+   - Change `[Unreleased]` to compare the new tag to `HEAD`:
+     `[Unreleased]: https://github.com/draptik/BpMonitor/compare/vX.Y.Z...HEAD`
+   - Add a new compare line for the new version above the previous latest:
+     `[X.Y.Z]: https://github.com/draptik/BpMonitor/compare/vPREV...vX.Y.Z`
+
+Commit, push, open a PR, and **merge it to `main`** before proceeding:
+
+```bash
+git add CHANGELOG.md
+git commit -m "📝 docs: update changelog for vX.Y.Z"
+git push -u origin chore/changelog-vX.Y.Z
+gh pr create --title "📝 docs: update changelog for vX.Y.Z" --body "Changelog entry for the upcoming vX.Y.Z release."
+# wait for CI to pass, then merge
+gh pr merge --squash
+```
+
+After the PR is merged, pull `main` so the tag lands on the changelog commit:
+
+```bash
+git switch main
+git pull
+```
 
 ## Step 6 — Create annotated tag and push
 
@@ -138,3 +190,5 @@ not become `/releases/latest` — correct behaviour for RCs.
   operators are the audience.
 - NEVER create a release from a branch other than `main`.
 - NEVER skip the preflight; failing CI on `main` means the release isn't ready.
+- NEVER tag before the `CHANGELOG.md` PR (Step 5a) is merged; the tag annotation
+  and the `CHANGELOG.md` version section must match.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ Never start work on `main`. Creating the branch is the first step, not an aftert
 - `docs/vision.md` — product vision and requirements
 - `docs/architecture.md` — tech stack, architectural decisions, and dev tooling (mise, Biome)
 - `docs/install.md` — end-user install guide (Web app)
-- `CONTRIBUTING.md` — developer setup, linting, testing, release process
+- `CONTRIBUTING.md` — developer setup, linting, testing, changelog convention, release process
+- `CHANGELOG.md` — version history in Keep a Changelog format; add `[Unreleased]` bullets in each PR for user-facing changes
 - `.claude/skills/` — skill definitions (git-workflow, review-tests, setup-tooling, model-advisor, status-bar)
 
 ## Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,189 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.4.1] - 2026-06-15
+
+### Changed
+
+- Internal tooling improvements (no user-facing changes).
+
+## [1.4.0] - 2026-06-15
+
+### Fixed
+
+- Chart height rendering in the history view is now correct.
+
+### Changed
+
+- Pico CSS is now vendored locally — no CDN request at startup.
+  No action needed; existing deployments update automatically on upgrade.
+
+## [1.3.0] - 2026-06-14
+
+### Changed
+
+- Internal code organisation improvements (no user-facing changes).
+
+## [1.2.1] - 2026-06-13
+
+### Changed
+
+- Internal code organisation improvements (no user-facing changes).
+
+## [1.2.0] - 2026-06-12
+
+### Changed
+
+- Test suite now runs all projects in parallel, significantly reducing local CI time.
+
+## [1.1.0] - 2026-06-12
+
+### Added
+
+- Granularity selector on the history chart: switch between Weekly, Monthly, and Yearly views.
+- Horizontally-scrollable sub-period row (12 weeks / 12 months / 5 years) with chronological navigation.
+- Chart aggregation and X-axis labels adapt per granularity (daily / weekly / monthly averages).
+
+## [1.0.1] - 2026-06-10
+
+### Fixed
+
+- Version number in the footer now displays correctly for a tagged `v1.0.0` release
+  (previously it was shown as "dev").
+
+## [1.0.0] - 2026-06-09
+
+First stable release of the BpMonitor web app.
+
+### Added
+
+- `/trends` page: windowed daily-grouped chart for spotting long-term trends.
+- Admin and Active flags for family members, with an admin edit flow.
+
+### Fixed
+
+- Trends chart hover tooltip no longer shows the reading count once per trace.
+
+## [0.1.14] - 2026-06-04
+
+### Changed
+
+- MIT license now mentioned explicitly in contribution docs.
+
+## [0.1.13] - 2026-06-01
+
+### Changed
+
+- Release assets restructured: TUI and web app now ship as separate named tarballs.
+
+## [0.1.12] - 2026-06-01
+
+### Added
+
+- Web app container image published to `ghcr.io/draptik/bpmonitor-web` on every release.
+- Web install paths added to `install.sh`.
+
+## [0.1.11] - 2026-06-01
+
+### Changed
+
+- Pre-release tags (containing `-`) are now correctly flagged as GitHub pre-releases,
+  keeping `/releases/latest` on the stable release.
+
+## [0.1.10] - 2026-04-29
+
+### Changed
+
+- Dependency update (no user-facing changes).
+
+## [0.1.9] - 2026-04-14
+
+### Changed
+
+- Internal refactoring (no user-facing changes).
+
+## [0.1.8] - 2026-04-14
+
+### Changed
+
+- Install documentation updated; helper scripts added.
+
+## [0.1.7] - 2026-04-14
+
+### Changed
+
+- `install.sh` now accepts CLI arguments for a configurable install.
+
+## [0.1.6] - 2026-04-13
+
+### Fixed
+
+- Chart and import timestamps now display in local time instead of UTC.
+
+## [0.1.5] - 2026-04-13
+
+### Fixed
+
+- Tilde (`~`) in the `Import:MarkdownDirectory` config path is now expanded correctly
+  before the file dialog opens.
+
+## [0.1.4] - 2026-04-13
+
+### Added
+
+- Serilog file logging with a configurable path via `appsettings.json`.
+
+## [0.1.3] - 2026-04-13
+
+### Added
+
+- `Import:MarkdownDirectory` config key in `appsettings.json` (default: current directory).
+
+## [0.1.2] - 2026-04-13
+
+### Changed
+
+- Internal test refactoring (no user-facing changes).
+
+## [0.1.1] - 2026-04-13
+
+### Fixed
+
+- `appsettings.json` is now included in release assets and picked up by `install.sh`.
+
+## [0.1.0] - 2026-04-13
+
+### Added
+
+- Initial GitHub release workflow and `install.sh` for automated deployment.
+
+[Unreleased]: https://github.com/draptik/BpMonitor/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/draptik/BpMonitor/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/draptik/BpMonitor/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/draptik/BpMonitor/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/draptik/BpMonitor/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/draptik/BpMonitor/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/draptik/BpMonitor/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/draptik/BpMonitor/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/draptik/BpMonitor/compare/v0.1.14...v1.0.0
+[0.1.14]: https://github.com/draptik/BpMonitor/compare/v0.1.13...v0.1.14
+[0.1.13]: https://github.com/draptik/BpMonitor/compare/v0.1.12...v0.1.13
+[0.1.12]: https://github.com/draptik/BpMonitor/compare/v0.1.11...v0.1.12
+[0.1.11]: https://github.com/draptik/BpMonitor/compare/v0.1.10...v0.1.11
+[0.1.10]: https://github.com/draptik/BpMonitor/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/draptik/BpMonitor/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.com/draptik/BpMonitor/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/draptik/BpMonitor/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/draptik/BpMonitor/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/draptik/BpMonitor/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/draptik/BpMonitor/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/draptik/BpMonitor/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/draptik/BpMonitor/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/draptik/BpMonitor/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/draptik/BpMonitor/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,17 @@ the "F# Style Conventions" section of [AGENTS.md](AGENTS.md).
 
 See [AGENTS.md](AGENTS.md) for the full git workflow rules.
 
+## Changelog
+
+User-facing changes belong in [`CHANGELOG.md`](CHANGELOG.md) under the
+`## [Unreleased]` section. Add a bullet there as part of every PR that introduces
+a user-visible change — group it under `### Added`, `### Changed`, or `### Fixed`
+as appropriate. Internal-only changes (refactors, test-only, CI tweaks) do not
+need a changelog entry.
+
+When a release is cut (see below), `/cut-release` promotes the `[Unreleased]`
+entries into the new version section automatically.
+
 ## Creating a release
 
 Use the `/cut-release` skill, which walks through the full flow (preflight, change


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` backfilled for all releases (v0.1.0 → v1.4.1) in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, with an `[Unreleased]` section at the top and compare-link references at the bottom. RC tags (v1.0.0-rc1..rc5) are consolidated into the `[1.0.0]` entry.
- Update `cut-release` skill: add **Step 5a** that promotes approved summary bullets into a new CHANGELOG version section (via a `chore/changelog-vX.Y.Z` branch + squash PR) before the tag is created. Adds a matching Rule: never tag before the changelog PR is merged.
- Add a **Changelog** section to `CONTRIBUTING.md` explaining the convention: add `[Unreleased]` bullets in every PR for user-facing changes; `/cut-release` promotes them automatically.
- Add `CHANGELOG.md` to the Docs list in `AGENTS.md`.