### PR TITLE
✨ feat: add Fig. 5-style value strip to recent chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Recent chart now overlays a LOWESS-smoothed trend line for systolic and diastolic; the trend line is the visual focus (full color, thicker) and the raw per-reading line is faded, matching the Wegier et al. 2021 design
+- Recent page now shows a Fig. 5-style "value strip" directly above the chart, listing every Systolic/Diastolic value in the chart's 30-day window in chronological order, sized to match the chart's width with no horizontal scrolling
 - Demo dataset gains a sixth member, Ned Flanders, whose readings tell a Fig. 5-style story (elevated readings, a week-long gap, then improved control after starting medication) to showcase the new trend line and missing-data dashing
 
 ### Changed

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -168,3 +168,80 @@ let ``recent chart toggle label matches the history page's`` () =
 
   let body = TestHost.readBody ctx
   test <@ body.Contains "Blood Pressure Graph<" && not (body.Contains "(last 30 days)") @>
+
+[<Fact>]
+let ``recent shows a sys/dias value strip listing every reading in the chart window, oldest first`` () =
+  let tp = FakeTimeProvider(now)
+
+  let r1 =
+    { reading 3 1 with
+        Systolic = 130
+        Diastolic = 82 }
+
+  let r2 =
+    { reading 2 2 with
+        Systolic = 142
+        Diastolic = 91 }
+
+  let r3 =
+    { reading 1 3 with
+        Systolic = 118
+        Diastolic = 76 }
+
+  let ctx = TestHost.contextWithProvider (repoWith [ r1; r2; r3 ]) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "value-strip" @>
+
+  let systolicRow =
+    body.Substring(body.IndexOf "Systolic", body.IndexOf "Diastolic" - body.IndexOf "Systolic")
+
+  let diastolicRow = body.Substring(body.IndexOf "Diastolic")
+
+  test
+    <@
+      systolicRow.IndexOf "130" < systolicRow.IndexOf "142"
+      && systolicRow.IndexOf "142" < systolicRow.IndexOf "118"
+    @>
+
+  test
+    <@
+      diastolicRow.IndexOf "82" < diastolicRow.IndexOf "91"
+      && diastolicRow.IndexOf "91" < diastolicRow.IndexOf "76"
+    @>
+
+[<Fact>]
+let ``recent value strip uses a table so each reading's sys/dias values align in the same column`` () =
+  let tp = FakeTimeProvider(now)
+
+  let r1 =
+    { reading 3 1 with
+        Systolic = 130
+        Diastolic = 82 }
+
+  let r2 =
+    { reading 2 2 with
+        Systolic = 142
+        Diastolic = 91 }
+
+  let r3 =
+    { reading 1 3 with
+        Systolic = 118
+        Diastolic = 76 }
+
+  let ctx = TestHost.contextWithProvider (repoWith [ r1; r2; r3 ]) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  let stripStart = body.IndexOf "value-strip"
+  let stripEnd = body.IndexOf("</table>", stripStart)
+  let strip = body.Substring(stripStart, stripEnd - stripStart)
+
+  let cellValues =
+    System.Text.RegularExpressions.Regex.Matches(strip, "<td[^>]*>(\\d+)</td>")
+    |> Seq.map (fun m -> m.Groups[1].Value)
+    |> List.ofSeq
+
+  test <@ strip.Contains "<table" @>
+  test <@ cellValues = [ "130"; "142"; "118"; "82"; "91"; "76" ] @>

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -47,6 +47,20 @@ module ReadingViews =
     let section (heading: string) (anchor: string) (readings: BloodPressureReading list) =
       Elem.section [ Attr.id anchor ] [ Elem.h2 [] [ Text.raw heading ]; ViewLayout.readingsTable readings ]
 
