### PR TITLE
🐛 fix: pin sidebar correctly and shrink it on mobile and desktop

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -6,10 +6,6 @@ A loose collection of TODOs I want to tackle at some point in time.
 
 The mobile layout has room for improvement...
 
-- The sidebar
-  - is too wide
-  - should be pinned, so when it's expanded the entries should stay visible when scrolling down in the main window
-- all charts have the wrong width when they are initially opened (they are too narrow)
 - all charts heights are too large, they height can be smaller
 - recent page: 7/14/30 buttons should be smaller (similar height as on page trends)
 - The trend readings table is too wide on mobile

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -1,7 +1,14 @@
 /* ── Layout: sidebar + content area ─────────────────────────────────────── */
 
+:root {
+  /* Single source of truth for the sidebar's width — referenced by nav.sidebar,
+     the mobile backdrop's offset, and .content's margin-left, so they can't
+     drift out of sync. Same value on mobile and desktop (desktop used to be
+     14rem, which felt oversized for a nav-only column). */
+  --sidebar-width: 11rem;
+}
+
 body {
-  display: flex;
   min-height: 100vh;
 }
 
@@ -26,20 +33,28 @@ label.nav-backdrop {
   display: none;
 }
 
+/* `position: fixed` (not `sticky`) — sticky broke once the sidebar's own box
+   was stretched (via the body's flex layout) to match the height of the
+   page's tallest content, leaving it no shorter containing block to stick
+   within, so it scrolled away with the rest of the page on long pages like
+   History. Fixed takes it out of flow entirely; .content's margin-left
+   below reserves the space it would otherwise have occupied. */
 nav.sidebar {
-  width: 14rem;
-  flex-shrink: 0;
+  width: var(--sidebar-width);
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
+  height: 100vh;
+  z-index: 10;
   overflow-y: auto;
   border-right: 1px solid var(--pico-muted-border-color);
   padding: 1rem 0.75rem;
   /* Reset Pico's horizontal-flex nav layout */
   justify-content: flex-start;
   gap: 0;
+  background: var(--pico-background-color);
 }
 
 /* Override Pico's horizontal <ul> inside nav */
@@ -85,10 +100,10 @@ li:has(.sidebar-collapse) {
 }
 
 .content {
-  flex: 1;
-  min-width: 0;
+  margin-left: var(--sidebar-width);
   display: flex;
   flex-direction: column;
+  min-height: 100vh;
   padding-left: 1rem;
 }
 
@@ -221,17 +236,14 @@ g.errorbars path.yerror {
     user-select: none;
   }
 
-  /* Sidebar slides off-screen by default; slides in when checkbox is checked */
+  /* Sidebar is an off-canvas drawer on mobile: slides off-screen by default
+     (translateX), slides in when the checkbox is checked. Position/size
+     come from the shared baseline rule above — only the slide behavior and
+     stacking (above the backdrop) are mobile-specific. */
   nav.sidebar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    height: 100vh;
-    min-height: 100vh;
     z-index: 100;
     transform: translateX(-100%);
     transition: transform 0.25s ease;
-    background: var(--pico-background-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
   }
 
@@ -245,15 +257,18 @@ g.errorbars path.yerror {
     display: block;
     position: fixed;
     top: 0;
-    left: 14rem;
+    left: var(--sidebar-width);
     right: 0;
     bottom: 0;
     z-index: 99;
     background: rgba(0, 0, 0, 0.4);
   }
 
-  /* Push content down to clear the hamburger button */
+  /* On mobile the sidebar overlays as a drawer rather than pushing content
+     over, so content shouldn't reserve space for it. Also push content down
+     to clear the fixed hamburger button. */
   .content {
+    margin-left: 0;
     padding-top: 3rem;
   }
 }
@@ -269,6 +284,12 @@ g.errorbars path.yerror {
   /* Hide sidebar and show hamburger as the restore button */
   #nav-toggle:checked ~ nav.sidebar {
     display: none;
+  }
+
+  /* Sidebar is fixed (out of flow), so .content's margin-left above only
+     reserves its space while it's visible — release it when collapsed. */
+  #nav-toggle:checked ~ .content {
+    margin-left: 0;
   }
 
   #nav-toggle:checked ~ label.nav-burger {


### PR DESCRIPTION
## Summary
- Switch `nav.sidebar` from `position: sticky` to `position: fixed` — sticky broke once flex stretch made the sidebar's own box as tall as the page's tallest content, so it scrolled away on long pages like History (both desktop and mobile affected).
- Narrow the sidebar from 14rem to 11rem on both breakpoints via a shared `--sidebar-width` CSS variable (was eating ~60% of a phone screen and felt oversized on desktop too).
- As a side effect, `.content` no longer being a flex item also fixes charts rendering too narrow on initial open.

## Test plan
- Verified via Playwright at mobile (375px), tablet (800px), and desktop (1280px) viewports: sidebar entries, member name, and logout stay visible after scrolling 2000px down the History page.
- Verified desktop sidebar collapse/restore still works (content reclaims full width when collapsed).
- Verified `mise run lint:js` / pre-commit hooks pass.