### PR TITLE
✨ feat: color-code the recent value strip by goal range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recent page now shows a Fig. 5-style "value strip" directly above the chart, listing every Systolic/Diastolic value in the chart's 30-day window in chronological order, sized to match the chart's width with no horizontal scrolling
 - Demo dataset gains a sixth member, Ned Flanders, whose readings tell a Fig. 5-style story (elevated readings, a week-long gap, then improved control after starting medication) to showcase the new trend line and missing-data dashing
 - Recent chart now has a Fig. 5-style scrubber bar: hovering shows a vertical line that snaps to the nearest reading and boxes the matching column in the value strip above the chart, linking the two together
+- Recent page's value strip now color-codes each value against the member's goal range, matching Fig. 5: above the goal max renders orange, below the goal min renders blue, in-range values stay neutral
 
 ### Changed
 

--- a/code/BpMonitor.Core.Tests/GoalRangeTests.fs
+++ b/code/BpMonitor.Core.Tests/GoalRangeTests.fs
@@ -39,3 +39,39 @@ let ``create rejects diastolic min equal to max`` () =
 [<Fact>]
 let ``create rejects diastolic min greater than max`` () =
   test <@ GoalRange.create 100 130 90 65 = Error DiastolicRangeInvalid @>
+
+[<Fact>]
+let ``classifySystolic reports Above when the value exceeds the goal max`` () =
+  test <@ GoalRange.classifySystolic GoalRange.defaults 141 = Above @>
+
+[<Fact>]
+let ``classifySystolic reports Below when the value is under the goal min`` () =
+  test <@ GoalRange.classifySystolic GoalRange.defaults 89 = Below @>
+
+[<Fact>]
+let ``classifySystolic reports InRange for a value strictly inside the goal range`` () =
+  test <@ GoalRange.classifySystolic GoalRange.defaults 120 = InRange @>
+
+[<Fact>]
+let ``classifySystolic treats the goal min and max boundaries as InRange`` () =
+  test
+    <@
+      GoalRange.classifySystolic GoalRange.defaults GoalRange.defaults.SystolicMin = InRange
+      && GoalRange.classifySystolic GoalRange.defaults GoalRange.defaults.SystolicMax = InRange
+    @>
+
+[<Fact>]
+let ``classifyDiastolic reports Above when the value exceeds the goal max`` () =
+  test <@ GoalRange.classifyDiastolic GoalRange.defaults 91 = Above @>
+
+[<Fact>]
+let ``classifyDiastolic reports Below when the value is under the goal min`` () =
+  test <@ GoalRange.classifyDiastolic GoalRange.defaults 59 = Below @>
+
+[<Fact>]
+let ``classifyDiastolic treats the goal min and max boundaries as InRange`` () =
+  test
+    <@
+      GoalRange.classifyDiastolic GoalRange.defaults GoalRange.defaults.DiastolicMin = InRange
+      && GoalRange.classifyDiastolic GoalRange.defaults GoalRange.defaults.DiastolicMax = InRange
+    @>

--- a/code/BpMonitor.Core/GoalRange.fs
+++ b/code/BpMonitor.Core/GoalRange.fs
@@ -10,6 +10,14 @@ type GoalRangeError =
   | SystolicRangeInvalid
   | DiastolicRangeInvalid
 
+/// Where a reading falls relative to the goal range, for the Fig. 5-style
+/// (Wegier et al. 2021) value-strip color-coding: out-of-range readings are
+/// highlighted, in-range readings are left neutral.
+type RangePosition =
+  | Below
+  | InRange
+  | Above
+
 module GoalRange =
   let defaults =
     { SystolicMin = 90
@@ -28,3 +36,13 @@ module GoalRange =
           SystolicMax = sysMax
           DiastolicMin = diaMin
           DiastolicMax = diaMax }
+
+  let classifySystolic (goal: GoalRange) (value: int) : RangePosition =
+    if value > goal.SystolicMax then Above
+    elif value < goal.SystolicMin then Below
+    else InRange
+
+  let classifyDiastolic (goal: GoalRange) (value: int) : RangePosition =
+    if value > goal.DiastolicMax then Above
+    elif value < goal.DiastolicMin then Below
+    else InRange

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -211,3 +211,37 @@ let ``recent value strip tags each cell with the reading's chart x-label, for th
 
   test <@ body.Contains $"data-x=\"{expectedX1}\"" @>
   test <@ body.Contains $"data-x=\"{expectedX2}\"" @>
+
+[<Fact>]
+let ``recent value strip marks a reading above the goal range as 'above'`` () =
+  // Default goal range (GoalRange.defaults): systolic max 140. 142 > 140.
+  let r = { reading 1 1 with Systolic = 142 }
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "value-strip-value above" @>
+
+[<Fact>]
+let ``recent value strip marks a reading below the goal range as 'below'`` () =
+  // Default goal range (GoalRange.defaults): diastolic min 60. 59 < 60.
+  let r = { reading 1 1 with Diastolic = 59 }
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "value-strip-value below" @>
+
+[<Fact>]
+let ``recent value strip leaves an in-range reading's cells unmarked`` () =
+  // reading helper's defaults (Systolic = 120, Diastolic = 80) are inside GoalRange.defaults.
+  let r = reading 1 1
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ not (body.Contains "value-strip-value above") @>
+  test <@ not (body.Contains "value-strip-value below") @>

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -42,19 +42,36 @@ module ReadingViews =
       // Each cell is tagged with the same x-label the chart uses for this reading
       // (Charts.fs `seriesOf` formats x as Formats.formatLocal r.Timestamp), so the
       // scrubber script below can match a hovered chart point back to its strip column.
