### PR TITLE
🐛 fix: judge Recent chart gaps by calendar day, name line segments for hover

### DIFF
--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -175,6 +175,24 @@ let ``toHtmlRecent connects readings with a solid line when the gap stays within
   test <@ not (html.Contains("\"dash\":\"dash\"")) @>
 
 [<Fact>]
+let ``toHtmlRecent judges gaps by calendar days, not raw elapsed time`` () =
+  // Window = 30 days; threshold = 3.0 missing days. Day 1 → Day 5 is a 4-calendar-day gap
+  // (missingDays = 3, not > 3), so it must render solid even though the readings are
+  // 9:00 → 10:00, i.e. raw elapsed time (4.0417 days) would cross the threshold if used directly.
+  let readings = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 5 10 None ]
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  test <@ not (html.Contains("\"dash\":\"dash\"")) @>
+
+[<Fact>]
+let ``toHtmlRecent names each line segment after its series for hover text`` () =
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 readings
+
+  let lineNameCount =
+    Regex.Matches(html, "\"name\":\"(Systolic|Diastolic)\",\"showlegend\":false,\"mode\":\"lines\"").Count
+
+  test <@ lineNameCount > 0 @>
+
+[<Fact>]
 let ``toHtmlRecent renders one marker per reading for each series, regardless of gap count`` () =
   let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
   let sysMarkers = Regex.Match(html, "\"name\":\"Systolic\".*?\"y\":\\[([^\\]]*)\\]")

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -331,27 +331,36 @@ module BpChart =
   // such gaps render dashed, ordinary gaps render solid. Connecting lines are split into
   // per-gap segments (legend-hidden) so each gap can carry its own dash style, with a
   // separate markers-only trace per series carrying the legend entry.
-  let private isGapDashed (windowDays: int) (gapDays: float) =
-    let missingDays = gapDays - 1.0
-    missingDays > 0.10 * float windowDays
+  let private isGapDashed (windowDays: int) (gapDays: int) =
+    let missingDays = gapDays - 1
+    float missingDays > 0.10 * float windowDays
+
+  // Calendar-day gap between two readings, in the member's local time zone — using the
+  // raw elapsed TotalDays would make the dashed/solid threshold sensitive to the time of
+  // day each reading was taken, flipping styling for gaps that are the same number of
+  // calendar days apart.
+  let private calendarGapDays (r0: BloodPressureReading) (r1: BloodPressureReading) =
+    (r1.Timestamp.ToLocalTime().Date - r0.Timestamp.ToLocalTime().Date).Days
+
+  let private dashPattern (windowDays: int) (sorted: BloodPressureReading list) : StyleParam.DrawingStyle list =
+    sorted
+    |> List.pairwise
+    |> List.map (fun (r0, r1) ->
+      if isGapDashed windowDays (calendarGapDays r0 r1) then
+        StyleParam.DrawingStyle.Dash
+      else
+        StyleParam.DrawingStyle.Solid)
 
   let private lineSegments
     (color: Color)
-    (windowDays: int)
-    (sorted: BloodPressureReading list)
+    (name: string)
+    (dashes: StyleParam.DrawingStyle list)
     (labels: string list)
     (values: int list)
     : GenericChart list =
-    List.zip3 sorted labels values
-    |> List.pairwise
-    |> List.map (fun ((r0, l0, v0), (r1, l1, v1)) ->
-      let dash =
-        if isGapDashed windowDays (r1.Timestamp - r0.Timestamp).TotalDays then
-          StyleParam.DrawingStyle.Dash
-        else
-          StyleParam.DrawingStyle.Solid
-
-      Chart.Line(x = [ l0; l1 ], y = [ v0; v1 ], ShowLegend = false, LineDash = dash)
+    List.zip3 (List.pairwise labels) (List.pairwise values) dashes
+    |> List.map (fun ((l0, l1), (v0, v1), dash) ->
+      Chart.Line(x = [ l0; l1 ], y = [ v0; v1 ], Name = name, ShowLegend = false, LineDash = dash)
       |> Chart.withLineStyle (Color = color))
 
   let private markerTrace (color: Color) (name: string) (labels: string list) (values: int list) =
@@ -363,6 +372,7 @@ module BpChart =
     let systolic = readings |> List.map _.Systolic
     let diastolic = readings |> List.map _.Diastolic
     let commented = readings |> List.filter _.Comments.IsSome
+    let dashes = dashPattern windowDays readings
 
     let commentTraces =
       if commented.IsEmpty then
@@ -382,9 +392,9 @@ module BpChart =
           |> Chart.withMarkerStyle (Size = 10) ]
 
     [ markerTrace systolicColor "Systolic" timestamps systolic
-      yield! lineSegments systolicColor windowDays readings timestamps systolic
+      yield! lineSegments systolicColor "Systolic" dashes timestamps systolic
       markerTrace diastolicColor "Diastolic" timestamps diastolic
-      yield! lineSegments diastolicColor windowDays readings timestamps diastolic
+      yield! lineSegments diastolicColor "Diastolic" dashes timestamps diastolic
       yield! commentTraces ]
     |> Chart.combine
     |> Chart.withTitle "Blood Pressure History"

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -75,6 +75,8 @@ module ReadingHandlers =
       let chartHtml = BpChart.toHtml m.Goal readings
       htmlResponse (ReadingViews.history m chartHtml readings) ctx)
 
+  let private recentChartWindowDays = 30
+
   let recent: HttpContext -> Task =
     withMember (fun m ctx ->
       let now = (timeProvider ctx).GetUtcNow()
@@ -85,8 +87,8 @@ module ReadingHandlers =
         |> ReadingStats.between (now.AddDays(-float days)) now
         |> List.sortByDescending _.Timestamp
 
-      let days30 = window 30
-      let chartHtml = BpChart.toHtmlRecent m.Goal 30 days30
+      let days30 = window recentChartWindowDays
+      let chartHtml = BpChart.toHtmlRecent m.Goal recentChartWindowDays days30
       htmlResponse (ReadingViews.recent m chartHtml (window 7) (window 14) days30) ctx)
 
   let trends: HttpContext -> Task =


### PR DESCRIPTION
## Summary

Follow-ups from code review on the Recent chart missing-data dash styling (#259):

- `isGapDashed` compared raw elapsed `TotalDays`, so two gaps that were the same number of calendar days apart could flip between solid and dashed depending on time-of-day jitter between readings. Now compares local calendar dates.
- Per-gap line segments had no `Name`, so hovering the connecting line (not a marker) showed a blank/generic trace label instead of "Systolic"/"Diastolic".
- The dash pattern was computed independently for the systolic and diastolic series even though it only depends on shared timestamps — now computed once and reused for both.
- `windowDays=30` was a second, untied literal alongside the `window 30` call building the displayed data — factored into one named constant (`recentChartWindowDays`) so they can't drift apart.