### PR TITLE
✨ feat: spike Playwright .NET E2E smoke tests for the web app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
         run: dotnet build --no-restore --configuration Release
         working-directory: code
 
+      - name: Install Playwright browsers
+        run: pwsh bin/Release/net10.0/playwright.ps1 install --with-deps chromium
+        working-directory: code/BpMonitor.Web.E2E.Tests
+
       - name: Test
         run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura
         working-directory: code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ code/
 ├── BpMonitor.Charts.Tests
 ├── BpMonitor.Web               # Falco web app (login + per-member auth, landing, add, history, recent, trends, members pages); Serilog structured stdout logging
 ├── BpMonitor.Web.Tests
+├── BpMonitor.Web.E2E.Tests     # Playwright .NET browser smoke tests against a real out-of-process BpMonitor.Web instance
 └── BpMonitor.Arch.Tests        # ArchUnit Clean Architecture rules
 docs/                           # Product vision, architecture, ADRs
 scripts/                        # Dev tooling scripts (e.g. extract-plotly-js.fsx)
@@ -105,7 +106,7 @@ Never start work on `main`. Creating the branch is the first step, not an aftert
 
 ## Testing
 
-Tests run on **Microsoft.Testing.Platform (MTP)** — all 7 test projects execute in parallel (default: CPU count concurrent modules):
+Tests run on **Microsoft.Testing.Platform (MTP)** — all 8 test projects execute in parallel (default: CPU count concurrent modules):
 
 ```bash
 # Run all tests in parallel (local dev)
@@ -120,6 +121,8 @@ dotnet test --configuration Release --max-parallel-test-modules 2
 ```
 
 `BpMonitor.Arch.Tests` uses `DoNotResideInNamespaceMatching("Microsoft\\.CodeCoverage.*")` in its type filters to exclude coverage-injected tracker types from ArchUnitNET dependency checks.
+
+`BpMonitor.Web.E2E.Tests` boots a real `BpMonitor.Web` instance out-of-process (`dotnet run`, fresh temp SQLite file, demo seeding off) on a free port, then drives it with a real Playwright Chromium browser. First run needs Chromium installed locally — `playwright.ps1 install chromium` from the build output dir if `pwsh` is available, otherwise via `dotnet fsi` calling `Microsoft.Playwright.Program.Main([| "install"; "chromium" |])`.
 
 ## Dev Tooling
 

--- a/code/BpMonitor.Web.E2E.Tests/BpMonitor.Web.E2E.Tests.fsproj
+++ b/code/BpMonitor.Web.E2E.Tests/BpMonitor.Web.E2E.Tests.fsproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="WebAppFixture.fs" />
+    <Compile Include="SmokeTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Unquote" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.Playwright" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Referenced only so `dotnet test` builds the web app before the suite runs;
+         the app itself is launched out-of-process via `dotnet run`, not in-process. -->
+    <ProjectReference Include="..\BpMonitor.Web\BpMonitor.Web.fsproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
+++ b/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
@@ -1,0 +1,42 @@
+module BpMonitor.Web.E2E.SmokeTests
+
+open System.Threading.Tasks
+open Microsoft.Playwright
+open Xunit
+
+/// End-to-end smoke test: claim the default account, add a reading, and
+/// confirm it shows up in the history table. Runs against a real
+/// out-of-process BpMonitor.Web instance with a real browser.
+type LoginAddHistoryTests(fixture: WebAppFixture) =
+  interface IClassFixture<WebAppFixture>
+
+  [<Fact>]
+  member _.``login, add a reading, and see it in history``() : Task =
+    task {
+      let! page = fixture.Browser.NewPageAsync()
+
+      // Log in: claim the default "Me" account.
+      let! _ = page.GotoAsync($"{fixture.BaseUrl}/login")
+      do! page.FillAsync("#Username", "Me")
+      do! page.ClickAsync("button[type=submit]")
+
+      do! page.FillAsync("#Password", "correct-horse-battery-staple")
+      do! page.FillAsync("#PasswordConfirm", "correct-horse-battery-staple")
+      do! page.ClickAsync("button[type=submit]")
+      do! page.WaitForURLAsync($"{fixture.BaseUrl}/")
+
+      // Add a reading.
+      let! _ = page.GotoAsync($"{fixture.BaseUrl}/add")
+      do! page.FillAsync("#Timestamp", "2026-06-19 08:30")
+      do! page.FillAsync("#Systolic", "118")
+      do! page.FillAsync("#Diastolic", "76")
+      do! page.FillAsync("#HeartRate", "62")
+      do! page.ClickAsync("form[action='/readings'] button[type=submit]")
+      do! page.WaitForURLAsync($"{fixture.BaseUrl}/history")
+
+      // Confirm it appears in the history table.
+      let! tableText = page.Locator("table").TextContentAsync()
+      Assert.Contains("118", tableText)
+      Assert.Contains("76", tableText)
+      Assert.Contains("62", tableText)
+    }

