### PR TITLE
🐛 fix: remove nonexistent Pico CSS variable reference

### DIFF
--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -498,7 +498,7 @@ form.inline button {
 }
 
 .badge-claimed {
-  background: var(--pico-color-green-550, #16a34a);
+  background: #16a34a;
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary

- Use literal color value (`#16a34a`) instead of referencing `--pico-color-green-550`
- The minified `pico.min.css` bundle doesn't include color-scale custom properties, causing Rider IDE to flag it as an unresolved variable
- Functionally no change — the fallback value was already `#16a34a`, now we use it directly