### PR TITLE
🔧 chore: use absolute path for git add in cut-release skill

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -135,7 +135,7 @@ Edit `CHANGELOG.md`:
 Commit, push, open a PR, and **merge it to `main`** before proceeding:
 
 ```bash
-git add CHANGELOG.md
+git add "$(git rev-parse --show-toplevel)/CHANGELOG.md"
 git commit -m "📝 docs: update changelog for vX.Y.Z"
 git push -u origin chore/changelog-vX.Y.Z
 gh pr create --title "📝 docs: update changelog for vX.Y.Z" --body "Changelog entry for the upcoming vX.Y.Z release."


### PR DESCRIPTION
## Summary

- `git add CHANGELOG.md` in the cut-release skill silently fails when the shell cwd is `code/` rather than the repo root
- Replace with `git add "$(git rev-parse --show-toplevel)/CHANGELOG.md"` so the path resolves correctly regardless of cwd