### PR TITLE
✨ feat: dash the Recent chart's connecting line across large gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Charts now show denser y-axis gridlines, visible x/y axis lines and tick marks that adapt to the light/dark theme, and a "blood pressure [mmHg]" y-axis label
 - History and Recent charts now mark every reading with a circle, and comment markers sit on the x-axis baseline instead of overlapping the systolic line
+- Recent chart now dashes the connecting line across gaps where missing readings exceed 10% of the 30-day window, matching the rest of the chart's solid styling elsewhere
 
 ## [1.6.0-rc1] - 2026-06-20
 

--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -161,6 +161,29 @@ let private asAggregated (rs: BloodPressureReading list) =
       MaxDiastolic = r.Diastolic })
 
 [<Fact>]
+let ``toHtmlRecent renders a dashed line segment when a gap exceeds 10% of the window as missing days`` () =
+  // Window = 10 days; threshold = 1.0 missing day. Gap of 6 days → 5 missing days → dashed.
+  let sparse = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 7 9 None ]
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 sparse
+  test <@ html.Contains("\"dash\":\"dash\"") @>
+
+[<Fact>]
+let ``toHtmlRecent connects readings with a solid line when the gap stays within 10% of the window`` () =
+  // Window = 10 days; threshold = 1.0 missing day. Gap of 1 day → 0 missing days → solid.
+  let dense = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 2 9 None ]
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 dense
+  test <@ not (html.Contains("\"dash\":\"dash\"")) @>
+
+[<Fact>]
+let ``toHtmlRecent renders one marker per reading for each series, regardless of gap count`` () =
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let sysMarkers = Regex.Match(html, "\"name\":\"Systolic\".*?\"y\":\\[([^\\]]*)\\]")
+  let diaMarkers = Regex.Match(html, "\"name\":\"Diastolic\".*?\"y\":\\[([^\\]]*)\\]")
+  test <@ sysMarkers.Success && diaMarkers.Success @>
+  test <@ sysMarkers.Groups[1].Value.Split(',').Length = readings.Length @>
+  test <@ diaMarkers.Groups[1].Value.Split(',').Length = readings.Length @>
+
+[<Fact>]
 let ``toHtmlDashed matches snapshot`` () : Task =
   let html: string =
     BpChart.toHtmlDashed GoalRange.defaults Weekly (asAggregated readings)

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -146,8 +146,8 @@ module BpChart =
     |> _.Replace("\"height\":600,", "")
     |> fun html -> html + errorBarScript
 
-  /// Classic x/y plot — one point per reading. Used by /history and /recent.
-  /// `includeHeartRate` is false for /recent, which omits the Heart Rate trace.
+  /// Classic x/y plot — one point per reading. Used by /history.
+  /// `includeHeartRate` is currently always false (no caller passes true).
   let private renderIndividual
     (includeHeartRate: bool)
     (goal: GoalRange)
@@ -324,3 +324,71 @@ module BpChart =
 
   let toHtml (goal: GoalRange) = renderIndividual false goal
   let toHtmlDashed (goal: GoalRange) (gran: Granularity) = renderDashed goal gran
+
+  // ── /recent: missing-data-aware solid/dashed line styling ──────────────────
+  // Wegier et al. 2021 (docs/resources/12911_2021_Article_1598.pdf, "Missing data"):
+  // a gap is "missing data" once the days it skips exceed 10% of the displayed window;
+  // such gaps render dashed, ordinary gaps render solid. Connecting lines are split into
+  // per-gap segments (legend-hidden) so each gap can carry its own dash style, with a
+  // separate markers-only trace per series carrying the legend entry.
+  let private isGapDashed (windowDays: int) (gapDays: float) =
+    let missingDays = gapDays - 1.0
+    missingDays > 0.10 * float windowDays
+
+  let private lineSegments
+    (color: Color)
+    (windowDays: int)
+    (sorted: BloodPressureReading list)
+    (labels: string list)
+    (values: int list)
+    : GenericChart list =
+    List.zip3 sorted labels values
+    |> List.pairwise
+    |> List.map (fun ((r0, l0, v0), (r1, l1, v1)) ->
+      let dash =
+        if isGapDashed windowDays (r1.Timestamp - r0.Timestamp).TotalDays then
+          StyleParam.DrawingStyle.Dash
+        else
+          StyleParam.DrawingStyle.Solid
+
+      Chart.Line(x = [ l0; l1 ], y = [ v0; v1 ], ShowLegend = false, LineDash = dash)
+      |> Chart.withLineStyle (Color = color))
+
+  let private markerTrace (color: Color) (name: string) (labels: string list) (values: int list) =
+    Chart.Point(x = labels, y = values, Name = name, MarkerColor = color)
+
+  let private renderRecent (goal: GoalRange) (windowDays: int) (readings: BloodPressureReading list) : string =
+    let readings = readings |> List.sortBy _.Timestamp
+    let timestamps = readings |> List.map (_.Timestamp >> Formats.formatLocal)
+    let systolic = readings |> List.map _.Systolic
+    let diastolic = readings |> List.map _.Diastolic
+    let commented = readings |> List.filter _.Comments.IsSome
+
+    let commentTraces =
+      if commented.IsEmpty then
+        []
+      else
+        let cTimestamps = commented |> List.map (_.Timestamp >> Formats.formatLocal)
+        let cBaseline = commented |> List.map (fun _ -> 0)
+        let cTexts = commented |> List.map (fun r -> r.Comments |> Option.defaultValue "")
+
+        [ Chart.Point(
+            x = cTimestamps,
+            y = cBaseline,
+            Name = "Comments",
+            MultiText = cTexts,
+            MarkerColor = systolicColor
+          )
+          |> Chart.withMarkerStyle (Size = 10) ]
+
+    [ markerTrace systolicColor "Systolic" timestamps systolic
+      yield! lineSegments systolicColor windowDays readings timestamps systolic
+      markerTrace diastolicColor "Diastolic" timestamps diastolic
+      yield! lineSegments diastolicColor windowDays readings timestamps diastolic
+      yield! commentTraces ]
+    |> Chart.combine
+    |> Chart.withTitle "Blood Pressure History"
+    |> Chart.withShapes (goalBands goal)
+    |> finish
+
+  let toHtmlRecent (goal: GoalRange) (windowDays: int) = renderRecent goal windowDays

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -86,7 +86,7 @@ module ReadingHandlers =
         |> List.sortByDescending _.Timestamp
 
       let days30 = window 30
-      let chartHtml = BpChart.toHtml m.Goal days30
+      let chartHtml = BpChart.toHtmlRecent m.Goal 30 days30
       htmlResponse (ReadingViews.recent m chartHtml (window 7) (window 14) days30) ctx)
 
   let trends: HttpContext -> Task =


### PR DESCRIPTION
## Summary

- Applies the solid/dashed missing-data rule from Wegier et al. 2021 (`docs/resources/12911_2021_Article_1598.pdf`, "Missing data" section) to the **/recent** chart: a gap's connecting line renders dashed once its missing days exceed 10% of the displayed 30-day window, otherwise solid.
- Implemented as `BpChart.toHtmlRecent` — per-gap line segments (legend-hidden) plus a markers-only trace per series for the legend entry — so each gap can carry its own dash style with Plotly.NET's single-dash-per-trace constraint.
- Scoped to `/recent` only; `/history`'s `toHtml` is unchanged.