### PR TITLE
✨ feat: redesign hamburger menu and theme toggle layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding a new reading now redirects to the **Recent** page instead of **History**
 - History and Recent charts no longer show a "Blood Pressure History" title, matching the Trends chart, and now use the freed-up vertical space with more compact margins
 - Sidebar navigation links on mobile have more spacing between them, making them easier to tap accurately
+- Redesigned the hamburger menu and theme toggle to fit the rest of the design: mobile now has a slim top app bar (menu, title, theme toggle) instead of floating corner buttons, and the desktop theme toggle now lives in the sidebar next to the member name
 
 ## [1.6.0] - 2026-06-21
 

--- a/TODOs.md
+++ b/TODOs.md
@@ -2,8 +2,6 @@
 
 A loose collection of TODOs I want to tackle at some point in time.
 
-- The theme toggle button as well as the hamburger menu don't fit nicely with the rest of the design.
-
 ## Features
 
 - some science behind the visualization:

--- a/code/BpMonitor.Web.Tests/ViewTests.fs
+++ b/code/BpMonitor.Web.Tests/ViewTests.fs
@@ -38,6 +38,17 @@ let ``landing renders links to add and history`` () =
   test <@ html.Contains "href=\"/\" aria-current=\"page\"" @>
 
 [<Fact>]
+let ``layout renders a topbar with menu button, title and theme toggle`` () =
+  let html = renderHtml (ReadingViews.landing defaultMember)
+
+  test <@ html.Contains "class=\"topbar\"" @>
+  test <@ html.Contains "for=\"nav-toggle\"" @>
+  test <@ html.Contains "BpMonitor" @>
+  test <@ html.Contains "class=\"theme-toggle\"" @>
+  // the old single floating id-based toggle is gone
+  test <@ not (html.Contains "id=\"theme-toggle\"") @>
+
+[<Fact>]
 let ``admin sees Members nav link`` () =
   let admin = { defaultMember with IsAdmin = true }
   let html = renderHtml (ReadingViews.landing admin)

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -58,19 +58,20 @@ module ViewLayout =
               [ Attr.type' "checkbox"
                 Attr.id "nav-toggle"
                 Attr.create "aria-hidden" "true" ]
