### PR TITLE
💄 style: sidebar nav improvements

### DIFF
--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -75,9 +75,8 @@ module ViewLayout =
               [ Elem.ul
                   []
                   [ Elem.li
-                      [ Attr.class' "sidebar-header-item" ]
-                      [ Elem.strong [] [ Text.raw "BpMonitor" ]
-                        Elem.label
+                      []
+                      [ Elem.label
                           [ Attr.create "for" "nav-toggle"
                             Attr.class' "sidebar-collapse"
                             Attr.create "aria-label" "Collapse sidebar" ]

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -50,11 +50,38 @@ module ViewLayout =
       [ htmlHead title [ Elem.script [ Attr.src "/htmx.min.js" ] [] ]
         Elem.body
           [ Attr.create "hx-boost" "true" ]
-          [ Elem.nav
-              [ Attr.class' "container" ]
+          [ // Checkbox drives the mobile off-canvas drawer via pure CSS sibling selectors.
+            // hx-boost re-renders <body> on every navigation, so the checkbox resets to
+            // unchecked automatically — the drawer auto-closes after tapping a link.
+            Elem.input
+              [ Attr.type' "checkbox"
+                Attr.id "nav-toggle"
+                Attr.create "aria-hidden" "true" ]
+            Elem.label
+              [ Attr.create "for" "nav-toggle"
+                Attr.class' "nav-burger"
+                Attr.create "aria-label" "Menu" ]
+              [ Text.raw "☰" ]
+            // Second label for same checkbox: acts as the backdrop — clicking it unchecks
+            // the checkbox and closes the drawer.
+            Elem.label [ Attr.create "for" "nav-toggle"; Attr.class' "nav-backdrop" ] []
+            Elem.button
+              [ Attr.id "theme-toggle"
+                Attr.class' "outline secondary"
+                Attr.create "onclick" "toggleTheme()" ]
+              []
+            Elem.nav
+              [ Attr.class' "sidebar" ]
               [ Elem.ul
                   []
-                  [ Elem.li [] [ Elem.strong [] [ Text.raw "BpMonitor" ] ]
+                  [ Elem.li
+                      [ Attr.class' "sidebar-header-item" ]
+                      [ Elem.strong [] [ Text.raw "BpMonitor" ]
+                        Elem.label
+                          [ Attr.create "for" "nav-toggle"
+                            Attr.class' "sidebar-collapse"
+                            Attr.create "aria-label" "Collapse sidebar" ]
+                          [ Text.raw "◀" ] ]
                     navLink active Routes.home "Home"
                     navLink active Routes.add "Add"
                     navLink active Routes.history "History"
@@ -71,23 +98,17 @@ module ViewLayout =
                       [ Elem.a [ Attr.href Routes.exportCsv; Attr.create "hx-boost" "false" ] [ Text.raw "Export CSV" ] ]
                     if isAdmin then
                       navLink active Routes.members "Members" ]
-                Elem.ul
-                  []
-                  [ Elem.li [] [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ] ]
-                    Elem.li
-                      []
-                      [ Elem.form
-                          [ Attr.method "post"; Attr.action "/logout"; Attr.class' "inline" ]
-                          [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Logout" ] ] ]
-                    Elem.li
-                      []
-                      [ Elem.button
-                          [ Attr.id "theme-toggle"
-                            Attr.class' "outline secondary"
-                            Attr.create "onclick" "toggleTheme()" ]
-                          [] ] ] ]
-            Elem.main [ Attr.class' "container" ] content
-            Elem.footer [ Attr.class' "container" ] [ Elem.small [] (versionFooter ()) ]
+                // Member name and logout pinned to the bottom of the sidebar.
+                Elem.div
+                  [ Attr.class' "sidebar-user" ]
+                  [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ]
+                    Elem.form
+                      [ Attr.method "post"; Attr.action "/logout"; Attr.class' "inline" ]
+                      [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Logout" ] ] ] ]
+            Elem.div
+              [ Attr.class' "content" ]
+              [ Elem.main [ Attr.class' "container" ] content
+                Elem.footer [ Attr.class' "container" ] [ Elem.small [] (versionFooter ()) ] ]
             // Re-runs on every body render (initial + hx-boost swaps) to sync the button label.
             Elem.script [ Attr.src "/theme-label.js" ] [] ] ]
 
@@ -98,18 +119,11 @@ module ViewLayout =
       [ htmlHead title []
         Elem.body
           [ Attr.create "hx-boost" "false" ]
-          [ Elem.nav
-              [ Attr.class' "container" ]
-              [ Elem.ul [] []
-                Elem.ul
-                  []
-                  [ Elem.li
-                      []
-                      [ Elem.button
-                          [ Attr.id "theme-toggle"
-                            Attr.class' "outline secondary"
-                            Attr.create "onclick" "toggleTheme()" ]
-                          [] ] ] ]
+          [ Elem.button
+              [ Attr.id "theme-toggle"
+                Attr.class' "outline secondary"
+                Attr.create "onclick" "toggleTheme()" ]
+              []
             Elem.main
               [ Attr.class' "container login-container" ]
               ([ Elem.header

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -1,18 +1,116 @@
-main,
-nav.container {
+/* ── Layout: sidebar + content area ─────────────────────────────────────── */
+
+body {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* Checkbox that drives the mobile off-canvas drawer — visually hidden */
+#nav-toggle {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Hamburger button — hidden on desktop, shown on mobile.
+   Specificity needs to be (0,1,1) to beat Pico's
+   [type="checkbox"] ~ label { display: inline-block } rule (also 0,1,1),
+   relying on app.css loading after pico.min.css for the tie-break. */
+label.nav-burger {
+  display: none;
+}
+
+/* Backdrop overlay — hidden until drawer is open on mobile. Same specificity
+   reasoning as .nav-burger above. */
+label.nav-backdrop {
+  display: none;
+}
+
+nav.sidebar {
+  width: 14rem;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  position: sticky;
+  top: 0;
+  overflow-y: auto;
+  border-right: 1px solid var(--pico-muted-border-color);
+  padding: 1rem 0.75rem;
+  /* Reset Pico's horizontal-flex nav layout */
+  justify-content: flex-start;
+  gap: 0;
+}
+
+/* Override Pico's horizontal <ul> inside nav */
+nav.sidebar ul {
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  margin: 0;
+  gap: 0;
+}
+
+nav.sidebar ul li {
+  padding: 0;
+  margin: 0;
+}
+
+/* Sidebar header row: title + collapse button */
+.sidebar-header-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sidebar-header-item strong {
+  flex: 1;
+}
+
+/* Collapse button (◀) — desktop only; hidden on mobile */
+.sidebar-collapse {
+  display: none;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0.1rem 0.3rem;
+  line-height: 1;
+  user-select: none;
+}
+
+/* Member name / logout / theme toggle pinned to the sidebar bottom */
+.sidebar-user {
+  margin-top: auto;
+  padding-top: 1rem;
+  border-top: 1px solid var(--pico-muted-border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding-left: 1rem;
+}
+
+main {
   max-width: 700px;
 }
 
 nav a[aria-current="page"] {
-  background: var(--pico-primary);
-  color: var(--pico-primary-inverse);
   font-weight: 600;
-  padding: 0.25rem 0.75rem;
-  border-radius: var(--pico-border-radius);
-  text-decoration: none;
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 #theme-toggle {
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 200;
   padding: 0.25rem 0.75rem;
   font-size: 0.875rem;
   margin: 0;
@@ -102,6 +200,98 @@ g.errorbars path.yerror {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+  }
+
+  /* ── Mobile sidebar / off-canvas drawer ─────────────────────────────────── */
+
+  /* Hamburger button — fixed top-left, above all content.
+     label.nav-burger for (0,1,1) specificity to beat Pico's checkbox~label rule. */
+  label.nav-burger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: 0.5rem;
+    left: 0.5rem;
+    z-index: 200;
+    cursor: pointer;
+    font-size: 1.25rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    background: var(--pico-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    line-height: 1;
+    user-select: none;
+  }
+
+  /* Sidebar slides off-screen by default; slides in when checkbox is checked */
+  nav.sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    min-height: 100vh;
+    z-index: 100;
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    background: var(--pico-background-color);
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
+  }
+
+  #nav-toggle:checked ~ nav.sidebar {
+    transform: translateX(0);
+  }
+
+  /* Backdrop shown when drawer is open; starts after the sidebar so
+     it only covers the content area — avoids z-index interception. */
+  #nav-toggle:checked ~ label.nav-backdrop {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 14rem;
+    right: 0;
+    bottom: 0;
+    z-index: 99;
+    background: rgba(0, 0, 0, 0.4);
+  }
+
+  /* Push content down to clear the hamburger button */
+  .content {
+    padding-top: 3rem;
+  }
+}
+
+/* ── Desktop sidebar collapse ───────────────────────────────────────────── */
+@media (min-width: 601px) {
+  /* Show the collapse button (◀) inside the sidebar header */
+  .sidebar-collapse {
+    display: flex;
+    align-items: center;
+  }
+
+  /* Hide sidebar and show hamburger as the restore button */
+  #nav-toggle:checked ~ nav.sidebar {
+    display: none;
+  }
+
+  #nav-toggle:checked ~ label.nav-burger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: 0.5rem;
+    left: 0.5rem;
+    z-index: 200;
+    cursor: pointer;
+    font-size: 1.25rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    background: var(--pico-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    line-height: 1;
+    user-select: none;
   }
 }
 

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -56,16 +56,6 @@ nav.sidebar ul li {
   margin: 0;
 }
 
-/* Sidebar header row: title + collapse button */
-.sidebar-header-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.sidebar-header-item strong {
-  flex: 1;
-}
 
 /* Collapse button (◀) — desktop only; hidden on mobile */
 .sidebar-collapse {

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -67,6 +67,12 @@ nav.sidebar ul li {
   user-select: none;
 }
 
+/* Right-align the collapse button in its li so it sits at the sidebar edge */
+li:has(.sidebar-collapse) {
+  display: flex;
+  justify-content: flex-end;
+}
+
 /* Member name / logout / theme toggle pinned to the sidebar bottom */
 .sidebar-user {
   margin-top: auto;

--- a/code/BpMonitor.Web/wwwroot/theme-label.js
+++ b/code/BpMonitor.Web/wwwroot/theme-label.js
@@ -1,2 +1,2 @@
-// Re-runs on every body render (initial + hx-boost swaps) to sync the button label.
-(()=> {var b=document.getElementById('theme-toggle');if(b)b.textContent=document.documentElement.getAttribute('data-theme')==='dark'?'Light':'Dark';})();
+// Re-runs on every body render (initial + hx-boost swaps) to sync the button icon.
+(()=> {var b=document.getElementById('theme-toggle');if(b)b.textContent=document.documentElement.getAttribute('data-theme')==='dark'?'☀️':'🌙';})();

--- a/code/BpMonitor.Web/wwwroot/theme.js
+++ b/code/BpMonitor.Web/wwwroot/theme.js
@@ -22,7 +22,7 @@ window.toggleTheme=()=> {
   h.setAttribute('data-theme',n);
   localStorage.setItem('theme',n);
   var b=document.getElementById('theme-toggle');
-  if(b)b.textContent=n==='dark'?'Light':'Dark';
+  if(b)b.textContent=n==='dark'?'☀️':'🌙';
   applyChartTheme(n);
 };
 


### PR DESCRIPTION
## Summary
- Theme toggle button moved to fixed top-right corner (login and authenticated pages)
- Theme button now shows ☀️/🌙 emoji instead of "Light"/"Dark" text
- Sidebar is collapsible on desktop: ◀ in the sidebar collapses it, ☰ restores it
- Active nav link uses underline + bold instead of a filled pill highlight
- Sidebar headline ("BpMonitor") removed — collapse button right-aligned at top
- Content area gets `padding-left` for breathing room next to the sidebar border