-      let row (label: string) (value: BloodPressureReading -> int) =
+      //
+      // Fig. 5's data table color-codes each value by where it falls relative to the
+      // member's goal range (Wegier et al. 2021): out-of-range values are highlighted,
+      // in-range values stay neutral. See app.css `.value-strip-value.above/.below`.
+      let cellClass (position: RangePosition) =
+        match position with
+        | Above -> "value-strip-value above"
+        | Below -> "value-strip-value below"
+        | InRange -> "value-strip-value"
+
+      let row (label: string) (value: BloodPressureReading -> int) (classify: int -> RangePosition) =
         Elem.tr
           []
           [ yield Elem.th [ Attr.scope "row"; Attr.class' "value-strip-label" ] [ Text.raw label ]
             for r in chronological ->
+              let v = value r
+
               Elem.td
-                [ Attr.class' "value-strip-value"
+                [ Attr.class' (cellClass (classify v))
                   Attr.create "data-x" (Formats.formatLocal r.Timestamp) ]
-                [ Text.raw (string (value r)) ] ]
+                [ Text.raw (string v) ] ]
 
       Elem.div
         [ Attr.class' "value-strip" ]
-        [ Elem.table [] [ Elem.tbody [] [ row "Systolic" _.Systolic; row "Diastolic" _.Diastolic ] ] ]
+        [ Elem.table
+            []
+            [ Elem.tbody
+                []
+                [ row "Systolic" _.Systolic (GoalRange.classifySystolic activeMember.Goal)
+                  row "Diastolic" _.Diastolic (GoalRange.classifyDiastolic activeMember.Goal) ] ] ]
 
     // Fig. 5's scrubber bar (Wegier et al. 2021): the chart's x-axis spike (Charts.fs
     // `recentXAxis`) already draws the moving vertical line; this links it to the value

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -551,6 +551,17 @@ form.inline button {
   color: var(--pico-muted-color);
 }
 
+/* Fig. 5's data table color-codes each value by where it falls relative to the
+   member's goal range (GoalRange.classifySystolic/classifyDiastolic): out-of-range
+   values are highlighted, in-range values stay the default text color. */
+.value-strip td.value-strip-value.above {
+  color: #ff9800;
+}
+
+.value-strip td.value-strip-value.below {
+  color: #2a49f9;
+}
+
 /* Scrubber bar (Wegier et al. 2021, "Scrubber bar"): boxes the value-strip column under
    the chart's hovered point, echoing Fig. 5's highlighted column. Toggled by the inline
    script in ReadingViews.recent's `scrubberScript`, matched against the chart's x-axis

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,7 +154,7 @@ graph TD
 - **Isolation:** each member sees only their own readings; admins manage members via `/members` but not their readings
 - **Routes:** `/` hub, `/add`, `/history`, `/recent`, `/trends`, `/settings`, `/members`, `/members/{id}/edit`, `/members/{id}/reset-password`, `/login`, `/login/{id}`, `POST /logout`
 - **`/settings`:** self-service page where the logged-in member edits their own chart goal range (`GoalRange`); validated via `GoalRange.create` (min < max per pair)
-- **`/recent`:** three rolling windows (last 7 / 14 / 30 days) of raw readings plus a 30-day chart — no aggregation. Above the chart, a Fig. 5-style (Wegier et al. 2021) "value strip" table lists every Systolic/Diastolic value in the chart's 30-day window in chronological order, sized to match the chart's rendered width with no horizontal scrolling
+- **`/recent`:** three rolling windows (last 7 / 14 / 30 days) of raw readings plus a 30-day chart — no aggregation. Above the chart, a Fig. 5-style (Wegier et al. 2021) "value strip" table lists every Systolic/Diastolic value in the chart's 30-day window in chronological order, sized to match the chart's rendered width with no horizontal scrolling. Each value is color-coded against the member's `GoalRange` (`GoalRange.classifySystolic`/`classifyDiastolic`): above the goal max renders orange, below the goal min renders blue, in-range stays neutral
 - **`/trends`:** granularity selector (Weekly/Monthly/Yearly) + htmx-swapped period fragments; stats from `ReadingStats` (Core); `TimeProvider` injected for testability
 - `protect` / `protectAdmin` combinators; active member resolved from `ClaimsPrincipal`
 - Server-rendered HTML via `Falco.Markup`; htmx for partial updates; scoped `DbContext` per request


### PR DESCRIPTION
## Summary
- Color-codes each value in the `/recent` page's Fig. 5-style value strip against the member's goal range (Wegier et al. 2021): above the goal max renders orange (`#FF9800`), below the goal min renders blue (`#2A49F9`), in-range values stay neutral.
- New `RangePosition` + `GoalRange.classifySystolic`/`classifyDiastolic` in Core, built test-first.