### PR TITLE
✨ feat: add LOWESS trend line to recent chart, with a Fig. 5 demo persona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Recent chart now overlays a LOWESS-smoothed trend line for systolic and diastolic; the trend line is the visual focus (full color, thicker) and the raw per-reading line is faded, matching the Wegier et al. 2021 design
+- Demo dataset gains a sixth member, Ned Flanders, whose readings tell a Fig. 5-style story (elevated readings, a week-long gap, then improved control after starting medication) to showcase the new trend line and missing-data dashing
+
 ### Changed
 
 - History page heading no longer repeats the family member's name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,11 @@ dotnet run --project code/BpMonitor.Web
 
 For developer onboarding and demos, a pre-built Simpson-family dataset can be
 seeded into a fresh database. It covers ~5 years of readings with per-member
-personalities so all features render richly out of the box:
+personalities so all features render richly out of the box. A sixth member,
+Ned Flanders, tells a Fig. 5-style story (Wegier et al. 2021, see
+`docs/resources/12911_2021_Article_1598.pdf`): elevated readings, a week-long
+gap, then improved control after starting medication — exercising the
+/recent chart's missing-data dashed line and LOWESS trend overlay:
 
 ```bash
 # Remove any existing DB and start fresh with the Simpson family

--- a/TODOs.md
+++ b/TODOs.md
@@ -8,7 +8,7 @@ A loose collection of TODOs I want to tackle at some point in time.
   [Home blood pressure data visualization for the management of hypertension: using human factors and design principles](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8340525/)
   (as reference, I included the paper in the docs folder: [pdf](./docs/resources/12911_2021_Article_1598.pdf))
 - Replace the recent display with something like fig 5 in the paper above
-  - Add a smoothing curve (for example using LOWESS algorithm)
+  - ~~Add a smoothing curve (for example using LOWESS algorithm)~~ — done: hand-rolled LOWESS overlay on the recent chart
   - add a moving window which always shows xx days (see [fig. 5](https://pmc.ncbi.nlm.nih.gov/articles/PMC8340525/figure/Fig5/) in the paper above)?
   - add another display above the graph of the sys/dias values like in fig 5
 - Exploratory data analysis using [Jupyter Notebooks](https://jupyter.org/).

--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -184,7 +184,7 @@ let ``toHtmlRecent connects readings with a solid line when the gap stays within
 let ``toHtmlRecent judges gaps by calendar days, not raw elapsed time`` () =
   // Window = 30 days; threshold = 3.0 missing days. Day 1 → Day 5 is a 4-calendar-day gap
   // (missingDays = 3, not > 3), so it must render solid even though the readings are
-  // 9:00 → 10:00, i.e. raw elapsed time (4.0417 days) would cross the threshold if used directly.
+  // 9:00 → 10:00, i.e., raw elapsed time (4.0417 days) would cross the threshold if used directly.
   let readings = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 5 10 None ]
   let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
   test <@ not (html.Contains("\"dash\":\"dash\"")) @>
@@ -253,6 +253,37 @@ let ``toHtmlRecent shows exactly one legend entry per series, even when split ac
 
   test <@ legendCount "Systolic" = 1 @>
   test <@ legendCount "Diastolic" = 1 @>
+
+[<Fact>]
+let ``toHtmlRecent renders a smoothed trend line for systolic and diastolic`` () =
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  test <@ html.Contains("\"name\":\"Systolic (trend)\"") @>
+  test <@ html.Contains("\"name\":\"Diastolic (trend)\"") @>
+
+[<Fact>]
+let ``toHtmlRecent omits the trend line when there are too few readings to smooth meaningfully`` () =
+  let sparse = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 2 9 None ]
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 sparse
+  test <@ not (html.Contains("(trend)")) @>
+
+[<Fact>]
+let ``toHtmlRecent fades the raw measurement line so the LOWESS trend line stands out as the visual focus`` () =
+  // Wegier et al. 2021, "Smoothing data": "The line graph of (raw) measurements was
+  // then faded slightly to help the smoothing line stand out." — the raw series should
+  // render at reduced opacity (rgba alpha < 1) while the trend series keeps full color.
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+
+  let traceLineColor (exactName: string) =
+    let m =
+      Regex.Match(html, $"\"name\":\"{Regex.Escape(exactName)}\".*?\"line\":{{[^}}]*\"color\":\"([^\"]*)\"")
+
+    test <@ m.Success @>
+    m.Groups[1].Value
+
+  test <@ (traceLineColor "Systolic").StartsWith("rgba") @>
+  test <@ (traceLineColor "Diastolic").StartsWith("rgba") @>
+  test <@ traceLineColor "Systolic (trend)" = "#008471" @>
+  test <@ traceLineColor "Diastolic (trend)" = "#9C652B" @>
 
 [<Fact>]
 let ``toHtmlDashed matches snapshot`` () : Task =

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -9,10 +9,29 @@ module BpChart =
   // ── palette ──────────────────────────────────────────────────────────────
   let private transparent = Color.fromString "rgba(0,0,0,0)"
   let private lightGridLine = Color.fromString "rgba(0,0,0,0.08)"
-  let private systolicColor = Color.fromString "#008471"
-  let private diastolicColor = Color.fromString "#9C652B"
-  let private systolicBandColor = Color.fromString "rgba(0,132,113,0.12)"
-  let private diastolicBandColor = Color.fromString "rgba(156,101,43,0.12)"
+
+  // Each series has one RGB source of truth; every other shade (full-strength line,
+  // faded line, background band) is a derived alpha of it, so retuning a series' hue
+  // only ever needs a change in one place.
+  let private opaque (r, g, b) =
+    Color.fromString (sprintf "#%02X%02X%02X" r g b)
+
+  let private withAlpha (alpha: float) (r, g, b) =
+    Color.fromString (sprintf "rgba(%d,%d,%d,%g)" r g b alpha)
+
+  let private systolicRgb = (0, 132, 113)
+  let private diastolicRgb = (156, 101, 43)
+
+  let private systolicColor = opaque systolicRgb
+  let private diastolicColor = opaque diastolicRgb
+
+  // The /recent chart fades the raw per-reading line so the LOWESS trend line (kept at
+  // full strength) stands out as the visual focus — Wegier et al. 2021, "Smoothing data".
+  let private systolicFadedColor = withAlpha 0.22 systolicRgb
+  let private diastolicFadedColor = withAlpha 0.22 diastolicRgb
+
+  let private systolicBandColor = withAlpha 0.12 systolicRgb
+  let private diastolicBandColor = withAlpha 0.12 diastolicRgb
 
   /// Full-width horizontal background bands behind the data, one per series, matching
   /// the series' color (the "like-with-like" goal-range design from Wegier et al. 2021).
@@ -410,12 +429,48 @@ module BpChart =
         )
         |> Chart.withLineStyle (Color = color))
 
+  // Fraction of points in each point's local LOWESS neighbourhood. A wide bandwidth
+  // (e.g. 0.5) averages over so many points that real local structure — a dip right
+  // before a gap, a spike right after one — gets smoothed away into one broad hump,
+  // unlike the responsive trend line in Wegier et al. 2021's Fig. 5. A narrow
+  // bandwidth keeps the day-to-day jitter damped while still tracking those shifts.
+  let private lowessBandwidth = 0.12
+
+  // Minimum reading count for a trend line to be meaningful; below this, a local
+  // regression is mostly fitting noise.
+  let private minReadingsForTrend = 4
+
+  /// The LOWESS trend overlay for one series — the chart's visual focus, drawn at full
+  /// color and thicker than the (faded) raw line, with no markers. Omitted when there
+  /// aren't enough readings for the smoothing to be meaningful.
+  let private smoothTrace
+    (color: Color)
+    (name: string)
+    (sorted: BloodPressureReading list)
+    (labels: string list)
+    (values: int list)
+    : GenericChart list =
+    if List.length values < minReadingsForTrend then
+      []
+    else
+      let first = (List.head sorted).Timestamp.ToLocalTime().Date
+
+      let xs =
+        sorted |> List.map (fun r -> (r.Timestamp.ToLocalTime().Date - first).TotalDays)
+
+      let smoothed = Lowess.smooth lowessBandwidth xs (values |> List.map float)
+
+      [ Chart.Line(x = labels, y = smoothed, Name = name, ShowLegend = true)
+        |> Chart.withLineStyle (Color = color, Width = 3.5) ]
+
   let private renderRecent (goal: GoalRange) (windowDays: int) (readings: BloodPressureReading list) : string =
     let readings, timestamps, systolic, diastolic = seriesOf readings
     let dashes = dashPattern windowDays readings
 
-    [ yield! seriesTraces systolicColor "Systolic" dashes timestamps systolic
-      yield! seriesTraces diastolicColor "Diastolic" dashes timestamps diastolic
+    [ yield! seriesTraces systolicFadedColor "Systolic" dashes timestamps systolic
+      yield! seriesTraces diastolicFadedColor "Diastolic" dashes timestamps diastolic
+      yield! smoothTrace systolicColor "Systolic (trend)" readings timestamps systolic
+      yield! smoothTrace diastolicColor "Diastolic (trend)" readings timestamps diastolic
       yield! commentTraces readings ]
     |> Chart.combine
     |> Chart.withShapes (goalBands goal)

--- a/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
+++ b/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="ReadingStatsTests.fs" />
     <Compile Include="PasswordHashingTests.fs" />
     <Compile Include="DemoDataTests.fs" />
+    <Compile Include="LowessTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Core.Tests/DemoDataTests.fs
+++ b/code/BpMonitor.Core.Tests/DemoDataTests.fs
@@ -11,9 +11,9 @@ let private now = DateTimeOffset(2026, 6, 14, 12, 0, 0, TimeSpan.Zero)
 // ── member shape ─────────────────────────────────────────────────────────────
 
 [<Fact>]
-let ``simpsons produces exactly 5 member entries`` () =
+let ``simpsons produces exactly 6 member entries`` () =
   let result = DemoData.simpsons ranges now
-  test <@ result.Length = 5 @>
+  test <@ result.Length = 6 @>
 
 [<Fact>]
 let ``simpsons has exactly one admin member`` () =
@@ -24,7 +24,7 @@ let ``simpsons has exactly one admin member`` () =
 [<Fact>]
 let ``simpsons admin is Marge Simpson`` () =
   let result = DemoData.simpsons ranges now
-  let (spec, _) = result |> List.find (fun (spec, _) -> spec.IsAdmin)
+  let spec, _ = result |> List.find (fun (spec, _) -> spec.IsAdmin)
   test <@ spec.Name = "Marge Simpson" @>
 
 // ── reading validity ──────────────────────────────────────────────────────────
@@ -33,7 +33,7 @@ let ``simpsons admin is Marge Simpson`` () =
 let ``all generated readings are in range (no parse errors)`` () =
   let result = DemoData.simpsons ranges now
 
-  for (_, readings) in result do
+  for _, readings in result do
     for r in readings do
       test
         <@
@@ -81,7 +81,7 @@ let ``Homer mean systolic is higher than Marge mean systolic`` () =
   let result = DemoData.simpsons ranges now
 
   let meanSys name =
-    let (_, readings) = result |> List.find (fun (s, _) -> s.Name = name)
+    let _, readings = result |> List.find (fun (s, _) -> s.Name = name)
     readings |> List.averageBy (fun r -> float r.Systolic)
 
   test <@ meanSys "Homer Simpson" > meanSys "Marge Simpson" @>
@@ -91,14 +91,235 @@ let ``Marge mean systolic is higher than Bart mean systolic`` () =
   let result = DemoData.simpsons ranges now
 
   let meanSys name =
-    let (_, readings) = result |> List.find (fun (s, _) -> s.Name = name)
+    let _, readings = result |> List.find (fun (s, _) -> s.Name = name)
     readings |> List.averageBy (fun r -> float r.Systolic)
 
   test <@ meanSys "Marge Simpson" > meanSys "Bart Simpson" @>
+
+// ── Ned Flanders: a Fig. 5-style narrative (Wegier et al. 2021) ───────────────
+// Elevated BP, a multi-day gap in home monitoring, then visibly improved control
+// after starting treatment — exercises the /recent chart's missing-data dashing
+// and LOWESS trend line on the same kind of story the paper's mock-up display shows.
+
+let private nedReadings () =
+  DemoData.simpsons ranges now
+  |> List.find (fun (s, _) -> s.Name = "Ned Flanders")
+  |> snd
+
+[<Fact>]
+let ``Ned Flanders has a multi-day gap in his most recent readings`` () =
+  let readings = nedReadings ()
+  let sorted = readings |> List.sortBy _.Timestamp
+
+  let largestGapDays =
+    sorted
+    |> List.pairwise
+    |> List.map (fun (a, b) -> (b.Timestamp.ToLocalTime().Date - a.Timestamp.ToLocalTime().Date).Days)
+    |> List.max
+
+  // > 3 missing days exceeds 10% of a 30-day window, triggering the dashed-line treatment.
+  test <@ largestGapDays - 1 > 3 @>
+
+[<Fact>]
+let ``Ned Flanders' blood pressure improves after the gap`` () =
+  let readings = nedReadings ()
+  let sorted = readings |> List.sortBy _.Timestamp
+
+  let gapEndIdx =
+    sorted
+    |> List.pairwise
+    |> List.indexed
+    |> List.maxBy (fun (_, (a, b)) -> (b.Timestamp.ToLocalTime().Date - a.Timestamp.ToLocalTime().Date).Days)
+    |> fun (i, _) -> i + 1
+
+  let before = sorted |> List.take gapEndIdx
+  let after = sorted |> List.skip gapEndIdx
+
+  test
+    <@ (before |> List.averageBy (fun r -> float r.Systolic)) > (after |> List.averageBy (fun r -> float r.Systolic)) @>
+
+  test
+    <@ (before |> List.averageBy (fun r -> float r.Diastolic)) > (after |> List.averageBy (fun r -> float r.Diastolic)) @>
+
+[<Fact>]
+let ``Ned Flanders' gap falls within the last 30 days, so it's visible on the /recent chart`` () =
+  let readings = nedReadings ()
+
+  let last30Days =
+    readings |> List.filter (fun r -> r.Timestamp >= now.AddDays(-30.0))
+
+  let largestGapWithinWindow =
+    last30Days
+    |> List.sortBy _.Timestamp
+    |> List.pairwise
+    |> List.map (fun (a, b) -> (b.Timestamp.ToLocalTime().Date - a.Timestamp.ToLocalTime().Date).Days)
+    |> List.max
+
+  test <@ largestGapWithinWindow - 1 > 3 @>
+
+[<Fact>]
+let ``Ned Flanders' last 30 days mirror Fig. 5's systolic/diastolic values exactly, in order`` () =
+  // Transcribed verbatim from the "Blood Pressure Values" data table in Fig. 5
+  // (Wegier et al. 2021, docs/resources/12911_2021_Article_1598.pdf, page 10).
+  let expectedSystolic =
+    [ 147
+      157
+      155
+      160
+      154
+      161
+      158
+      150
+      141
+      163
+      144
+      149
+      158
+      181
+      169
+      173
+      153
+      154
+      151
+      163
+      157
+      155
+      146
+      167
+      155
+      164
+      136
+      129
+      125
+      126
+      134
+      128
+      130
+      123
+      126
+      132
+      119
+      149
+      129
+      141
+      117
+      140
+      151
+      120
+      122
+      150
+      128
+      132
+      129
+      125
+      132
+      138
+      140
+      135
+      122
+      123
+      116 ]
+
+  let expectedDiastolic =
+    [ 100
+      101
+      105
+      122
+      93
+      99
+      110
+      100
+      92
+      106
+      96
+      98
+      101
+      98
+      102
+      107
+      114
+      100
+      96
+      119
+      94
+      93
+      93
+      101
+      96
+      114
+      76
+      76
+      69
+      73
+      79
+      77
+      72
+      76
+      72
+      80
+      77
+      85
+      85
+      78
+      73
+      80
+      79
+      70
+      70
+      53
+      81
+      73
+      75
+      77
+      77
+      79
+      76
+      80
+      82
+      76
+      70 ]
+
+  let readings = nedReadings ()
+
+  let last30Days =
+    readings
+    |> List.filter (fun r -> r.Timestamp >= now.AddDays(-30.0))
+    |> List.sortBy _.Timestamp
+
+  test <@ (last30Days |> List.map _.Systolic) = expectedSystolic @>
+  test <@ (last30Days |> List.map _.Diastolic) = expectedDiastolic @>
+
+[<Fact>]
+let ``Ned Flanders' Fig. 5 readings are uniformly spaced apart from the one gap`` () =
+  // LOWESS picks its neighborhood by point rank, not a fixed time window — if the
+  // 57 Fig. 5 readings were unevenly dense (e.g., sparse before the gap, packed
+  // afterward). The fit would be skewed by whichever region's points dominate
+  // the rank-nearest search, distorting the curve's shape relative to the paper's.
+  // Spacing must be uniform throughout except for the one intentional gap.
+  let readings = nedReadings ()
+
+  let last30Days =
+    readings
+    |> List.filter (fun r -> r.Timestamp >= now.AddDays(-30.0))
+    |> List.sortBy _.Timestamp
+    |> List.map _.Timestamp
+
+  let gapsInDays =
+    last30Days |> List.pairwise |> List.map (fun (a, b) -> (b - a).TotalDays)
+
+  let ordinarySteps = gapsInDays |> List.filter (fun d -> d < 1.0)
+  let bigGaps = gapsInDays |> List.filter (fun d -> d >= 1.0)
+
+  // Exactly one big gap (the cuff-broken stretch); every other step is the same
+  // uniform fractional-day spacing (within floating-point tolerance).
+  test <@ bigGaps.Length = 1 @>
+  test <@ ordinarySteps.Length = gapsInDays.Length - 1 @>
+  let minStep, maxStep = List.min ordinarySteps, List.max ordinarySteps
+  test <@ maxStep - minStep < 0.001 @>
 
 [<Fact>]
 let ``each member has enough readings for trend granularities`` () =
   let result = DemoData.simpsons ranges now
   // Minimum: expect at least 52 readings per member (roughly 1 per week for a year)
-  for (_, readings) in result do
+  for _, readings in result do
     test <@ readings.Length >= 52 @>

--- a/code/BpMonitor.Core.Tests/LowessTests.fs
+++ b/code/BpMonitor.Core.Tests/LowessTests.fs
@@ -1,0 +1,76 @@
+module LowessTests
+
+open Xunit
+open Swensen.Unquote
+open BpMonitor.Core
+
+[<Fact>]
+let ``smooth returns the same y values for perfectly linear data`` () =
+  let xs = [ 0.0; 1.0; 2.0; 3.0; 4.0 ]
+  let ys = [ 0.0; 1.0; 2.0; 3.0; 4.0 ]
+
+  let result = Lowess.smooth 0.5 xs ys
+
+  test <@ List.forall2 (fun a b -> abs (a - b) < 0.001) result ys @>
+
+[<Fact>]
+let ``smooth returns the same constant value for constant data`` () =
+  let xs = [ 0.0; 1.0; 2.0; 3.0; 4.0 ]
+  let ys = [ 7.0; 7.0; 7.0; 7.0; 7.0 ]
+
+  let result = Lowess.smooth 0.5 xs ys
+
+  test <@ List.forall (fun y -> abs (y - 7.0) < 0.001) result @>
+
+[<Fact>]
+let ``smooth reduces noise variance around an underlying linear trend`` () =
+  let xs = [ 0.0; 1.0; 2.0; 3.0; 4.0; 5.0; 6.0; 7.0; 8.0; 9.0 ]
+  let trend = xs |> List.map (fun x -> 2.0 * x + 1.0)
+  // Alternating +/- noise around the trend line.
+  let noise = [ 3.0; -3.0; 3.0; -3.0; 3.0; -3.0; 3.0; -3.0; 3.0; -3.0 ]
+  let ys = List.map2 (+) trend noise
+
+  let result = Lowess.smooth 0.5 xs ys
+
+  let sumSquaredError series =
+    List.map2 (fun a b -> (a - b) ** 2.0) series trend |> List.sum
+
+  test <@ sumSquaredError result < sumSquaredError ys @>
+
+[<Fact>]
+let ``smooth returns the input unchanged when there are fewer than 3 points`` () =
+  let xs = [ 0.0; 1.0 ]
+  let ys = [ 5.0; 12.0 ]
+
+  let result = Lowess.smooth 0.5 xs ys
+
+  test <@ result = ys @>
+
+[<Fact>]
+let ``smooth keeps the overall direction of a monotone increasing trend`` () =
+  let xs = [ 0.0 .. 9.0 ]
+  let ys = [ 1.0; 3.0; 2.0; 5.0; 4.0; 7.0; 6.0; 9.0; 8.0; 11.0 ]
+
+  let result = Lowess.smooth 0.5 xs ys
+
+  test <@ List.head result < List.last result @>
+
+[<Fact>]
+let ``smooth downweights a single extreme outlier instead of being pulled toward it`` () =
+  // A clean linear trend with one wild outlier in the middle. Cleveland's LOWESS
+  // is defined by its robustifying iterations (bisquare-reweight on residuals,
+  // then refit) — that's precisely what lets it shrug off an outlier reading
+  // instead of dragging the local fit toward it like plain weighted regression would.
+  let xs = [ 0.0 .. 10.0 ]
+  let trend = xs |> List.map (fun x -> 2.0 * x + 1.0)
+  let outlierIdx = 5
+  let ys = trend |> List.mapi (fun i y -> if i = outlierIdx then y + 100.0 else y)
+
+  let result = Lowess.smooth 1.0 xs ys
+
+  let trueValue = trend[outlierIdx]
+  let outlierValue = ys[outlierIdx]
+  let smoothedValue = result[outlierIdx]
+
+  test <@ abs (smoothedValue - trueValue) < abs (smoothedValue - outlierValue) @>
+  test <@ abs (smoothedValue - trueValue) < 10.0 @>

--- a/code/BpMonitor.Core.Tests/PasswordHashingTests.fs
+++ b/code/BpMonitor.Core.Tests/PasswordHashingTests.fs
@@ -64,7 +64,7 @@ let private passwordGen: Gen<string> =
     let! len = Gen.choose (1, 64)
 
     let! chars =
-      Gen.elements ([ '!' .. '~' ]) // printable ASCII excluding space
+      Gen.elements [ '!' .. '~' ] // printable ASCII excluding space
       |> Gen.listOfLength len
 
     return System.String(List.toArray chars)

--- a/code/BpMonitor.Core/BpMonitor.Core.fsproj
+++ b/code/BpMonitor.Core/BpMonitor.Core.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="DemoData.fs" />
     <Compile Include="TrendPeriod.fs" />
     <Compile Include="ReadingStats.fs" />
+    <Compile Include="Lowess.fs" />
     <Compile Include="IReadingRepository.fs" />
   </ItemGroup>
 

--- a/code/BpMonitor.Core/DemoData.fs
+++ b/code/BpMonitor.Core/DemoData.fs
@@ -8,7 +8,7 @@ type MemberSpec = { Name: string; IsAdmin: bool }
 
 /// Deterministic demo-data generator — the Simpson family.
 ///
-/// All generation is pure (no I/O). A per-member fixed Random seed ensures
+/// All generations are pure (no I/O). A per-member fixed Random seed ensures
 /// identical output for the same `now` value across multiple calls.
 module DemoData =
 
@@ -106,6 +106,28 @@ module DemoData =
 
   let private clamp lo hi v = max lo (min hi v)
 
+  // Clamps raw vitals into range and parses them into a reading. Shared by every
+  // generator below (the random-jitter Simpson profiles and Ned Flanders' scripted
+  // narrative alike) so there's one place that builds an `unvalidated` record.
+  let private buildReading
+    (ranges: ReadingRanges)
+    (systolic: int)
+    (diastolic: int)
+    (heartRate: int)
+    (timestamp: DateTimeOffset)
+    (comment: string option)
+    : BloodPressureReading option =
+    let unvalidated =
+      { Systolic = clamp ranges.SystolicMin ranges.SystolicMax systolic
+        Diastolic = clamp ranges.DiastolicMin ranges.DiastolicMax diastolic
+        HeartRate = clamp ranges.HeartRateMin ranges.HeartRateMax heartRate
+        Timestamp = timestamp
+        Comments = comment }
+
+    match BloodPressureReading.parse ranges unvalidated with
+    | Ok r -> Some r
+    | Error _ -> None // never reached: values are clamped into range
+
   // ── reading generation ────────────────────────────────────────────────────
 
   let private generateReadings (ranges: ReadingRanges) (now: DateTimeOffset) (profile: Profile) =
@@ -132,45 +154,238 @@ module DemoData =
           let ts =
             DateTimeOffset(date.Year, date.Month, date.Day, hour, minute, 0, TimeSpan.Zero)
 
-          let sys =
-            clamp
-              ranges.SystolicMin
-              ranges.SystolicMax
-              (profile.SysBase + rng.Next(-profile.SysJitter, profile.SysJitter + 1))
-
-          let dia =
-            clamp
-              ranges.DiastolicMin
-              ranges.DiastolicMax
-              (profile.DiaBase + rng.Next(-profile.DiaJitter, profile.DiaJitter + 1))
-
-          let hr =
-            clamp
-              ranges.HeartRateMin
-              ranges.HeartRateMax
-              (profile.HrBase + rng.Next(-profile.HrJitter, profile.HrJitter + 1))
-
+          // Random draw order matters for determinism — preserve sys, dia, hr, then
+          // comment, matching the original sequence so existing demo values don't shift.
+          let sys = profile.SysBase + rng.Next(-profile.SysJitter, profile.SysJitter + 1)
+          let dia = profile.DiaBase + rng.Next(-profile.DiaJitter, profile.DiaJitter + 1)
+          let hr = profile.HrBase + rng.Next(-profile.HrJitter, profile.HrJitter + 1)
           let commentIdx = rng.Next(0, profile.Comments.Length)
           let comment = profile.Comments[commentIdx]
 
-          let unvalidated =
-            { Systolic = sys
-              Diastolic = dia
-              HeartRate = hr
-              Timestamp = ts
-              Comments = comment }
+          buildReading ranges sys dia hr ts comment)
 
-          match BloodPressureReading.parse ranges unvalidated with
-          | Ok r -> Some r
-          | Error _ -> None // never reached: values are clamped into range
-    )
+  // ── Ned Flanders: a Fig. 5-style narrative (Wegier et al. 2021) ───────────
+  //
+  // Unlike the random-jitter profiles above, Ned's last 30 days mirror the
+  // "Blood Pressure Values" data table from Fig. 5 exactly, verbatim, in order:
+  // 9 elevated readings, a 5-day gap (4 missing days — he forgot his cuff on a
+  // mission trip, matching the figure's "BP cuff broken for four days"
+  // annotation), then 48 readings that visibly improve after starting
+  // medication. All 57 readings are spaced uniformly (except for that one gap),
+  // so the density doesn't skew the LOWESS fit — see the comment at
+  // `generateNedReadings`. A year of sparser, mildly elevated background
+  // readings precedes it for /trends and /history.
+
+  let private nedSpec =
+    { Name = "Ned Flanders"
+      IsAdmin = false }
+
+  let private nedReadingAt
+    (ranges: ReadingRanges)
+    (now: DateTimeOffset)
+    (rng: Random)
+    (daysAgo: int)
+    (sysBase: int)
+    (sysJitter: int)
+    (diaBase: int)
+    (diaJitter: int)
+    (comment: string option)
+    : BloodPressureReading option =
+    let date = now.AddDays(-float daysAgo).Date
+    let hour = rng.Next(7, 21)
+    let minute = rng.Next(0, 60)
+
+    let ts =
+      DateTimeOffset(date.Year, date.Month, date.Day, hour, minute, 0, TimeSpan.Zero)
+
+    buildReading
+      ranges
+      (sysBase + rng.Next(-sysJitter, sysJitter + 1))
+      (diaBase + rng.Next(-diaJitter, diaJitter + 1))
+      (74 + rng.Next(-5, 6))
+      ts
+      comment
+
+  // An exact (non-jittered) reading at a fractional days-ago offset, for the Fig. 5
+  // values — only HeartRate (absent from the figure) is synthesized.
+  let private nedExactReadingAt
+    (ranges: ReadingRanges)
+    (now: DateTimeOffset)
+    (rng: Random)
+    (daysAgo: float)
+    (systolic: int)
+    (diastolic: int)
+    (comment: string option)
+    : BloodPressureReading option =
+    buildReading ranges systolic diastolic (74 + rng.Next(-5, 6)) (now.AddDays(-daysAgo)) comment
+
+  // Transcribed verbatim from the "Blood Pressure Values" data table in Fig. 5
+  // (docs/resources/12911_2021_Article_1598.pdf, page 10).
+  let private nedSysPreGap = [ 147; 157; 155; 160; 154; 161; 158; 150; 141 ]
+  let private nedDiaPreGap = [ 100; 101; 105; 122; 93; 99; 110; 100; 92 ]
+
+  let private nedSysPostGap =
+    [ 163
+      144
+      149
+      158
+      181
+      169
+      173
+      153
+      154
+      151
+      163
+      157
+      155
+      146
+      167
+      155
+      164
+      136
+      129
+      125
+      126
+      134
+      128
+      130
+      123
+      126
+      132
+      119
+      149
+      129
+      141
+      117
+      140
+      151
+      120
+      122
+      150
+      128
+      132
+      129
+      125
+      132
+      138
+      140
+      135
+      122
+      123
+      116 ]
+
+  let private nedDiaPostGap =
+    [ 106
+      96
+      98
+      101
+      98
+      102
+      107
+      114
+      100
+      96
+      119
+      94
+      93
+      93
+      101
+      96
+      114
+      76
+      76
+      69
+      73
+      79
+      77
+      72
+      76
+      72
+      80
+      77
+      85
+      85
+      78
+      73
+      80
+      79
+      70
+      70
+      53
+      81
+      73
+      75
+      77
+      77
+      79
+      76
+      80
+      82
+      76
+      70 ]
+
+  let private generateNedReadings (ranges: ReadingRanges) (now: DateTimeOffset) : BloodPressureReading list =
+    let rng = Random(6)
+
+    // Phase 1 (background, ~1 year): infrequent (every 4 days — under the >10%-of-30-days
+    // missing-data threshold, so it never renders dashed), mildly elevated, undiagnosed.
+    // Stops a few days before the Fig. 5 window so that the boundary gap stays well under
+    // the mission-trip gap, keeping the latter the single largest gap overall.
+    let background =
+      [ 380..-4..32 ]
+      |> List.choose (fun daysAgo -> nedReadingAt ranges now rng daysAgo 141 6 89 5 None)
+
+    // Uniform spacing across the entire 57-point Fig. 5 sequence (matching the figure's
+    // roughly daily cadence), compressed to fit a 30-day window with one explicit 5-day
+    // gap (4 missing days, matching the figure's "BP cuff broken for four days"
+    // annotation exactly). Density must stay uniform on both sides of the gap: LOWESS
+    // picks its neighborhood by point rank, not a fixed time window, so a sparse region
+    // sitting next to a dense one would get its fit dragged toward the dense side just
+    // to find enough neighbors — badly distorting the curve's shape relative to the
+    // paper's.
+    let preGapCount = nedSysPreGap.Length // 9
+    let totalPoints = preGapCount + nedSysPostGap.Length // 57
+
+    // 57 points have 56 gaps between them; one of those gaps is the mission-trip
+    // stretch, leaving 55 uniform steps to fill the rest of the 29-day span.
+    let bigGapDays = 5.0
+    let stepDays = (29.0 - bigGapDays) / float (totalPoints - 2)
+
+    // How much further back a point sits once it's past the gap: one ordinary step
+    // is replaced by the (longer) gap, so everything past it shifts back by the
+    // difference. Index j's days-ago is then a single formula: a uniform `j * stepDays`
+    // ramp, with that one extra shift applied from the gap onward.
+    let gapShift = bigGapDays - stepDays
+
+    let figFiveReadings =
+      List.zip3 (nedSysPreGap @ nedSysPostGap) (nedDiaPreGap @ nedDiaPostGap) [ 0 .. totalPoints - 1 ]
+      |> List.map (fun (sys, dia, j) ->
+        let shift = if j >= preGapCount then gapShift else 0.0
+        let daysAgo = 29.0 - float j * stepDays - shift
+
+        let comment =
+          if j = preGapCount - 1 then
+            Some "Forgot the cuff on a mission trip, diddly!"
+          elif j = preGapCount + 17 then
+            Some "Started on a little Lisinopril, feeling neighborly!"
+          else
+            None
+
+        nedExactReadingAt ranges now rng daysAgo sys dia comment)
+      |> List.choose id
+
+    background @ figFiveReadings
 
   // ── public API ────────────────────────────────────────────────────────────
 
-  /// Returns the Simpson family as a list of (MemberSpec, readings) pairs.
+  /// Returns the Simpson family (plus Ned Flanders) as a list of (MemberSpec,
+  /// readings) pairs.
   ///
   /// Generation is deterministic: given the same `ranges` and `now`, the result
-  /// is always identical. `now` anchors the 5-year window so trend charts look
+  /// is always identical. `now` anchors the 5-year window, so trend charts look
   /// current when the demo data is first seeded.
   let simpsons (ranges: ReadingRanges) (now: DateTimeOffset) : (MemberSpec * BloodPressureReading list) list =
-    profiles |> List.map (fun p -> p.Spec, generateReadings ranges now p)
+    let simpsonFamily =
+      profiles |> List.map (fun p -> p.Spec, generateReadings ranges now p)
+
+    simpsonFamily @ [ nedSpec, generateNedReadings ranges now ]

--- a/code/BpMonitor.Core/Lowess.fs
+++ b/code/BpMonitor.Core/Lowess.fs
@@ -1,0 +1,98 @@
+namespace BpMonitor.Core
+
+/// Locally weighted scatter plot smoothing (LOWESS, Cleveland 1979): a tricube-weighted
+/// local linear regression with robustifying iterations, used to draw a trend curve
+/// through noisy per-reading data (e.g., the /recent chart) without depending on an
+/// external statistics library. The robustifying iterations are LOWESS's defining trait over
+/// plain local regression — they downweight outlier readings instead of being pulled
+/// toward them, which is precisely why Wegier et al. 2021 chose it for BP displays.
+module Lowess =
+
+  // A standard number of robustifying (reweight-and-refit) passes after the initial fit,
+  // matching the conventional default (e.g., R's `lowess`, statsmodels' `lowess`).
+  let private robustnessIterations = 3
+
+  let private tricube (maxDist: float) (dist: float) =
+    if maxDist = 0.0 then
+      1.0
+    else
+      let u = dist / maxDist
+      (1.0 - u ** 3.0) ** 3.0
+
+  // Bisquare weight of a residual scaled by 6x the median absolute residual — Cleveland's
+  // robustness weighting. Residuals beyond 6 MAD are fully excluded from the next fit.
+  let private bisquare (scale: float) (residual: float) =
+    if scale = 0.0 then
+      1.0
+    else
+      let u = residual / scale
+      if abs u >= 1.0 then 0.0 else (1.0 - u * u) ** 2.0
+
+  // One weighted linear regression y = a + b*x over `points` (weight, x, y), evaluated at `xi`.
+  let private weightedLinearFitAt (xi: float) (points: (float * float * float) array) =
+    let sumW = points |> Array.sumBy (fun (w, _, _) -> w)
+    let meanX = (points |> Array.sumBy (fun (w, x, _) -> w * x)) / sumW
+    let meanY = (points |> Array.sumBy (fun (w, _, y) -> w * y)) / sumW
+    let sxx = points |> Array.sumBy (fun (w, x, _) -> w * (x - meanX) * (x - meanX))
+    let sxy = points |> Array.sumBy (fun (w, x, y) -> w * (x - meanX) * (y - meanY))
+
+    if sxx = 0.0 then
+      meanY
+    else
+      let b = sxy / sxx
+      let a = meanY - b * meanX
+      a + b * xi
+
+  /// Smooths `ys` against `xs` using Cleveland's LOWESS: a tricube-weighted local linear
+  /// regression refined by robustifying iterations that downweight outlier residuals.
+  /// `bandwidth` is the fraction of points (0.0–1.0] included in each point's local
+  /// neighborhood. Returns one smoothed y per input x, in input order.
+  let smooth (bandwidth: float) (xs: float list) (ys: float list) : float list =
+    let n = List.length xs
+
+    if n < 3 then
+      ys
+    else
+      let xs = List.toArray xs
+      let ys = List.toArray ys
+
+      // Number of neighbours considered for each point's local fit.
+      let k = max 2 (int (ceil (bandwidth * float n)))
+
+      // Each point's k nearest neighbours depend only on `xs`, not on the robustness
+      // weights — so they're identical across every robustifying iteration. Computed
+      // once here rather than re-sorting all n points per point on every iteration.
+      let neighbours =
+        Array.init n (fun i ->
+          let xi = xs[i]
+
+          Array.init n (fun j -> j, xs[j], ys[j], abs (xs[j] - xi))
+          |> Array.sortBy (fun (_, _, _, dist) -> dist)
+          |> Array.truncate k)
+
+      let fitAt (robustWeights: float array) (i: int) =
+        let xi = xs[i]
+        let pointNeighbours = neighbours[i]
+
+        let maxDist =
+          pointNeighbours |> Array.map (fun (_, _, _, dist) -> dist) |> Array.max
+
+        let points =
+          pointNeighbours
+          |> Array.map (fun (j, x, y, dist) -> tricube maxDist dist * robustWeights[j], x, y)
+
+        weightedLinearFitAt xi points
+
+      let rec iterate (robustWeights: float array) (remaining: int) =
+        let fitted = Array.init n (fitAt robustWeights)
+
+        if remaining = 0 then
+          fitted
+        else
+          let residuals = Array.map2 (fun y f -> abs (y - f)) ys fitted
+          let medianAbsResidual = residuals |> Array.sort |> (fun r -> r[r.Length / 2])
+          let scale = 6.0 * medianAbsResidual
+          let nextWeights = residuals |> Array.map (bisquare scale)
+          iterate nextWeights (remaining - 1)
+
+      iterate (Array.create n 1.0) robustnessIterations |> Array.toList

--- a/code/BpMonitor.Data.Tests/DemoSeederTests.fs
+++ b/code/BpMonitor.Data.Tests/DemoSeederTests.fs
@@ -29,13 +29,13 @@ let ``disabled flag leaves the store untouched`` () =
 // ── enabled seeder ────────────────────────────────────────────────────────────
 
 [<Fact>]
-let ``enabled seeder on empty store creates exactly 5 members`` () =
+let ``enabled seeder on empty store creates exactly 6 members`` () =
   let members, readings = emptyStore ()
   DemoSeeder.seedIfEmpty members readings ranges tp true
-  test <@ members.GetAll().Length = 5 @>
+  test <@ members.GetAll().Length = 6 @>
 
 [<Fact>]
-let ``enabled seeder renames the default Me member (no sixth member)`` () =
+let ``enabled seeder renames the default Me member (no extra member)`` () =
   let members, readings = emptyStore ()
   DemoSeeder.seedIfEmpty members readings ranges tp true
   let names = members.GetAll() |> List.map _.Name

--- a/code/BpMonitor.Data/DemoSeeder.fs
+++ b/code/BpMonitor.Data/DemoSeeder.fs
@@ -17,7 +17,7 @@ module DemoSeeder =
   /// Seeds the Simpson family iff `enabled` is true and the store is empty.
   ///
   /// The lone auto-seeded "Me" member (created by SchemaMigrations) is repurposed
-  /// as Marge Simpson so the final member count is exactly 5, not 6.
+  /// as Marge Simpson, so the final member count is exactly 6, not 7.
   let seedIfEmpty
     (members: IFamilyMemberRepository)
     (readings: IReadingRepository)

--- a/code/BpMonitor.sln.DotSettings
+++ b/code/BpMonitor.sln.DotSettings
@@ -2,5 +2,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=errorbar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=errorbars/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=granularities/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=lowess/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Wegier/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=yerror/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
## Summary
- Overlay a Cleveland-style LOWESS trend line (with robustifying iterations) on the `/recent` chart's systolic/diastolic series, fading the raw per-reading line so the trend is the visual focus — matching the data-display design in Wegier et al. 2021 (`docs/resources/12911_2021_Article_1598.pdf`)
- Bandwidth tuned (`0.12`) so the curve tracks real local structure (dips/spikes around gaps) instead of over-smoothing into one broad hump
- Adds a sixth demo member, Ned Flanders, whose last 30 days mirror the paper's Fig. 5 "Blood Pressure Values" table exactly — elevated readings, a 4-day cuff-broken gap, then improved control after starting medication — uniformly spaced so the LOWESS fit isn't skewed by density
- Simplification pass: shared `buildReading` helper (was duplicated 3x), unified day-offset formula for Ned's pre/post-gap readings, `Lowess.fs` perf fix (neighbour sets computed once instead of per robustifying iteration), chart colors derived from one RGB source per series, test helper dedup