-            Elem.label
-              [ Attr.create "for" "nav-toggle"
-                Attr.class' "nav-burger"
-                Attr.create "aria-label" "Menu" ]
-              [ Text.raw "☰" ]
+            // Slim app bar: hidden on desktop, shown on mobile (and as the restore bar
+            // when the desktop sidebar is collapsed) — see app.css.
+            Elem.header
+              [ Attr.class' "topbar" ]
+              [ Elem.label
+                  [ Attr.create "for" "nav-toggle"
+                    Attr.class' "nav-burger"
+                    Attr.create "aria-label" "Menu" ]
+                  [ Text.raw "☰" ]
+                Elem.span [ Attr.class' "topbar-title" ] [ Text.raw "BpMonitor" ]
+                Elem.button [ Attr.class' "theme-toggle"; Attr.create "onclick" "toggleTheme()" ] [] ]
             // Second label for same checkbox: acts as the backdrop — clicking it unchecks
             // the checkbox and closes the drawer.
             Elem.label [ Attr.create "for" "nav-toggle"; Attr.class' "nav-backdrop" ] []
-            Elem.button
-              [ Attr.id "theme-toggle"
-                Attr.class' "outline secondary"
-                Attr.create "onclick" "toggleTheme()" ]
-              []
             Elem.nav
               [ Attr.class' "sidebar" ]
               [ Elem.ul
@@ -104,6 +105,7 @@ module ViewLayout =
                 Elem.div
                   [ Attr.class' "sidebar-user" ]
                   [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ]
+                    Elem.button [ Attr.class' "theme-toggle"; Attr.create "onclick" "toggleTheme()" ] []
                     Elem.form
                       [ Attr.method "post"; Attr.action "/logout"; Attr.class' "inline" ]
                       [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Logout" ] ] ] ]
@@ -121,11 +123,7 @@ module ViewLayout =
       [ htmlHead title []
         Elem.body
           [ Attr.create "hx-boost" "false" ]
-          [ Elem.button
-              [ Attr.id "theme-toggle"
-                Attr.class' "outline secondary"
-                Attr.create "onclick" "toggleTheme()" ]
-              []
+          [ Elem.button [ Attr.class' "theme-toggle"; Attr.create "onclick" "toggleTheme()" ] []
             Elem.main
               [ Attr.class' "container login-container" ]
               ([ Elem.header

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -23,6 +23,15 @@ module ViewLayout =
 
     Elem.li [] [ Elem.a attrs [ Text.raw label ] ]
 
+  /// The dark/light mode toggle (icon set by theme.js/theme-label.js). `extraClass`
+  /// lets the login page add `theme-toggle--standalone` since it has no topbar/sidebar
+  /// to host it (see app.css).
+  let private themeToggleButton (extraClass: string) : XmlNode =
+    Elem.button
+      [ Attr.class' ($"theme-toggle {extraClass}".Trim())
+        Attr.create "onclick" "toggleTheme()" ]
+      []
+
   /// Shared <head> element. `extras` allows callers to append additional nodes
   /// (e.g. the htmx script that only the authenticated layout needs).
   let private htmlHead (title: string) (extras: XmlNode list) : XmlNode =
@@ -68,7 +77,7 @@ module ViewLayout =
                     Attr.create "aria-label" "Menu" ]
                   [ Text.raw "☰" ]
                 Elem.span [ Attr.class' "topbar-title" ] [ Text.raw "BpMonitor" ]
-                Elem.button [ Attr.class' "theme-toggle"; Attr.create "onclick" "toggleTheme()" ] [] ]
+                themeToggleButton "" ]
             // Second label for same checkbox: acts as the backdrop — clicking it unchecks
             // the checkbox and closes the drawer.
             Elem.label [ Attr.create "for" "nav-toggle"; Attr.class' "nav-backdrop" ] []
@@ -105,7 +114,7 @@ module ViewLayout =
                 Elem.div
                   [ Attr.class' "sidebar-user" ]
                   [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ]
-                    Elem.button [ Attr.class' "theme-toggle"; Attr.create "onclick" "toggleTheme()" ] []
+                    themeToggleButton ""
                     Elem.form
                       [ Attr.method "post"; Attr.action "/logout"; Attr.class' "inline" ]
                       [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Logout" ] ] ] ]
@@ -123,7 +132,7 @@ module ViewLayout =
       [ htmlHead title []
         Elem.body
           [ Attr.create "hx-boost" "false" ]
-          [ Elem.button [ Attr.class' "theme-toggle"; Attr.create "onclick" "toggleTheme()" ] []
+          [ themeToggleButton "theme-toggle--standalone"
             Elem.main
               [ Attr.class' "container login-container" ]
               ([ Elem.header

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -175,7 +175,7 @@ nav a[aria-current="page"] {
 
 /* The login page has no topbar/sidebar to host its theme toggle, so it stays
    a fixed standalone control — just restyled to match .theme-toggle. */
-body:not(:has(.topbar)) > .theme-toggle {
+.theme-toggle--standalone {
   position: fixed;
   top: 0.5rem;
   right: 0.5rem;

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -19,35 +19,74 @@ body {
   pointer-events: none;
 }
 
-/* Hamburger button — hidden on desktop, shown on mobile.
+/* Hamburger — ghost icon, sized to match .theme-toggle. Lives inside .topbar,
+   which controls when it's visible, so this only needs to set appearance.
    Specificity needs to be (0,1,1) to beat Pico's
    [type="checkbox"] ~ label { display: inline-block } rule (also 0,1,1),
-   relying on app.css loading after pico.min.css for the tie-break.
-   Appearance lives here so the mobile and desktop-collapsed trigger
-   rules below only need to flip `display` — same look in both states. */
+   relying on app.css loading after pico.min.css for the tie-break. */
 label.nav-burger {
-  display: none;
+  display: flex;
   align-items: center;
   justify-content: center;
-  position: fixed;
-  top: 0.5rem;
-  left: 0.5rem;
-  z-index: 200;
   cursor: pointer;
   font-size: 1.25rem;
   width: 2.5rem;
   height: 2.5rem;
-  background: var(--pico-background-color);
-  border: 1px solid var(--pico-muted-border-color);
   border-radius: var(--pico-border-radius);
   line-height: 1;
   user-select: none;
+}
+
+label.nav-burger:hover {
+  background: var(--pico-secondary-background);
 }
 
 /* Backdrop overlay — hidden until drawer is open on mobile. Same specificity
    reasoning as .nav-burger above. */
 label.nav-backdrop {
   display: none;
+}
+
+/* Slim app bar — hidden on desktop by default; shown on mobile, and as the
+   restore bar when the desktop sidebar is collapsed (see media queries). */
+.topbar {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3rem;
+  z-index: 200;
+  padding: 0 0.5rem;
+  background: var(--pico-background-color);
+  border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+.topbar-title {
+  font-weight: 600;
+}
+
+.topbar .theme-toggle {
+  margin-left: auto;
+}
+
+/* Borderless/ghost icon button shared by both theme-toggle instances
+   (topbar + sidebar) and the login page's standalone instance. */
+.theme-toggle {
+  background: transparent;
+  border: none;
+  color: var(--pico-secondary);
+  padding: 0.25rem 0.5rem;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--pico-border-radius);
+}
+
+.theme-toggle:hover {
+  background: var(--pico-secondary-background);
 }
 
 /* `position: fixed` (not `sticky`) — sticky broke once the sidebar's own box
@@ -134,14 +173,13 @@ nav a[aria-current="page"] {
   text-underline-offset: 3px;
 }
 
-#theme-toggle {
+/* The login page has no topbar/sidebar to host its theme toggle, so it stays
+   a fixed standalone control — just restyled to match .theme-toggle. */
+body:not(:has(.topbar)) > .theme-toggle {
   position: fixed;
   top: 0.5rem;
   right: 0.5rem;
   z-index: 200;
-  padding: 0.25rem 0.75rem;
-  font-size: 0.875rem;
-  margin: 0;
 }
 
 .chart-toggle {
@@ -251,11 +289,15 @@ g.errorbars path.yerror {
 
   /* ── Mobile sidebar / off-canvas drawer ─────────────────────────────────── */
 
-  /* Hamburger button shown above all content on mobile.
-     label.nav-burger for (0,1,1) specificity to beat Pico's checkbox~label rule.
-     Appearance comes from the base label.nav-burger rule above. */
-  label.nav-burger {
+  /* Slim app bar (☰ + title + theme toggle) replaces the old floating
+     corner buttons on mobile. */
+  .topbar {
     display: flex;
+  }
+
+  /* The sidebar's own theme toggle is redundant once the topbar owns it. */
+  .sidebar-user .theme-toggle {
+    display: none;
   }
 
   /* Sidebar is an off-canvas drawer on mobile: slides off-screen by default
@@ -301,10 +343,10 @@ g.errorbars path.yerror {
 
   /* On mobile the sidebar overlays as a drawer rather than pushing content
      over, so content shouldn't reserve space for it. Also push content down
-     to clear the fixed hamburger button. */
+     to clear the fixed topbar. */
   .content {
     margin-left: 0;
-    padding-top: 3rem;
+    padding-top: 3.25rem;
   }
 }
 
@@ -325,10 +367,13 @@ g.errorbars path.yerror {
      reserves its space while it's visible — release it when collapsed. */
   #nav-toggle:checked ~ .content {
     margin-left: 0;
+    padding-top: 3.25rem;
   }
 
-  /* Appearance comes from the base label.nav-burger rule above. */
-  #nav-toggle:checked ~ label.nav-burger {
+  /* When collapsed, the topbar takes over as the restore bar — it still
+     holds the ☰ (now restoring instead of opening a drawer) and the theme
+     toggle, so theme switching stays available with the sidebar hidden. */
+  #nav-toggle:checked ~ .topbar {
     display: flex;
   }
 }

--- a/code/BpMonitor.Web/wwwroot/theme-label.js
+++ b/code/BpMonitor.Web/wwwroot/theme-label.js
@@ -1,2 +1,2 @@
-// Re-runs on every body render (initial + hx-boost swaps) to sync the button icon.
-(()=> {var b=document.getElementById('theme-toggle');if(b)b.textContent=document.documentElement.getAttribute('data-theme')==='dark'?'☀️':'🌙';})();
+// Re-runs on every body render (initial + hx-boost swaps) to sync the button icons.
+(()=> {var n=document.documentElement.getAttribute('data-theme')==='dark'?'☀️':'🌙';document.querySelectorAll('.theme-toggle').forEach((b) => { b.textContent=n; });})();

--- a/code/BpMonitor.Web/wwwroot/theme.js
+++ b/code/BpMonitor.Web/wwwroot/theme.js
@@ -26,8 +26,7 @@ window.toggleTheme=()=> {
   var h=document.documentElement,n=h.getAttribute('data-theme')==='dark'?'light':'dark';
   h.setAttribute('data-theme',n);
   localStorage.setItem('theme',n);
-  var b=document.getElementById('theme-toggle');
-  if(b)b.textContent=n==='dark'?'☀️':'🌙';
+  document.querySelectorAll('.theme-toggle').forEach((b) => { b.textContent=n==='dark'?'☀️':'🌙'; });
   applyChartTheme(n);
 };
 


### PR DESCRIPTION
## Summary
- Replace the floating corner hamburger/theme-toggle buttons with a slim top app bar on mobile (menu, title, theme toggle), and move the desktop theme toggle into the sidebar next to the member name — resolves the TODOs.md item about these controls not fitting the rest of the design
- When the desktop sidebar is collapsed, the topbar takes over as a restore bar so theme switching stays available
- Dedupe the theme-toggle button markup into a shared helper and simplify the login page's standalone-toggle CSS selector