### PR TITLE
♻️ refactor: extract shared login helper for E2E tests

### DIFF
--- a/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
+++ b/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
@@ -1,7 +1,7 @@
 module BpMonitor.Web.E2E.SmokeTests
 
 open System.Threading.Tasks
-open Microsoft.Playwright
+open BpMonitor.Web.E2E
 open Xunit
 
 /// End-to-end smoke test: claim the default account, add a reading, and
@@ -15,15 +15,7 @@ type LoginAddHistoryTests(fixture: WebAppFixture) =
     task {
       let! page = fixture.Browser.NewPageAsync()
 
-      // Log in: claim the default "Me" account.
-      let! _ = page.GotoAsync($"{fixture.BaseUrl}/login")
-      do! page.FillAsync("#Username", "Me")
-      do! page.ClickAsync("button[type=submit]")
-
-      do! page.FillAsync("#Password", "correct-horse-battery-staple")
-      do! page.FillAsync("#PasswordConfirm", "correct-horse-battery-staple")
-      do! page.ClickAsync("button[type=submit]")
-      do! page.WaitForURLAsync($"{fixture.BaseUrl}/")
+      do! TestAccount.claimAndLogin fixture.BaseUrl page
 
       // Add a reading.
       let! _ = page.GotoAsync($"{fixture.BaseUrl}/add")

--- a/code/BpMonitor.Web.E2E.Tests/WebAppFixture.fs
+++ b/code/BpMonitor.Web.E2E.Tests/WebAppFixture.fs
@@ -9,6 +9,28 @@ open System.Threading.Tasks
 open Microsoft.Playwright
 open Xunit
 
+/// Shared test member used to log in against a fresh BpMonitor.Web instance.
+/// `SchemaMigrations` auto-seeds a single unclaimed member named "Me" on an
+/// empty database, so every E2E test that needs to be logged in claims it
+/// with the same password.
+module TestAccount =
+  let username = "Me"
+  let password = "correct-horse-battery-staple"
+
+  /// Claims the default "Me" account (sets its password) and signs in,
+  /// leaving `page` on the app's landing page.
+  let claimAndLogin (baseUrl: string) (page: IPage) : Task =
+    task {
+      let! _ = page.GotoAsync($"{baseUrl}/login")
+      do! page.FillAsync("#Username", username)
+      do! page.ClickAsync("button[type=submit]")
+
+      do! page.FillAsync("#Password", password)
+      do! page.FillAsync("#PasswordConfirm", password)
+      do! page.ClickAsync("button[type=submit]")
+      do! page.WaitForURLAsync($"{baseUrl}/")
+    }
+
 /// Locates the repository's `code/` directory (the one containing BpMonitor.slnx)
 /// by walking up from the test assembly's own output directory.
 module private RepoLayout =


### PR DESCRIPTION
## Summary
- Extracts the "claim default account + log in" boilerplate out of `SmokeTests` into a `TestAccount` module in `WebAppFixture.fs`
- Future E2E tests can reuse `TestAccount.claimAndLogin` instead of duplicating the login flow