--- a/code/BpMonitor.Web.E2E.Tests/WebAppFixture.fs
+++ b/code/BpMonitor.Web.E2E.Tests/WebAppFixture.fs
@@ -1,0 +1,107 @@
+namespace BpMonitor.Web.E2E
+
+open System
+open System.Diagnostics
+open System.IO
+open System.Net.Http
+open System.Net.Sockets
+open System.Threading.Tasks
+open Microsoft.Playwright
+open Xunit
+
+/// Locates the repository's `code/` directory (the one containing BpMonitor.slnx)
+/// by walking up from the test assembly's own output directory.
+module private RepoLayout =
+  let rec private findUpwards (marker: string) (dir: DirectoryInfo) : DirectoryInfo =
+    if File.Exists(Path.Combine(dir.FullName, marker)) then
+      dir
+    elif dir.Parent = null then
+      failwith $"Could not locate '{marker}' above {AppContext.BaseDirectory}"
+    else
+      findUpwards marker dir.Parent
+
+  let codeDir () : string =
+    (findUpwards "BpMonitor.slnx" (DirectoryInfo(AppContext.BaseDirectory))).FullName
+
+/// Boots a real BpMonitor.Web instance as a child process (out-of-process, real
+/// HTTP, real SQLite file) and drives it with a Playwright Chromium browser.
+/// Each test class gets its own instance + fresh temp database via xunit's
+/// `IClassFixture`.
+type WebAppFixture() =
+  let mutable webProcess: Process = null
+  let mutable playwright: IPlaywright = null
+  let mutable browser: IBrowser = null
+  let mutable dbPath = ""
+
+  let port =
+    let listener = new TcpListener(System.Net.IPAddress.Loopback, 0)
+    listener.Start()
+    let p = (listener.LocalEndpoint :?> System.Net.IPEndPoint).Port
+    listener.Stop()
+    p
+
+  member val BaseUrl = "" with get, set
+  member _.Browser: IBrowser = browser
+
+  member private _.WaitUntilReadyAsync() : Task =
+    task {
+      use client = new HttpClient(Timeout = TimeSpan.FromSeconds 2.0)
+      let deadline = DateTime.UtcNow.AddSeconds(30.0)
+      let mutable ready = false
+
+      while not ready do
+        if DateTime.UtcNow > deadline then
+          failwith $"BpMonitor.Web did not become ready on {port} within 30s"
+
+        try
+          let! resp = client.GetAsync($"http://127.0.0.1:{port}/login")
+          ready <- resp.IsSuccessStatusCode
+        with _ ->
+          do! Task.Delay(250)
+    }
+
+  interface IAsyncLifetime with
+    member this.InitializeAsync() : ValueTask =
+      task {
+        this.BaseUrl <- $"http://127.0.0.1:{port}"
+        dbPath <- Path.Combine(Path.GetTempPath(), $"bpmonitor-e2e-{Guid.NewGuid():N}.db")
+
+        let webProjectPath =
+          Path.Combine(RepoLayout.codeDir (), "BpMonitor.Web", "BpMonitor.Web.fsproj")
+
+        let psi =
+          ProcessStartInfo(
+            FileName = "dotnet",
+            Arguments = $"run --project \"%s{webProjectPath}\" -c Release --no-build -- --urls=%s{this.BaseUrl}",
+            UseShellExecute = false
+          )
+
+        psi.EnvironmentVariables["ConnectionStrings__DefaultConnection"] <- $"Data Source={dbPath}"
+        psi.EnvironmentVariables["BpMonitor__SeedDemoData"] <- "false"
+
+        webProcess <- Process.Start(psi)
+        do! this.WaitUntilReadyAsync()
+
+        let! pw = Playwright.CreateAsync()
+        playwright <- pw
+        let! b = playwright.Chromium.LaunchAsync()
+        browser <- b
+      }
+      |> ValueTask
+
+    member _.DisposeAsync() : ValueTask =
+      task {
+        if browser <> null then
+          do! browser.CloseAsync()
+
+        if playwright <> null then
+          playwright.Dispose()
+
+        if webProcess <> null && not webProcess.HasExited then
+          webProcess.Kill(entireProcessTree = true)
+          webProcess.WaitForExit(5000) |> ignore
+
+        if File.Exists(dbPath) then
+          File.Delete(dbPath)
+      }
+      |> ValueTask

