### PR TITLE
✨ feat: add Fig. 5-style scrubber bar to recent chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recent chart now overlays a LOWESS-smoothed trend line for systolic and diastolic; the trend line is the visual focus (full color, thicker) and the raw per-reading line is faded, matching the Wegier et al. 2021 design
 - Recent page now shows a Fig. 5-style "value strip" directly above the chart, listing every Systolic/Diastolic value in the chart's 30-day window in chronological order, sized to match the chart's width with no horizontal scrolling
 - Demo dataset gains a sixth member, Ned Flanders, whose readings tell a Fig. 5-style story (elevated readings, a week-long gap, then improved control after starting medication) to showcase the new trend line and missing-data dashing
+- Recent chart now has a Fig. 5-style scrubber bar: hovering shows a vertical line that snaps to the nearest reading and boxes the matching column in the value strip above the chart, linking the two together
 
 ### Changed
 

--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -286,6 +286,20 @@ let ``toHtmlRecent fades the raw measurement line so the LOWESS trend line stand
   test <@ traceLineColor "Diastolic (trend)" = "#9C652B" @>
 
 [<Fact>]
+let ``toHtmlRecent shows a spikeline on the x-axis, to scrub through the chart and value strip`` () =
+  // Wegier et al. 2021, "Scrubber bar": a vertical line tracks the cursor's horizontal
+  // position across the display. Plotly's x-axis spikes give this for free.
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  test <@ html.Contains("\"showspikes\":true") @>
+
+[<Fact>]
+let ``toHtml (history) does not show a spikeline`` () =
+  // The scrubber bar is a /recent-only affordance (it links to the value strip, which
+  // only /recent has) — /history's chart keeps its plain x-axis.
+  let html = BpChart.toHtml GoalRange.defaults readings
+  test <@ not (html.Contains("\"showspikes\":true")) @>
+
+[<Fact>]
 let ``toHtmlDashed matches snapshot`` () : Task =
   let html: string =
     BpChart.toHtmlDashed GoalRange.defaults Weekly (asAggregated readings)

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -73,6 +73,28 @@ module BpChart =
       TickColor = axisLineColor
     )
 
+  // Fig. 5's scrubber bar (Wegier et al. 2021, "Scrubber bar"): a vertical line that
+  // tracks the cursor's horizontal position, linking the chart to the value strip above
+  // it. Plotly's x-axis spikes give us this for free — snapped to the nearest data point
+  // (SpikeSnap = Data) and drawn across the whole plot area (SpikeMode = Across).
+  // /recent-only: the spike is only meaningful where there's a value strip to link to.
+  let private scrubberColor = Color.fromString "#00C853"
+
+  let private recentXAxis =
+    LinearAxis.init (
+      ShowGrid = false,
+      ShowLine = true,
+      LineColor = axisLineColor,
+      Ticks = StyleParam.TickOptions.Outside,
+      TickColor = axisLineColor,
+      ShowSpikes = true,
+      SpikeColor = scrubberColor,
+      SpikeThickness = 2,
+      SpikeDash = StyleParam.DrawingStyle.Solid,
+      SpikeMode = StyleParam.SpikeMode.Across,
+      SpikeSnap = StyleParam.SpikeSnap.Data
+    )
+
   let private yAxis () =
     let defaultYMin = 0
     let defaultYMax = 200
@@ -129,6 +151,28 @@ module BpChart =
     chart
     |> Chart.withLayout (layout ())
     |> Chart.withXAxis xAxis
+    |> Chart.withYAxis (yAxis ())
+    |> Chart.withConfig (Config.init (Responsive = true))
+    |> GenericChart.toChartHTML
+    |> _.Replace("\"width\":600,", "")
+    |> _.Replace("\"height\":600,", "")
+    |> fun html -> html + errorBarScript
+
+  // Like `finish`, but with the scrubber-bar x-axis and unified hover (HoverMode.X finds
+  // the nearest point across all traces at the hovered x, not just the one under the
+  // cursor) — used only by /recent, which has a value strip to link the spike to.
+  let private finishRecentLayout () =
+    Layout.init (
+      PaperBGColor = transparent,
+      PlotBGColor = transparent,
+      Margin = compactMargin,
+      HoverMode = StyleParam.HoverMode.X
+    )
+
+  let private finishRecent (chart: GenericChart) =
+    chart
+    |> Chart.withLayout (finishRecentLayout ())
+    |> Chart.withXAxis recentXAxis
     |> Chart.withYAxis (yAxis ())
     |> Chart.withConfig (Config.init (Responsive = true))
     |> GenericChart.toChartHTML
@@ -481,6 +525,6 @@ module BpChart =
       X = 0.5,
       XAnchor = StyleParam.XAnchorPosition.Center
     )
-    |> finish
+    |> finishRecent
 
   let toHtmlRecent (goal: GoalRange) (windowDays: int) = renderRecent goal windowDays

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -245,3 +245,30 @@ let ``recent value strip uses a table so each reading's sys/dias values align in
 
   test <@ strip.Contains "<table" @>
   test <@ cellValues = [ "130"; "142"; "118"; "82"; "91"; "76" ] @>
