### PR TITLE
✨ feat: add Recent page with 7/14/30-day rolling windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ code/
 ├── BpMonitor.Export.Tests
 ├── BpMonitor.Charts            # Plotly.NET chart generation → HTML output
 ├── BpMonitor.Charts.Tests
-├── BpMonitor.Web               # Falco web app (login + per-member auth, landing, add, history, members pages); Serilog structured stdout logging
+├── BpMonitor.Web               # Falco web app (login + per-member auth, landing, add, history, recent, trends, members pages); Serilog structured stdout logging
 ├── BpMonitor.Web.Tests
 └── BpMonitor.Arch.Tests        # ArchUnit Clean Architecture rules
 docs/                           # Product vision, architecture, ADRs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New **Recent** page (`/recent`) showing raw readings from the last 7, 14, and 30 days as three separate tables, plus a 30-day chart — no aggregates
+
 ## [1.5.1] - 2026-06-16
 
 ### Changed

--- a/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
+++ b/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="LoginHandlerTests.fs" />
     <Compile Include="TrendHandlerTests.fs" />
     <Compile Include="ExportHandlerTests.fs" />
+    <Compile Include="RecentHandlerTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -1,0 +1,135 @@
+module RecentHandlerTests
+
+open Xunit
+open Swensen.Unquote
+open Microsoft.Extensions.Time.Testing
+open BpMonitor.Core
+open BpMonitor.Web
+open HandlerTestHelpers
+
+let private now = Timestamp.utc 2026 6 17 12 0 0
+
+// Marge Simpson's readings for the last 5 years anchored to `now`, stamped as member 1.
+// Deterministic (fixed seed 1); ~3.5 readings/week guarantees data in every recent window.
+let private simpsonReadings =
+  DemoData.simpsons ReadingRanges.defaults now
+  |> List.head
+  |> snd
+  |> List.map (fun r -> { r with MemberId = defaultMemberId })
+
+let private reading daysAgo (id: int) : BloodPressureReading =
+  { Id = id
+    MemberId = defaultMemberId
+    Systolic = 120
+    Diastolic = 80
+    HeartRate = 66
+    Timestamp = now.AddDays(-float daysAgo)
+    Comments = None
+    CreatedAt = now
+    ModifiedAt = now }
+
+[<Fact>]
+let ``recent returns 200 with three window headings`` () =
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith []) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  let body = TestHost.readBody ctx
+
+  test
+    <@
+      body.Contains "Last 7 days"
+      && body.Contains "Last 14 days"
+      && body.Contains "Last 30 days"
+    @>
+
+[<Fact>]
+let ``recent renders pill links for each window`` () =
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith []) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+
+  test
+    <@
+      body.Contains "href=\"#days-7\""
+      && body.Contains "href=\"#days-14\""
+      && body.Contains "href=\"#days-30\""
+    @>
+
+[<Fact>]
+let ``recent sections have anchor ids`` () =
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith []) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+
+  test
+    <@
+      body.Contains "id=\"days-7\""
+      && body.Contains "id=\"days-14\""
+      && body.Contains "id=\"days-30\""
+    @>
+
+[<Fact>]
+let ``recent shows simpson readings in all three windows`` () =
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith simpsonReadings) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  let body = TestHost.readBody ctx
+  // Marge has ~3.5 readings/week — all three windows will have edit links.
+  test <@ body.Contains "/readings/" @>
+
+[<Fact>]
+let ``recent omits a reading older than 30 days`` () =
+  let tp = FakeTimeProvider(now)
+  let r = reading 31 1
+  let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "Last 30 days" && not (body.Contains "/readings/1/edit") @>
+
+[<Fact>]
+let ``recent does not show a reading from 10 days ago in the 7-day window`` () =
+  let tp = FakeTimeProvider(now)
+  let r = reading 10 42
+  let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  // 10-day reading falls in 14d and 30d windows but not 7d.
+  let body = TestHost.readBody ctx
+  let occurrences = body.Split("/readings/42/edit").Length - 1
+  test <@ occurrences = 2 @>
+
+[<Fact>]
+let ``recent renders a chart`` () =
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith simpsonReadings) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "Plotly.newPlot" @>
+
+[<Fact>]
+let ``recent chart is open by default`` () =
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith []) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "<details open" @>
+
+[<Fact>]
+let ``recent chart toggle label matches the history page's`` () =
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith []) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "Blood Pressure Graph<" && not (body.Contains "(last 30 days)") @>

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -25,6 +25,7 @@ let private endpoints =
     get Routes.home (AuthHandlers.protect ReadingHandlers.landing)
     get Routes.add (AuthHandlers.protect ReadingHandlers.newReading)
     get Routes.history (AuthHandlers.protect ReadingHandlers.history)
+    get Routes.recent (AuthHandlers.protect ReadingHandlers.recent)
     get Routes.trends (AuthHandlers.protect ReadingHandlers.trends)
     get "/trends/{gran}" (AuthHandlers.protect ReadingHandlers.trendsPanel)
     get "/trends/{gran}/{key}" (AuthHandlers.protect ReadingHandlers.trendsPanel)

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -74,6 +74,20 @@ module ReadingHandlers =
       let chartHtml = BpChart.toHtml readings
       htmlResponse (ReadingViews.history m chartHtml readings) ctx)
 
