### PR TITLE
♻️ refactor: fix MemberMapping.toEntity to take explicit timestamps

### DIFF
--- a/code/BpMonitor.Data/EfFamilyMemberRepository.fs
+++ b/code/BpMonitor.Data/EfFamilyMemberRepository.fs
@@ -17,14 +17,14 @@ module private MemberMapping =
       CreatedAt = r.CreatedAt
       ModifiedAt = r.ModifiedAt }
 
-  let toEntity (now: System.DateTimeOffset) (m: FamilyMember) : MemberRecord =
+  let toEntity (createdAt: System.DateTimeOffset) (modifiedAt: System.DateTimeOffset) (m: FamilyMember) : MemberRecord =
     { Id = m.Id
       Name = m.Name
       IsAdmin = m.IsAdmin
       IsActive = m.IsActive
       PasswordHash = m.PasswordHash |> Option.defaultValue ""
-      CreatedAt = now
-      ModifiedAt = now }
+      CreatedAt = createdAt
+      ModifiedAt = modifiedAt }
 
 type EfFamilyMemberRepository(ctx: BpMonitorDbContext, timeProvider: System.TimeProvider) =
   interface IFamilyMemberRepository with
@@ -38,7 +38,7 @@ type EfFamilyMemberRepository(ctx: BpMonitorDbContext, timeProvider: System.Time
 
     member _.Add(m) =
       let now = timeProvider.GetUtcNow()
-      let entity = MemberMapping.toEntity now m
+      let entity = MemberMapping.toEntity now now m
       let entry = ctx.Members.Add(entity)
       ctx.SaveChanges() |> ignore
       MemberMapping.toDomain entry.Entity
@@ -55,14 +55,5 @@ type EfFamilyMemberRepository(ctx: BpMonitorDbContext, timeProvider: System.Time
         |> Seq.tryFind (fun e -> e.Entity.Id = m.Id)
         |> Option.iter (fun e -> e.State <- Microsoft.EntityFrameworkCore.EntityState.Detached)
 
-        let entity: MemberRecord =
-          { Id = m.Id
-            Name = m.Name
-            IsAdmin = m.IsAdmin
-            IsActive = m.IsActive
-            PasswordHash = m.PasswordHash |> Option.defaultValue ""
-            CreatedAt = m.CreatedAt
-            ModifiedAt = now }
-
-        ctx.Members.Update(entity) |> ignore
+        ctx.Members.Update(MemberMapping.toEntity m.CreatedAt now m) |> ignore
         ctx.SaveChanges() |> ignore


### PR DESCRIPTION
## Summary

- `MemberMapping.toEntity` previously took a single `now` timestamp and used it for both `CreatedAt` and `ModifiedAt`, making it unusable for updates (which must preserve the original `CreatedAt`)
- Change the signature to `(createdAt, modifiedAt, member)` so it covers both cases
- `Add` passes `now now` (both timestamps fresh); `Update` passes `m.CreatedAt now` (preserves creation time)
- Eliminates the 8-line inline entity construction in `Update` that duplicated the mapping logic