### PR TITLE
📝 docs: remove completed recent-page button-size todo

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -6,7 +6,6 @@ A loose collection of TODOs I want to tackle at some point in time.
 
 The mobile layout has room for improvement...
 
-- recent page: 7/14/30 buttons should be smaller (similar height as on page trends)
 - The trend readings table is too wide on mobile
   - use "cards" instead of row (not practical for yearly view)
   - or: shorten time stamp string


### PR DESCRIPTION
## Summary
- The "recent page: 7/14/30 buttons should be smaller" todo was resolved by #241