### PR TITLE
🐛 fix: skip hover tooltip on the /recent LOWESS trend trace

### DIFF
--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -261,6 +261,16 @@ let ``toHtmlRecent renders a smoothed trend line for systolic and diastolic`` ()
   test <@ html.Contains("\"name\":\"Diastolic (trend)\"") @>
 
 [<Fact>]
+let ``toHtmlRecent skips hover for the LOWESS trend trace, since its value is smoothed not measured`` () =
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+
+  let hasHoverSkip (exactName: string) =
+    Regex.IsMatch(html, $"\"name\":\"{Regex.Escape(exactName)}\".*?\"hoverinfo\":\"skip\"")
+
+  test <@ hasHoverSkip "Systolic (trend)" @>
+  test <@ hasHoverSkip "Diastolic (trend)" @>
+
+[<Fact>]
 let ``toHtmlRecent omits the trend line when there are too few readings to smooth meaningfully`` () =
   let sparse = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 2 9 None ]
   let html = BpChart.toHtmlRecent GoalRange.defaults 10 sparse

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -506,7 +506,10 @@ module BpChart =
       let smoothed = Lowess.smooth lowessBandwidth xs (values |> List.map float)
 
       [ Chart.Line(x = labels, y = smoothed, Name = name, ShowLegend = true)
-        |> Chart.withLineStyle (Color = color, Width = 3.5) ]
+        |> Chart.withLineStyle (Color = color, Width = 3.5)
+        // The smoothed value is derived, not measured — skip its hover entry in the
+        // /recent chart's unified hover so the tooltip only ever shows real readings.
+        |> GenericChart.mapTrace (Trace2DStyle.Scatter(HoverInfo = StyleParam.HoverInfo.Skip)) ]
 
   let private renderRecent (goal: GoalRange) (windowDays: int) (readings: BloodPressureReading list) : string =
     let readings, timestamps, systolic, diastolic = seriesOf readings


### PR DESCRIPTION
## Summary
- The `/recent` chart's LOWESS trend line is a derived/smoothed value, not a real reading, so showing it in the unified hover tooltip alongside actual systolic/diastolic readings was misleading.
- Sets `hoverinfo: "skip"` on the trend trace so it's excluded from the unified hover box; the raw measurement traces keep their hover unchanged.