### PR TITLE
🔧 chore: suppress SQLitePCLRaw advisory blocking restore

### DIFF
--- a/code/Directory.Build.props
+++ b/code/Directory.Build.props
@@ -13,4 +13,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <!-- SQLitePCLRaw.lib.e_sqlite3 (transitive via EFCore.Sqlite): no patched NuGet package
+         exists yet, only an upstream SQLite source fix. Revisit when a fixed package ships. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- CI (and local restore) started failing with NU1903 for `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (transitive via `Microsoft.EntityFrameworkCore.Sqlite`), a newly-published advisory (GHSA-2m69-gcr7-jv3q / CVE-2025-6965)
- `TreatWarningsAsErrors=true` turns the NuGet audit warning into a hard restore failure
- No patched NuGet package exists yet — only an upstream SQLite source fix — so suppress this specific advisory via `NuGetAuditSuppress` until a fixed package ships