### PR TITLE
♻️ refactor: merge Recent chart's dash/solid runs, fix legend swatch mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Charts now show denser y-axis gridlines, visible x/y axis lines and tick marks that adapt to the light/dark theme, and a "blood pressure [mmHg]" y-axis label
 - History and Recent charts now mark every reading with a circle, and comment markers sit on the x-axis baseline instead of overlapping the systolic line
 - Recent chart now dashes the connecting line across gaps where missing readings exceed 10% of the 30-day window, matching the rest of the chart's solid styling elsewhere
+- Recent chart's Systolic/Diastolic legend swatches now match History's line+marker style instead of showing a marker-only dot
 
 ## [1.6.0-rc1] - 2026-06-20
 

--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -184,22 +184,59 @@ let ``toHtmlRecent judges gaps by calendar days, not raw elapsed time`` () =
   test <@ not (html.Contains("\"dash\":\"dash\"")) @>
 
 [<Fact>]
-let ``toHtmlRecent names each line segment after its series for hover text`` () =
+let ``toHtmlRecent names each line trace after its series for hover text`` () =
   let html = BpChart.toHtmlRecent GoalRange.defaults 10 readings
 
   let lineNameCount =
-    Regex.Matches(html, "\"name\":\"(Systolic|Diastolic)\",\"showlegend\":false,\"mode\":\"lines\"").Count
+    Regex.Matches(html, "\"name\":\"(Systolic|Diastolic)\",\"showlegend\":[a-z]*,\"mode\":\"lines\\+markers\"").Count
 
   test <@ lineNameCount > 0 @>
 
 [<Fact>]
-let ``toHtmlRecent renders one marker per reading for each series, regardless of gap count`` () =
+let ``toHtmlRecent does not drop any reading, even when split across dash/solid runs`` () =
+  // Window = 30 days; threshold = 3 missing days. Days 1-2-3 (solid), a 7-day gap to day 10
+  // (6 missing days, dashed), then days 10-11-12 (solid) — 3 runs sharing 2 boundary points.
+  let readings =
+    [ reading 1 120 80 70 1 9 None
+      reading 2 121 80 70 2 9 None
+      reading 3 122 80 70 3 9 None
+      reading 4 123 80 70 10 9 None
+      reading 5 124 80 70 11 9 None
+      reading 6 125 80 70 12 9 None ]
+
   let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
-  let sysMarkers = Regex.Match(html, "\"name\":\"Systolic\".*?\"y\":\\[([^\\]]*)\\]")
-  let diaMarkers = Regex.Match(html, "\"name\":\"Diastolic\".*?\"y\":\\[([^\\]]*)\\]")
-  test <@ sysMarkers.Success && diaMarkers.Success @>
-  test <@ sysMarkers.Groups[1].Value.Split(',').Length = readings.Length @>
-  test <@ diaMarkers.Groups[1].Value.Split(',').Length = readings.Length @>
+
+  let coveredLabels (name: string) =
+    Regex.Matches(html, $"\"name\":\"{name}\".*?\"x\":\\[([^\\]]*)\\]")
+    |> Seq.collect (fun m -> m.Groups[1].Value.Split(','))
+    |> Set.ofSeq
+
+  test <@ (coveredLabels "Systolic").Count = readings.Length @>
+  test <@ (coveredLabels "Diastolic").Count = readings.Length @>
+  test <@ html.Contains("\"dash\":\"dash\"") @>
+  test <@ html.Contains("\"dash\":\"solid\"") @>
+
+[<Fact>]
+let ``toHtmlRecent shows exactly one legend entry per series, even when split across multiple dash/solid runs`` () =
+  let readings =
+    [ reading 1 120 80 70 1 9 None
+      reading 2 121 80 70 2 9 None
+      reading 3 122 80 70 3 9 None
+      reading 4 123 80 70 10 9 None
+      reading 5 124 80 70 11 9 None
+      reading 6 125 80 70 12 9 None ]
+
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+
+  // Each trace object ends at the first "}}" (closing its "line" object then itself), so
+  // bounding the match there keeps "name"/"showlegend" from leaking into the next trace.
+  let legendCount (name: string) =
+    Regex.Matches(html, $"\"name\":\"{name}\".*?}}}}")
+    |> Seq.filter (fun m -> m.Value.Contains("\"showlegend\":true"))
+    |> Seq.length
+
+  test <@ legendCount "Systolic" = 1 @>
+  test <@ legendCount "Diastolic" = 1 @>
 
 [<Fact>]
 let ``toHtmlDashed matches snapshot`` () : Task =

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -146,6 +146,29 @@ module BpChart =
     |> _.Replace("\"height\":600,", "")
     |> fun html -> html + errorBarScript
 
