### PR TITLE
🐛 fix: shrink chart heights on mobile and desktop

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -6,7 +6,6 @@ A loose collection of TODOs I want to tackle at some point in time.
 
 The mobile layout has room for improvement...
 
-- all charts heights are too large, they height can be smaller
 - recent page: 7/14/30 buttons should be smaller (similar height as on page trends)
 - The trend readings table is too wide on mobile
   - use "cards" instead of row (not practical for yearly view)

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -136,7 +136,9 @@ nav a[aria-current="page"] {
 }
 
 :root {
-  --chart-height: 620px;
+  /* Was 620px — left a lot of empty space below the plotted data on both
+     chart types (history's line chart, trends' dashed/error-bar chart). */
+  --chart-height: 420px;
 }
 
 .chart {
@@ -192,8 +194,11 @@ g.errorbars path.yerror {
     flex: 1 1 100%;
   }
 
+  /* Was 420px. Can't go much shorter than this on mobile — both chart types
+     use the default (non-compact) top/bottom margins at this width, and a
+     shorter box starts clipping the x-axis labels and bottom legend row. */
   :root {
-    --chart-height: 420px;
+    --chart-height: 380px;
   }
 
   /* Stats table: full width, tighter column padding */


### PR DESCRIPTION
## Summary
- Reduce `--chart-height` from 620px to 420px on desktop, and from 420px to 380px on mobile — both left a lot of empty whitespace below the plotted data.

## Test plan
- Verified via Playwright on both chart types (history's line chart, trends' dashed/error-bar chart) at mobile (375px) and desktop (1280px) viewports: x-axis labels and legend render fully, unclipped, at the new heights.
- 380px is close to the floor for mobile — both chart types use default (non-compact) margins at that width, and going shorter starts clipping the x-axis labels/legend.