### PR TITLE
🔧 chore: enforce git-workflow skill rules via PreToolUse hook

### DIFF
--- a/.claude/hooks/git-workflow-reminder.sh
+++ b/.claude/hooks/git-workflow-reminder.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash(git *) / Bash(gh *): reminds Claude of git-workflow
+# skill rules at the moment a risky git/gh subcommand is about to run, instead
+# of relying on Claude to remember to invoke the skill itself.
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+reminder=""
+case "$cmd" in
+  *"git checkout -b"*|*"git switch -c"*)
+    reminder="git-workflow skill: creating a branch is the FIRST step before any code changes. Confirm you branched off main, and the name is lowercase-hyphenated with a feature/fix/chore prefix."
+    ;;
+  *"git commit"*)
+    reminder="git-workflow skill: commit message must be gitmoji + conventional commits, imperative mood. NEVER add a Co-Authored-By trailer. Only commit after showing the message and getting explicit user approval."
+    ;;
+  *"git push"*)
+    reminder="git-workflow skill: never force-push to main. Push only the feature branch."
+    ;;
+  *"gh pr create"*)
+    reminder="git-workflow skill: PR title must be gitmoji + conventional commits (it becomes the squash-merge commit). PR body is a Summary section only — no Test plan section, no Generated-with-Claude-Code footer."
+    ;;
+  *"gh pr merge"*)
+    reminder="git-workflow skill: do not merge until \`gh pr checks <number> --watch\` shows all checks green. Squash-merge only."
+    ;;
+  *"git branch -D"*)
+    reminder="git-workflow skill: only delete a branch after it's merged — run \`git fetch --prune\` first."
+    ;;
+esac
+
+if [ -n "$reminder" ]; then
+  jq -n --arg ctx "$reminder" '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$ctx}}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git *)",
+            "command": "bash .claude/hooks/git-workflow-reminder.sh",
+            "statusMessage": "Checking git-workflow rules..."
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh *)",
+            "command": "bash .claude/hooks/git-workflow-reminder.sh",
+            "statusMessage": "Checking git-workflow rules..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add PreToolUse hook in .claude/settings.json that fires before git-related Bash commands
- Hook script (.claude/hooks/git-workflow-reminder.sh) inspects git/gh subcommands and injects context reminders
- Covers: branch-first, gitmoji commits, no co-author trailers, CI before merge, squash merge, post-merge cleanup
- Makes git-workflow skill guidance actually enforced rather than relying on me remembering to invoke it