### PR TITLE
💄 style: gray out and disable period pills with no data

### DIFF
--- a/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
@@ -185,3 +185,25 @@ let ``trendsPanel with invalid gran string returns 400`` () =
   TestHost.run ReadingHandlers.trendsPanel ctx
 
   test <@ ctx.Response.StatusCode = 400 @>
+
+[<Fact>]
+let ``trendsPanel period pills without data are aria-disabled and have no href`` () =
+  let tp = FakeTimeProvider(trendsNow)
+
+  // Only a reading in current week (W24) — Last Week (W23) has no data
+  let r =
+    { sample with
+        Timestamp = trendsNow.AddDays(-1.0) // W24
+        Systolic = 130 }
+
+  let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
+  setRouteGran ctx "weekly"
+  TestHost.run ReadingHandlers.trendsPanel ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  let body = TestHost.readBody ctx
+  // W24 (This Week) pill should be a normal link
+  test <@ body.Contains "href=\"/trends/weekly/2026-W24\"" @>
+  // W23 (Last Week) pill should be disabled — no href, has aria-disabled
+  test <@ body.Contains "href=\"/trends/weekly/2026-W23\"" |> not @>
+  test <@ body.Contains "aria-disabled=\"true\"" @>

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -82,9 +82,20 @@ module ReadingHandlers =
       let windowed = allReadings |> ReadingStats.between period.Start period.EndExclusive
       let summary = ReadingStats.summarizeRange period windowed
       let periods = TrendPeriod.available Weekly now
+
+      let periodsWithData =
+        periods
+        |> List.filter (fun p ->
+          allReadings
+          |> ReadingStats.between p.Start p.EndExclusive
+          |> List.isEmpty
+          |> not)
+        |> List.map _.Key
+        |> Set.ofList
+
       let tableReadings = windowed |> List.sortByDescending _.Timestamp
       let chartHtml = BpChart.toHtmlDashed Weekly (ReadingStats.aggregate Weekly windowed)
-      htmlResponse (TrendViews.trends m summary periods tableReadings chartHtml) ctx)
+      htmlResponse (TrendViews.trends m summary periods periodsWithData tableReadings chartHtml) ctx)
 
   let trendsPanel: HttpContext -> Task =
     withMember (fun m ctx ->
@@ -102,10 +113,21 @@ module ReadingHandlers =
         let windowed = allReadings |> ReadingStats.between period.Start period.EndExclusive
         let summary = ReadingStats.summarizeRange period windowed
         let periods = TrendPeriod.available gran now
+
+        let periodsWithData =
+          periods
+          |> List.filter (fun p ->
+            allReadings
+            |> ReadingStats.between p.Start p.EndExclusive
+            |> List.isEmpty
+            |> not)
+          |> List.map _.Key
+          |> Set.ofList
+
         let tableReadings = windowed |> List.sortByDescending _.Timestamp
         let chartHtml = BpChart.toHtmlDashed gran (ReadingStats.aggregate gran windowed)
 
-        htmlResponse (TrendViews.trendsPanel summary periods tableReadings chartHtml) ctx)
+        htmlResponse (TrendViews.trendsPanel summary periods periodsWithData tableReadings chartHtml) ctx)
 
   // ---------------------------------------------------------------------------
   // Reading CRUD

--- a/code/BpMonitor.Web/TrendViews.fs
+++ b/code/BpMonitor.Web/TrendViews.fs
@@ -11,6 +11,7 @@ module TrendViews =
   let trendsPanel
     (summary: WindowSummary)
     (periods: TrendPeriod list)
+    (periodsWithData: Set<string>)
     (readings: BloodPressureReading list)
     (chartHtml: string)
     : XmlNode =
@@ -44,22 +45,32 @@ module TrendViews =
 
     // ── Level 2: sub-period pills ────────────────────────────────────────────
     let periodButton (p: TrendPeriod) =
-      let href = $"/trends/{granSlug}/{p.Key}"
+      let isActive = p.Key = summary.PeriodKey
+      let hasData = periodsWithData |> Set.contains p.Key
 
-      let baseAttrs =
-        [ Attr.href href
-          Attr.role "button"
-          Attr.create "hx-get" href
-          Attr.create "hx-target" "#trends-panel"
-          Attr.create "hx-swap" "outerHTML" ]
+      if not hasData && not isActive then
+        Elem.a
+          [ Attr.role "button"
+            Attr.class' "outline"
+            Attr.create "aria-disabled" "true" ]
+          [ Text.raw p.Label ]
+      else
+        let href = $"/trends/{granSlug}/{p.Key}"
 
-      let attrs =
-        if p.Key = summary.PeriodKey then
-          baseAttrs @ [ Attr.create "aria-current" "page" ]
-        else
-          baseAttrs @ [ Attr.class' "outline" ]
+        let baseAttrs =
+          [ Attr.href href
+            Attr.role "button"
+            Attr.create "hx-get" href
+            Attr.create "hx-target" "#trends-panel"
+            Attr.create "hx-swap" "outerHTML" ]
 
-      Elem.a attrs [ Text.raw p.Label ]
+        let attrs =
+          if isActive then
+            baseAttrs @ [ Attr.create "aria-current" "page" ]
+          else
+            baseAttrs @ [ Attr.class' "outline" ]
+
+        Elem.a attrs [ Text.raw p.Label ]
 
     // ── Content ──────────────────────────────────────────────────────────────
     let content =
@@ -102,6 +113,7 @@ module TrendViews =
     (m: FamilyMember)
     (summary: WindowSummary)
     (periods: TrendPeriod list)
+    (periodsWithData: Set<string>)
     (readings: BloodPressureReading list)
     (chartHtml: string)
     : XmlNode =
@@ -111,4 +123,4 @@ module TrendViews =
       m.IsAdmin
       "Trends"
       [ Elem.h1 [] [ Text.raw "Trends" ]
-        trendsPanel summary periods readings chartHtml ]
+        trendsPanel summary periods periodsWithData readings chartHtml ]

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -286,6 +286,13 @@ form.inline button {
   border-color: var(--pico-primary);
 }
 
+/* Disabled sub-period pill (no data in that period) */
+.trends-subperiod-buttons a[aria-disabled="true"] {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+}
+
 /* Stats table inside the panel */
 .trends-stats {
   width: auto;


### PR DESCRIPTION
## Summary

- Period pills in the trends sub-period strip that have no readings are now rendered as disabled `<a aria-disabled="true">` elements (no `href`, no htmx attributes) so they remain visible but are grayed out and unclickable
- The active period pill is always kept fully interactive regardless of data presence
- Added `.trends-subperiod-buttons a[aria-disabled="true"]` CSS rule: `opacity: 0.4`, `cursor: default`, `pointer-events: none`
- Both `trendsPanel` and `trends` handlers compute a `periodsWithData: Set<string>` by filtering all readings against each period's time range, then pass it to the view
- Covered by a new test: verifies that a period without data renders without `href` and with `aria-disabled="true"`, while a period with data keeps its link
- Closes the "period pills without data" item from TODOs.md