+    let valueStrip =
+      // The strip lists the same readings as the chart below it (days30).
+      let chronological = days30 |> List.sortBy _.Timestamp
+
+      let row (label: string) (value: BloodPressureReading -> int) =
+        Elem.tr
+          []
+          [ yield Elem.th [ Attr.scope "row"; Attr.class' "value-strip-label" ] [ Text.raw label ]
+            for r in chronological -> Elem.td [ Attr.class' "value-strip-value" ] [ Text.raw (string (value r)) ] ]
+
+      Elem.div
+        [ Attr.class' "value-strip" ]
+        [ Elem.table [] [ Elem.tbody [] [ row "Systolic" _.Systolic; row "Diastolic" _.Diastolic ] ] ]
+
     ViewLayout.layout
       Routes.recent
       activeMember.Name
@@ -61,7 +75,9 @@ module ReadingViews =
         Elem.details
           [ Attr.create "open" "" ]
           [ Elem.summary [ Attr.class' "chart-toggle" ] [ Text.raw "Blood Pressure Graph" ]
-            Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ]
+            Elem.div
+              [ Attr.class' "chart-container" ]
+              [ valueStrip; Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ] ]
         section "Last 7 days" "days-7" days7
         section "Last 14 days" "days-14" days14
         section "Last 30 days" "days-30" days30 ]

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -508,6 +508,50 @@ form.inline button {
   color: var(--pico-muted-color);
 }
 
+/* ── Recent page ────────────────────────────────────────────────────────── */
+
+/* Wraps the value strip and the chart together so the strip's table can
+   match the chart's rendered width without affecting .chart's own fixed
+   height/overflow rules (needed by Plotly). */
+.chart-container {
+  width: 100%;
+}
+
+/* Fig. 5-style "Blood Pressure Values" strip: a 2-row data table (Systolic/
+   Diastolic) listing every value currently shown in the chart window. Fixed
+   table layout stretches to the same width as the chart below it and
+   divides that width evenly across columns, so it never needs horizontal
+   scrolling — a real <table> still guarantees each reading's sys/dias
+   values land in the same column regardless of differing digit widths. */
+.value-strip {
+  margin-bottom: 1rem;
+}
+
+.value-strip table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  margin: 0;
+}
+
+.value-strip th,
+.value-strip td {
+  padding: 0.05rem 0.05rem;
+  border: none;
+  font-size: 0.5rem;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.value-strip-label {
+  width: 3rem;
+  text-align: left;
+  font-weight: bold;
+  color: var(--pico-muted-color);
+}
+
 /* ── Trends page ────────────────────────────────────────────────────────── */
 
 /* Granularity selector row (Weekly / Monthly / Yearly) */

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,7 +154,7 @@ graph TD
 - **Isolation:** each member sees only their own readings; admins manage members via `/members` but not their readings
 - **Routes:** `/` hub, `/add`, `/history`, `/recent`, `/trends`, `/settings`, `/members`, `/members/{id}/edit`, `/members/{id}/reset-password`, `/login`, `/login/{id}`, `POST /logout`
 - **`/settings`:** self-service page where the logged-in member edits their own chart goal range (`GoalRange`); validated via `GoalRange.create` (min < max per pair)
-- **`/recent`:** three rolling windows (last 7 / 14 / 30 days) of raw readings plus a 30-day chart — no aggregation
+- **`/recent`:** three rolling windows (last 7 / 14 / 30 days) of raw readings plus a 30-day chart — no aggregation. Above the chart, a Fig. 5-style (Wegier et al. 2021) "value strip" table lists every Systolic/Diastolic value in the chart's 30-day window in chronological order, sized to match the chart's rendered width with no horizontal scrolling
 - **`/trends`:** granularity selector (Weekly/Monthly/Yearly) + htmx-swapped period fragments; stats from `ReadingStats` (Core); `TimeProvider` injected for testability
 - `protect` / `protectAdmin` combinators; active member resolved from `ClaimsPrincipal`
 - Server-rendered HTML via `Falco.Markup`; htmx for partial updates; scoped `DbContext` per request


### PR DESCRIPTION
## Summary

- Adds a Fig. 5-style (Wegier et al. 2021) "value strip" directly above the Recent chart, listing every Systolic/Diastolic value in the chart's 30-day window in chronological order
- Uses a real `<table>` so each reading's sys/dias pair aligns in the same column regardless of digit width
- Sized to match the chart's rendered width with `table-layout: fixed`, no horizontal scrolling required
- Lives in the same `.chart-container` as the chart itself