### PR TITLE
📝 docs: add changelog entry for install.sh removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Install guide now documents manual tarball download and Docker Compose; the `install.sh` script has been removed.
+
 ## [1.4.2] - 2026-06-15
 
 ### Added


### PR DESCRIPTION
## Summary
- Add `[Unreleased]` entry missed in #214 — documents that `install.sh` was removed and the install guide now covers manual tarball and Docker Compose.