+  /// Sorts readings chronologically and extracts the parallel label/value series
+  /// shared by every per-reading chart (/history and /recent).
+  let private seriesOf (readings: BloodPressureReading list) =
+    let sorted = readings |> List.sortBy _.Timestamp
+    let labels = sorted |> List.map (_.Timestamp >> Formats.formatLocal)
+    let systolic = sorted |> List.map _.Systolic
+    let diastolic = sorted |> List.map _.Diastolic
+    sorted, labels, systolic, diastolic
+
+  /// Comment markers plotted on the x-axis baseline (y=0), one per commented reading.
+  let private commentTraces (sorted: BloodPressureReading list) : GenericChart list =
+    let commented = sorted |> List.filter _.Comments.IsSome
+
+    if commented.IsEmpty then
+      []
+    else
+      let cTimestamps = commented |> List.map (_.Timestamp >> Formats.formatLocal)
+      let cBaseline = commented |> List.map (fun _ -> 0)
+      let cTexts = commented |> List.map (fun r -> r.Comments |> Option.defaultValue "")
+
+      [ Chart.Point(x = cTimestamps, y = cBaseline, Name = "Comments", MultiText = cTexts, MarkerColor = systolicColor)
+        |> Chart.withMarkerStyle (Size = 10) ]
+
   /// Classic x/y plot — one point per reading. Used by /history.
   /// `includeHeartRate` is currently always false (no caller passes true).
   let private renderIndividual
@@ -153,28 +176,7 @@ module BpChart =
     (goal: GoalRange)
     (readings: BloodPressureReading list)
     : string =
-    let readings = readings |> List.sortBy _.Timestamp
-    let timestamps = readings |> List.map (_.Timestamp >> Formats.formatLocal)
-    let systolic = readings |> List.map _.Systolic
-    let diastolic = readings |> List.map _.Diastolic
-    let commented = readings |> List.filter _.Comments.IsSome
-
-    let commentTraces =
-      if commented.IsEmpty then
-        []
-      else
-        let cTimestamps = commented |> List.map (_.Timestamp >> Formats.formatLocal)
-        let cBaseline = commented |> List.map (fun _ -> 0)
-        let cTexts = commented |> List.map (fun r -> r.Comments |> Option.defaultValue "")
-
-        [ Chart.Point(
-            x = cTimestamps,
-            y = cBaseline,
-            Name = "Comments",
-            MultiText = cTexts,
-            MarkerColor = systolicColor
-          )
-          |> Chart.withMarkerStyle (Size = 10) ]
+    let readings, timestamps, systolic, diastolic = seriesOf readings
 
     let heartRateTrace =
       if includeHeartRate then
@@ -189,7 +191,7 @@ module BpChart =
       Chart.Line(x = timestamps, y = diastolic, Name = "Diastolic", ShowMarkers = true)
       |> Chart.withLineStyle (Color = diastolicColor)
       yield! heartRateTrace
-      yield! commentTraces ]
+      yield! commentTraces readings ]
     |> Chart.combine
     |> Chart.withTitle "Blood Pressure History"
     |> Chart.withShapes (goalBands goal)
@@ -328,9 +330,9 @@ module BpChart =
   // ── /recent: missing-data-aware solid/dashed line styling ──────────────────
   // Wegier et al. 2021 (docs/resources/12911_2021_Article_1598.pdf, "Missing data"):
   // a gap is "missing data" once the days it skips exceed 10% of the displayed window;
-  // such gaps render dashed, ordinary gaps render solid. Connecting lines are split into
-  // per-gap segments (legend-hidden) so each gap can carry its own dash style, with a
-  // separate markers-only trace per series carrying the legend entry.
+  // such gaps render dashed, ordinary gaps render solid. Consecutive same-style gaps are
+  // merged into a single multi-point trace (a "run") instead of one trace per gap, keeping
+  // the trace count proportional to the number of dash/solid transitions rather than to N.
   let private isGapDashed (windowDays: int) (gapDays: int) =
     let missingDays = gapDays - 1
     float missingDays > 0.10 * float windowDays
@@ -351,51 +353,56 @@ module BpChart =
       else
         StyleParam.DrawingStyle.Solid)
 