+
+[<Fact>]
+let ``recent value strip tags each cell with the reading's chart x-label, for the scrubber bar to match against`` () =
+  // Wegier et al. 2021, "Scrubber bar": the vertical line that tracks the cursor links
+  // the chart and the data table together. The chart's hover payload reports the
+  // hovered point's x as Formats.formatLocal r.Timestamp (see Charts.fs `seriesOf`), so
+  // each value-strip cell needs the same string in a data-x attribute to be matchable.
+  let r1 =
+    { reading 3 1 with
+        Systolic = 130
+        Diastolic = 82 }
+
+  let r2 =
+    { reading 2 2 with
+        Systolic = 142
+        Diastolic = 91 }
+
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith [ r1; r2 ]) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  let expectedX1 = Formats.formatLocal r1.Timestamp
+  let expectedX2 = Formats.formatLocal r2.Timestamp
+
+  test <@ body.Contains $"data-x=\"{expectedX1}\"" @>
+  test <@ body.Contains $"data-x=\"{expectedX2}\"" @>

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -51,15 +51,45 @@ module ReadingViews =
       // The strip lists the same readings as the chart below it (days30).
       let chronological = days30 |> List.sortBy _.Timestamp
 
+      // Each cell is tagged with the same x-label the chart uses for this reading
+      // (Charts.fs `seriesOf` formats x as Formats.formatLocal r.Timestamp), so the
+      // scrubber script below can match a hovered chart point back to its strip column.
       let row (label: string) (value: BloodPressureReading -> int) =
         Elem.tr
           []
           [ yield Elem.th [ Attr.scope "row"; Attr.class' "value-strip-label" ] [ Text.raw label ]
-            for r in chronological -> Elem.td [ Attr.class' "value-strip-value" ] [ Text.raw (string (value r)) ] ]
+            for r in chronological ->
+              Elem.td
+                [ Attr.class' "value-strip-value"
+                  Attr.create "data-x" (Formats.formatLocal r.Timestamp) ]
+                [ Text.raw (string (value r)) ] ]
 
       Elem.div
         [ Attr.class' "value-strip" ]
         [ Elem.table [] [ Elem.tbody [] [ row "Systolic" _.Systolic; row "Diastolic" _.Diastolic ] ] ]
+
+    // Fig. 5's scrubber bar (Wegier et al. 2021): the chart's x-axis spike (Charts.fs
+    // `recentXAxis`) already draws the moving vertical line; this links it to the value
+    // strip by boxing the hovered column. Follows the same poll-until-ready pattern as
+    // the chart's own errorBarScript (Charts.fs `errorBarScript`).
+    let scrubberScript =
+      Text.raw (
+        "<script>(function(){"
+        + "function setup(){"
+        + "var d=document.querySelector('.js-plotly-plot');"
+        + "if(!d||!d.on){setTimeout(setup,50);return;}"
+        + "d.on('plotly_hover',function(e){"
+        + "var x=e.points[0].x;"
+        + "document.querySelectorAll('.value-strip td.scrubbed').forEach(function(c){c.classList.remove('scrubbed');});"
+        + "document.querySelectorAll('.value-strip td[data-x=\"'+x+'\"]').forEach(function(c){c.classList.add('scrubbed');});"
+        + "});"
+        + "d.on('plotly_unhover',function(){"
+        + "document.querySelectorAll('.value-strip td.scrubbed').forEach(function(c){c.classList.remove('scrubbed');});"
+        + "});"
+        + "}"
+        + "setTimeout(setup,0);"
+        + "})()</script>"
+      )
 
     ViewLayout.layout
       Routes.recent
@@ -77,7 +107,9 @@ module ReadingViews =
           [ Elem.summary [ Attr.class' "chart-toggle" ] [ Text.raw "Blood Pressure Graph" ]
             Elem.div
               [ Attr.class' "chart-container" ]
-              [ valueStrip; Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ] ]
+              [ valueStrip
+                Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ]
+                scrubberScript ] ]
         section "Last 7 days" "days-7" days7
         section "Last 14 days" "days-14" days14
         section "Last 30 days" "days-30" days30 ]

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -552,6 +552,16 @@ form.inline button {
   color: var(--pico-muted-color);
 }
 
+/* Scrubber bar (Wegier et al. 2021, "Scrubber bar"): boxes the value-strip column under
+   the chart's hovered point, echoing Fig. 5's highlighted column. Toggled by the inline
+   script in ReadingViews.recent's `scrubberScript`, matched against the chart's x-axis
+   spike (Charts.fs `recentXAxis`) via each cell's `data-x` attribute. */
+.value-strip td.scrubbed {
+  outline: 2px solid #00c853;
+  outline-offset: -1px;
+  font-weight: bold;
+}
+
 /* ── Trends page ────────────────────────────────────────────────────────── */
 
 /* Granularity selector row (Weekly / Monthly / Yearly) */


### PR DESCRIPTION
## Summary
- Recent chart's x-axis now shows a vertical spikeline that snaps to the nearest reading as the cursor moves, completing the Fig. 5 (Wegier et al. 2021) elements already started by the trend line (#270) and value strip (#272)
- The hovered reading's column in the value strip above the chart gets boxed in the same green, linking chart and data table the way the paper's scrubber bar links its display elements
- Scoped to `/recent` only — `/history` and `/trends` are unaffected