### PR TITLE
🔧 chore: add CLAUDE.md and ban Co-Authored-By trailers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Follow the `git-workflow` skill (`.claude/skills/git-workflow/SKILL.md`). Key ru
 - Feature branches only, never commit to `main`
 - Squash merge via PR
 - Keep PRs small and focused
+- **NEVER add `Co-Authored-By:` trailers to commits** — no Claude attribution, no exceptions
 
 **Before making any code changes**, always create a feature branch first:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# BpMonitor
+
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` as harness entry point — imports `AGENTS.md` so there is one source of truth
- Add explicit rule to `AGENTS.md` Git Workflow section: never add `Co-Authored-By:` trailers