--- a/code/BpMonitor.slnx
+++ b/code/BpMonitor.slnx
@@ -15,5 +15,6 @@
   <Project Path="BpMonitor.Export/BpMonitor.Export.fsproj" />
   <Project Path="BpMonitor.Export.Tests/BpMonitor.Export.Tests.fsproj" />
   <Project Path="BpMonitor.Web/BpMonitor.Web.fsproj" />
+  <Project Path="BpMonitor.Web.E2E.Tests/BpMonitor.Web.E2E.Tests.fsproj" />
   <Project Path="BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj" />
 </Solution>

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -39,4 +39,7 @@
     <PackageVersion Include="FsCheck" Version="3.3.3" />
     <PackageVersion Include="FsCheck.Xunit.v3" Version="3.3.3" />
   </ItemGroup>
+  <ItemGroup Label="Test - E2E">
+    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
+  </ItemGroup>
 </Project>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@ code/
 ├── BpMonitor.Export.Tests   # Tests for Export
 ├── BpMonitor.Web            # Falco web app (dashboard, add, history pages)
 ├── BpMonitor.Web.Tests      # Tests for Web layer
+├── BpMonitor.Web.E2E.Tests  # Playwright .NET browser smoke tests (real out-of-process app + Chromium)
 └── BpMonitor.Arch.Tests     # ArchUnit tests enforcing Clean Architecture rules
 ```
 
@@ -32,7 +33,8 @@ code/
 | Validation | `FsToolkit.ErrorHandling` — applicative validation with `Validation<'ok, 'err>` |
 | Architecture | Clean Architecture (Core has zero dependencies on other projects) |
 | Architecture tests | ArchUnit (via `BpMonitor.Arch.Tests`) |
-| Test runner | xUnit v3 on Microsoft.Testing.Platform (MTP) — all 7 test projects run in parallel via `dotnet test` (default `--max-parallel-test-modules` = CPU count) |
+| E2E tests | Playwright .NET (via `BpMonitor.Web.E2E.Tests`) — drives a real Chromium browser against a real out-of-process `BpMonitor.Web` instance with a fresh temp SQLite file |
+| Test runner | xUnit v3 on Microsoft.Testing.Platform (MTP) — all 8 test projects run in parallel via `dotnet test` (default `--max-parallel-test-modules` = CPU count) |
 | Test coverage | `Microsoft.Testing.Extensions.CodeCoverage` (18.0.6); run with `dotnet test -- --coverage --coverage-output-format cobertura`; outputs one GUID-named `.cobertura.xml` per project into `TestResults/` |
 
 ## Data Model


### PR DESCRIPTION
## Summary
- Add `BpMonitor.Web.E2E.Tests`: boots a real out-of-process `BpMonitor.Web` instance (fresh temp SQLite file, demo seeding off) on a free port and drives it with a real Chromium browser via Microsoft.Playwright
- One smoke test: claim the default account → add a reading → confirm it shows up in the `/history` table
- Add a CI step to install Playwright's Chromium browser before the test step
- Sync `AGENTS.md` / `docs/architecture.md` with the new test project