### PR TITLE
♻️ refactor: extract authenticatedMemberName helper in AuthHandlers

### DIFF
--- a/code/BpMonitor.Web/AuthHandlers.fs
+++ b/code/BpMonitor.Web/AuthHandlers.fs
@@ -29,6 +29,10 @@ module AuthHandlers =
       | true, id -> (memberRepo ctx).GetById(id)
       | _ -> None
 
+  /// Returns the authenticated member's name, or "" if unauthenticated.
+  let authenticatedMemberName (ctx: HttpContext) : string =
+    authenticatedMember ctx |> Option.map _.Name |> Option.defaultValue ""
+
   /// Builds the auth claims principal for a member.
   let claimsPrincipal (m: FamilyMember) : ClaimsPrincipal =
     let claims =

--- a/code/BpMonitor.Web/MemberHandlers.fs
+++ b/code/BpMonitor.Web/MemberHandlers.fs
@@ -34,10 +34,9 @@ module MemberHandlers =
 
   let editMember: HttpContext -> Task =
     withRouteMember "editMember" (fun m ctx ->
-      let adminName =
-        authenticatedMember ctx |> Option.map _.Name |> Option.defaultValue ""
-
-      htmlResponse (MemberViews.memberForm Routes.members adminName true "Edit member" $"/members/{m.Id}" [] m) ctx)
+      htmlResponse
+        (MemberViews.memberForm Routes.members (authenticatedMemberName ctx) true "Edit member" $"/members/{m.Id}" [] m)
+        ctx)
 
   let private renderMemberEditError
     (id: int)
@@ -90,15 +89,12 @@ module MemberHandlers =
   let updateMember: HttpContext -> Task =
     withRouteMember "updateMember" (fun existing ctx ->
       task {
-        let adminName =
-          authenticatedMember ctx |> Option.map _.Name |> Option.defaultValue ""
-
         let! form = ctx.Request.ReadFormAsync()
 
         do!
           applyMemberEdit
             existing.Id
-            adminName
+            (authenticatedMemberName ctx)
             existing
             (form["Name"].ToString())
             (form.ContainsKey("IsAdmin"))


### PR DESCRIPTION
## Summary

- Add `authenticatedMemberName` to `AuthHandlers` — resolves the authenticated member's name from the principal, returning `""` if unauthenticated
- Replace the duplicated `authenticatedMember ctx |> Option.map _.Name |> Option.defaultValue ""` expression in `editMember` and `updateMember` with a single call to the new helper