### PR TITLE
🔧 chore: add launchSettings.json for dotnet run default Development env

### DIFF
--- a/code/BpMonitor.Web/Properties/launchSettings.json
+++ b/code/BpMonitor.Web/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "BpMonitor.Web": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/code/BpMonitor.Web/appsettings.Development.json
+++ b/code/BpMonitor.Web/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "BpMonitor": {
+    "SeedDemoData": true
+  }
+}


### PR DESCRIPTION
## Summary
- `dotnet run` left `ASPNETCORE_ENVIRONMENT` unset, defaulting to Production, so `appsettings.Development.json` (`SeedDemoData: true`) never merged and the demo dataset silently failed to seed even on an empty DB
- Add `code/BpMonitor.Web/Properties/launchSettings.json` so `dotnet run` sets `ASPNETCORE_ENVIRONMENT=Development` by default
- Commit `code/BpMonitor.Web/appsettings.Development.json` (`SeedDemoData: true`) so this works out of the box for local dev