-  let private lineSegments
+  // Groups consecutive equal-style gaps into (startPointIdx, endPointIdxInclusive, style)
+  // ranges. Adjacent runs share their boundary point, so the connecting line stays unbroken
+  // where the style changes.
+  let private dashRuns (dashes: StyleParam.DrawingStyle list) : (int * int * StyleParam.DrawingStyle) list =
+    dashes
+    |> List.indexed
+    |> List.fold
+      (fun acc (gapIdx, style) ->
+        match acc with
+        | (s, start, _) :: rest when s = style -> (s, start, gapIdx) :: rest
+        | _ -> (style, gapIdx, gapIdx) :: acc)
+      []
+    |> List.rev
+    |> List.map (fun (style, startGap, endGap) -> startGap, endGap + 1, style)
+
+  /// One trace per dash/solid run for a series; only the first run carries the legend
+  /// entry, all runs show markers so every reading still gets a point. Falls back to a
+  /// single trace when there's nothing to split (0 or 1 readings).
+  let private seriesTraces
     (color: Color)
     (name: string)
     (dashes: StyleParam.DrawingStyle list)
     (labels: string list)
     (values: int list)
     : GenericChart list =
-    List.zip3 (List.pairwise labels) (List.pairwise values) dashes
-    |> List.map (fun ((l0, l1), (v0, v1), dash) ->
-      Chart.Line(x = [ l0; l1 ], y = [ v0; v1 ], Name = name, ShowLegend = false, LineDash = dash)
-      |> Chart.withLineStyle (Color = color))
-
-  let private markerTrace (color: Color) (name: string) (labels: string list) (values: int list) =
-    Chart.Point(x = labels, y = values, Name = name, MarkerColor = color)
+    match labels, values with
+    | [], [] ->
+      [ Chart.Line(x = ([]: string list), y = ([]: int list), Name = name)
+        |> Chart.withLineStyle (Color = color) ]
+    | [ _ ], [ _ ] -> [ Chart.Point(x = labels, y = values, Name = name, MarkerColor = color) ]
+    | _ ->
+      dashRuns dashes
+      |> List.mapi (fun idx (startIdx, endIdx, style) ->
+        Chart.Line(
+          x = labels[startIdx..endIdx],
+          y = values[startIdx..endIdx],
+          Name = name,
+          ShowLegend = (idx = 0),
+          ShowMarkers = true,
+          LineDash = style
+        )
+        |> Chart.withLineStyle (Color = color))
 
   let private renderRecent (goal: GoalRange) (windowDays: int) (readings: BloodPressureReading list) : string =
-    let readings = readings |> List.sortBy _.Timestamp
-    let timestamps = readings |> List.map (_.Timestamp >> Formats.formatLocal)
-    let systolic = readings |> List.map _.Systolic
-    let diastolic = readings |> List.map _.Diastolic
-    let commented = readings |> List.filter _.Comments.IsSome
+    let readings, timestamps, systolic, diastolic = seriesOf readings
     let dashes = dashPattern windowDays readings
 
-    let commentTraces =
-      if commented.IsEmpty then
-        []
-      else
-        let cTimestamps = commented |> List.map (_.Timestamp >> Formats.formatLocal)
-        let cBaseline = commented |> List.map (fun _ -> 0)
-        let cTexts = commented |> List.map (fun r -> r.Comments |> Option.defaultValue "")
-
-        [ Chart.Point(
-            x = cTimestamps,
-            y = cBaseline,
-            Name = "Comments",
-            MultiText = cTexts,
-            MarkerColor = systolicColor
-          )
-          |> Chart.withMarkerStyle (Size = 10) ]
-
-    [ markerTrace systolicColor "Systolic" timestamps systolic
-      yield! lineSegments systolicColor "Systolic" dashes timestamps systolic
-      markerTrace diastolicColor "Diastolic" timestamps diastolic
-      yield! lineSegments diastolicColor "Diastolic" dashes timestamps diastolic
-      yield! commentTraces ]
+    [ yield! seriesTraces systolicColor "Systolic" dashes timestamps systolic
+      yield! seriesTraces diastolicColor "Diastolic" dashes timestamps diastolic
+      yield! commentTraces readings ]
     |> Chart.combine
     |> Chart.withTitle "Blood Pressure History"
     |> Chart.withShapes (goalBands goal)


### PR DESCRIPTION
## Summary

Remaining code review follow-ups from #259/#260 — the legend-swatch difference and the per-gap trace duplication, both previously left as a deliberate trade-off:

- Consecutive same-style gaps are now merged into one multi-point trace per run instead of one trace per single gap, cutting trace count from O(N) to the number of dash/solid transitions (e.g. 15→9 traces for a typical sparse member's 30-day window).
- Only the first run per series carries the legend entry, and all runs render `lines+markers`, matching `/history`'s legend swatch — previously `/recent` showed a marker-only dot.
- Extracted shared `seriesOf`/`commentTraces` helpers used by both `renderIndividual` (`/history`) and `renderRecent` (`/recent`), removing the duplicated preamble and comment-marker code between them. The `/history` snapshot test is unchanged byte-for-byte, confirming no behavior change there.