### PR TITLE
🔧 chore: remove window-selector buttons and per-window tables from recent page

### DIFF
--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -29,61 +29,12 @@ let private reading daysAgo (id: int) : BloodPressureReading =
     ModifiedAt = now }
 
 [<Fact>]
-let ``recent returns 200 with three window headings`` () =
+let ``recent returns 200`` () =
   let tp = FakeTimeProvider(now)
   let ctx = TestHost.contextWithProvider (repoWith []) tp
   TestHost.run ReadingHandlers.recent ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
-  let body = TestHost.readBody ctx
-
-  test
-    <@
-      body.Contains "Last 7 days"
-      && body.Contains "Last 14 days"
-      && body.Contains "Last 30 days"
-    @>
-
-[<Fact>]
-let ``recent renders pill links for each window`` () =
-  let tp = FakeTimeProvider(now)
-  let ctx = TestHost.contextWithProvider (repoWith []) tp
-  TestHost.run ReadingHandlers.recent ctx
-
-  let body = TestHost.readBody ctx
-
-  test
-    <@
-      body.Contains "href=\"#days-7\""
-      && body.Contains "href=\"#days-14\""
-      && body.Contains "href=\"#days-30\""
-    @>
-
-[<Fact>]
-let ``recent sections have anchor ids`` () =
-  let tp = FakeTimeProvider(now)
-  let ctx = TestHost.contextWithProvider (repoWith []) tp
-  TestHost.run ReadingHandlers.recent ctx
-
-  let body = TestHost.readBody ctx
-
-  test
-    <@
-      body.Contains "id=\"days-7\""
-      && body.Contains "id=\"days-14\""
-      && body.Contains "id=\"days-30\""
-    @>
-
-[<Fact>]
-let ``recent shows simpson readings in all three windows`` () =
-  let tp = FakeTimeProvider(now)
-  let ctx = TestHost.contextWithProvider (repoWith simpsonReadings) tp
-  TestHost.run ReadingHandlers.recent ctx
-
-  test <@ ctx.Response.StatusCode = 200 @>
-  let body = TestHost.readBody ctx
-  // Marge has ~3.5 readings/week — all three windows will have edit links.
-  test <@ body.Contains "/readings/" @>
 
 [<Fact>]
 let ``recent omits a reading older than 30 days`` () =
@@ -93,19 +44,7 @@ let ``recent omits a reading older than 30 days`` () =
   TestHost.run ReadingHandlers.recent ctx
 
   let body = TestHost.readBody ctx
-  test <@ body.Contains "Last 30 days" && not (body.Contains "/readings/1/edit") @>
-
-[<Fact>]
-let ``recent does not show a reading from 10 days ago in the 7-day window`` () =
-  let tp = FakeTimeProvider(now)
-  let r = reading 10 42
-  let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
-  TestHost.run ReadingHandlers.recent ctx
-
-  // 10-day reading falls in 14d and 30d windows but not 7d.
-  let body = TestHost.readBody ctx
-  let occurrences = body.Split("/readings/42/edit").Length - 1
-  test <@ occurrences = 2 @>
+  test <@ not (body.Contains "/readings/1/edit") @>
 
 [<Fact>]
 let ``recent renders a chart`` () =

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -83,14 +83,13 @@ module ReadingHandlers =
       let now = (timeProvider ctx).GetUtcNow()
       let allReadings = (repo ctx).GetAll(m.Id)
 
-      let window days =
+      let days30 =
         allReadings
-        |> ReadingStats.between (now.AddDays(-float days)) now
+        |> ReadingStats.between (now.AddDays(-float recentChartWindowDays)) now
         |> List.sortByDescending _.Timestamp
 
-      let days30 = window recentChartWindowDays
       let chartHtml = BpChart.toHtmlRecent m.Goal recentChartWindowDays days30
-      htmlResponse (ReadingViews.recent m chartHtml (window 7) (window 14) days30) ctx)
+      htmlResponse (ReadingViews.recent m chartHtml days30) ctx)
 
   let trends: HttpContext -> Task =
     withMember (fun m ctx ->

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -33,20 +33,8 @@ module ReadingViews =
             Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ]
         ViewLayout.readingsTable readings ]
 
-  /// Recent: chart of the last 30 days plus three rolling window tables (7/14/30 days).
-  let recent
-    (activeMember: FamilyMember)
-    (chartHtml: string)
-    (days7: BloodPressureReading list)
-    (days14: BloodPressureReading list)
-    (days30: BloodPressureReading list)
-    : XmlNode =
-    let pill (label: string) (anchor: string) =
-      Elem.a [ Attr.href $"#{anchor}"; Attr.role "button"; Attr.class' "outline" ] [ Text.raw label ]
-
-    let section (heading: string) (anchor: string) (readings: BloodPressureReading list) =
-      Elem.section [ Attr.id anchor ] [ Elem.h2 [] [ Text.raw heading ]; ViewLayout.readingsTable readings ]
-
+  /// Recent: chart of the last 30 days with a sys/dias value strip.
+  let recent (activeMember: FamilyMember) (chartHtml: string) (days30: BloodPressureReading list) : XmlNode =
     let valueStrip =
       // The strip lists the same readings as the chart below it (days30).
       let chronological = days30 |> List.sortBy _.Timestamp
@@ -97,11 +85,6 @@ module ReadingViews =
       activeMember.IsAdmin
       "Recent"
       [ Elem.h1 [] [ Text.raw "Recent" ]
-        Elem.div
-          [ Attr.class' "recent-window-buttons" ]
-          [ pill "Last 7 days" "days-7"
-            pill "Last 14 days" "days-14"
-            pill "Last 30 days" "days-30" ]
         Elem.details
           [ Attr.create "open" "" ]
           [ Elem.summary [ Attr.class' "chart-toggle" ] [ Text.raw "Blood Pressure Graph" ]
@@ -109,10 +92,7 @@ module ReadingViews =
               [ Attr.class' "chart-container" ]
               [ valueStrip
                 Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ]
-                scrubberScript ] ]
-        section "Last 7 days" "days-7" days7
-        section "Last 14 days" "days-14" days14
-        section "Last 30 days" "days-30" days30 ]
+                scrubberScript ] ] ]
 
   /// Shared add/edit form. `action` is the POST target; `errors` are rendered
   /// above the fields when re-displaying after a failed submit.

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -279,8 +279,7 @@ g.errorbars path.yerror {
   }
 
   /* Slightly taller tap targets for the window-selector buttons */
-  .trends-window-buttons a,
-  .recent-window-buttons a {
+  .trends-window-buttons a {
     min-height: 2.75rem;
     display: inline-flex;
     align-items: center;
@@ -565,16 +564,14 @@ form.inline button {
 /* ── Trends page ────────────────────────────────────────────────────────── */
 
 /* Granularity selector row (Weekly / Monthly / Yearly) */
-.trends-window-buttons,
-.recent-window-buttons {
+.trends-window-buttons {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
   margin-bottom: 0.75rem;
 }
 
-.trends-window-buttons a[role="button"],
-.recent-window-buttons a[role="button"] {
+.trends-window-buttons a[role="button"] {
   padding: 0.25rem 0.9rem;
   font-size: 0.9rem;
   margin: 0;


### PR DESCRIPTION
## Summary
- Removed the Last 7/14/30 days pill buttons and their corresponding rolling-window tables from the Recent page, leaving just the chart and value strip.
- Simplified `ReadingViews.recent` and `ReadingHandlers.recent` to drop the now-unused per-window data.
- Removed the now-dead `.recent-window-buttons` CSS rules (kept the shared `.trends-window-buttons` rules used by the Trends page).