+  let recent: HttpContext -> Task =
+    withMember (fun m ctx ->
+      let now = (timeProvider ctx).GetUtcNow()
+      let allReadings = (repo ctx).GetAll(m.Id)
+
+      let window days =
+        allReadings
+        |> ReadingStats.between (now.AddDays(-float days)) now
+        |> List.sortByDescending _.Timestamp
+
+      let days30 = window 30
+      let chartHtml = BpChart.toHtml days30
+      htmlResponse (ReadingViews.recent m chartHtml (window 7) (window 14) days30) ctx)
+
   let trends: HttpContext -> Task =
     withMember (fun m ctx ->
       let now = (timeProvider ctx).GetUtcNow()

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -33,6 +33,39 @@ module ReadingViews =
             Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ]
         ViewLayout.readingsTable readings ]
 
+  /// Recent: chart of the last 30 days plus three rolling window tables (7/14/30 days).
+  let recent
+    (activeMember: FamilyMember)
+    (chartHtml: string)
+    (days7: BloodPressureReading list)
+    (days14: BloodPressureReading list)
+    (days30: BloodPressureReading list)
+    : XmlNode =
+    let pill (label: string) (anchor: string) =
+      Elem.a [ Attr.href $"#{anchor}"; Attr.role "button"; Attr.class' "outline" ] [ Text.raw label ]
+
+    let section (heading: string) (anchor: string) (readings: BloodPressureReading list) =
+      Elem.section [ Attr.id anchor ] [ Elem.h2 [] [ Text.raw heading ]; ViewLayout.readingsTable readings ]
+
+    ViewLayout.layout
+      Routes.recent
+      activeMember.Name
+      activeMember.IsAdmin
+      "Recent"
+      [ Elem.h1 [] [ Text.raw $"Recent — {activeMember.Name}" ]
+        Elem.div
+          [ Attr.class' "recent-window-buttons" ]
+          [ pill "Last 7 days" "days-7"
+            pill "Last 14 days" "days-14"
+            pill "Last 30 days" "days-30" ]
+        Elem.details
+          [ Attr.create "open" "" ]
+          [ Elem.summary [ Attr.class' "chart-toggle" ] [ Text.raw "Blood Pressure Graph" ]
+            Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ]
+        section "Last 7 days" "days-7" days7
+        section "Last 14 days" "days-14" days14
+        section "Last 30 days" "days-30" days30 ]
+
   /// Shared add/edit form. `action` is the POST target; `errors` are rendered
   /// above the fields when re-displaying after a failed submit.
   let readingForm

--- a/code/BpMonitor.Web/Routes.fs
+++ b/code/BpMonitor.Web/Routes.fs
@@ -10,5 +10,6 @@ module Routes =
   let trends = "/trends"
   let readings = "/readings"
   let members = "/members"
+  let recent = "/recent"
   let exportJson = "/export"
   let exportCsv = "/export.csv"

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -84,6 +84,7 @@ module ViewLayout =
                     navLink active Routes.home "Home"
                     navLink active Routes.add "Add"
                     navLink active Routes.history "History"
+                    navLink active Routes.recent "Recent"
                     navLink active Routes.trends "Trends"
                     // hx-boost="false" prevents htmx from AJAX-swapping the download response.
                     Elem.li

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,8 @@ graph TD
 - Falco web application on `0.0.0.0:5000`; references Core + Data + Charts + Export
 - **Auth:** ASP.NET Core cookie auth; per-member PBKDF2-SHA256 password; unclaimed members set password on first login; cookie carries `NameIdentifier`/`Name`/`Role` claims
 - **Isolation:** each member sees only their own readings; admins manage members via `/members` but not their readings
-- **Routes:** `/` hub, `/add`, `/history`, `/trends`, `/members`, `/members/{id}/edit`, `/members/{id}/reset-password`, `/login`, `/login/{id}`, `POST /logout`
+- **Routes:** `/` hub, `/add`, `/history`, `/recent`, `/trends`, `/members`, `/members/{id}/edit`, `/members/{id}/reset-password`, `/login`, `/login/{id}`, `POST /logout`
+- **`/recent`:** three rolling windows (last 7 / 14 / 30 days) of raw readings plus a 30-day chart — no aggregation
 - **`/trends`:** granularity selector (Weekly/Monthly/Yearly) + htmx-swapped period fragments; stats from `ReadingStats` (Core); `TimeProvider` injected for testability
 - `protect` / `protectAdmin` combinators; active member resolved from `ClaimsPrincipal`
 - Server-rendered HTML via `Falco.Markup`; htmx for partial updates; scoped `DbContext` per request


### PR DESCRIPTION
## Summary
- New `/recent` page showing raw readings in three rolling windows (last 7, 14, 30 days) as separate tables, plus a 30-day chart — no aggregates
- Nav link added; docs and changelog updated to match