### PR TITLE
🐛 fix: guard zero-weight LOWESS neighbourhood to avoid NaN trend gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,13 +123,14 @@ dotnet test --configuration Release --max-parallel-test-modules 2
 
 `BpMonitor.Arch.Tests` uses `DoNotResideInNamespaceMatching("Microsoft\\.CodeCoverage.*")` in its type filters to exclude coverage-injected tracker types from ArchUnitNET dependency checks.
 
-`BpMonitor.Web.E2E.Tests` boots a real `BpMonitor.Web` instance out-of-process (`dotnet run`, fresh temp SQLite file, demo seeding off) on a free port, then drives it with a real Playwright Chromium browser. First run needs Chromium installed locally — `playwright.ps1 install chromium` from the build output dir if `pwsh` is available, otherwise via `dotnet fsi` calling `Microsoft.Playwright.Program.Main([| "install"; "chromium" |])`.
+`BpMonitor.Web.E2E.Tests` boots a real `BpMonitor.Web` instance out-of-process (`dotnet run`, fresh temp SQLite file, demo seeding off) on a free port, then drives it with a real Playwright Chromium browser. First run needs Chromium installed locally — run `mise run test:e2e-setup` (builds the test project, then installs Chromium via `playwright.ps1` if `pwsh` is available, otherwise via `dotnet fsi` calling `Microsoft.Playwright.Program.Main([| "install"; "chromium" |])`).
 
 ## Dev Tooling
 
-All non-dotnet linter versions are pinned in `mise.toml` (repo root). Run `mise install` once after cloning.
+All non-dotnet linter versions are pinned in `mise.toml` (repo root); it also hosts one-time dev setup tasks like the Playwright Chromium install. Run `mise install` once after cloning.
 
 - `biome.json` — Biome JS linter config (scoped to `wwwroot/theme.js` and `wwwroot/theme-label.js`)
 - `.markdownlint-cli2.yaml` — markdownlint config
 - Run `mise run lint` to run all non-dotnet linters; `mise run lint:js` / `lint:md` / `lint:shell` individually
+- Run `mise run test:e2e-setup` once locally before the first `BpMonitor.Web.E2E.Tests` run (installs Playwright's Chromium)
 - Run `mise exec -- biome check --write` to auto-fix JS issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Recent chart's LOWESS trend line no longer breaks into gaps when readings cluster on the same day — a zero-weight local fit was dividing by zero and producing NaN
+
 ## [1.7.0-rc1] - 2026-06-23
 
 ### Added

--- a/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
+++ b/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="PasswordHashingTests.fs" />
     <Compile Include="DemoDataTests.fs" />
     <Compile Include="LowessTests.fs" />
+    <Compile Include="LowessPropertyTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/BpMonitor.Core.Tests/LowessPropertyTests.fs
+++ b/code/BpMonitor.Core.Tests/LowessPropertyTests.fs
@@ -1,0 +1,38 @@
+module LowessPropertyTests
+
+open FsCheck
+open FsCheck.FSharp
+open FsCheck.Xunit
+open BpMonitor.Core
+
+/// x/y series biased toward the conditions that can make a local LOWESS fit singular:
+/// x's drawn from a small discrete set make duplicate x-values (e.g. same-day readings on
+/// the real /recent chart) likely, and a few outlier y's are large enough to get
+/// bisquare-zeroed during the robustifying iterations — together the combination that
+/// drove `weightedLinearFitAt`'s 0.0/0.0 division.
+let private clusteredSeriesGen: Gen<float list * float list> =
+  gen {
+    let! n = Gen.choose (3, 25)
+    let! xs = Gen.choose (0, 10) |> Gen.map float |> Gen.listOfLength n
+
+    let! ys =
+      Gen.frequency
+        [ 8, Gen.choose (60, 180) |> Gen.map float // plausible BP-like values
+          1, Gen.choose (-500, -200) |> Gen.map float // low outlier
+          1, Gen.choose (500, 1000) |> Gen.map float ] // high outlier
+      |> Gen.listOfLength n
+
+    return xs, ys
+  }
+
+[<Property>]
+let ``smooth never returns NaN or Infinity for any finite series and bandwidth`` () =
+  let arb =
+    Arb.fromGen (Gen.zip clusteredSeriesGen (Gen.choose (1, 100) |> Gen.map (fun p -> float p / 100.0)))
+
+  Prop.forAll arb (fun ((xs, ys), bandwidth) ->
+    let result = Lowess.smooth bandwidth xs ys
+
+    List.length result = List.length ys
+    && result
+       |> List.forall (fun y -> not (System.Double.IsNaN y || System.Double.IsInfinity y)))

--- a/code/BpMonitor.Core.Tests/LowessTests.fs
+++ b/code/BpMonitor.Core.Tests/LowessTests.fs
@@ -74,3 +74,21 @@ let ``smooth downweights a single extreme outlier instead of being pulled toward
 
   test <@ abs (smoothedValue - trueValue) < abs (smoothedValue - outlierValue) @>
   test <@ abs (smoothedValue - trueValue) < 10.0 @>
+
+[<Fact>]
+let ``smooth never returns NaN, even when a cluster of duplicate x-values contains an outlier`` () =
+  // Duplicate x-values arise in practice from same-day readings (the chart's x-axis is
+  // calendar days). A tight cluster of duplicates containing one outlier can, across the
+  // robustifying iterations, drive every weight in a point's neighbourhood to zero —
+  // leaving weightedLinearFitAt dividing 0.0/0.0. Reproduces the /recent chart's NaN-induced
+  // trend-line gaps reported against real reading data clustered around same-day duplicates.
+  let xs = [ 0.0; 1.0; 2.0; 3.0; 3.0; 3.0; 4.0; 4.0 ]
+  let ys = [ 10.0; 12.0; 9.0; 50.0; 8.0; 9.0; 10.0; 11.0 ]
+
+  let result = Lowess.smooth 0.3 xs ys
+
+  test
+    <@
+      result
+      |> List.forall (fun y -> not (System.Double.IsNaN y || System.Double.IsInfinity y))
+    @>

--- a/code/BpMonitor.Core/Lowess.fs
+++ b/code/BpMonitor.Core/Lowess.fs
@@ -31,17 +31,26 @@ module Lowess =
   // One weighted linear regression y = a + b*x over `points` (weight, x, y), evaluated at `xi`.
   let private weightedLinearFitAt (xi: float) (points: (float * float * float) array) =
     let sumW = points |> Array.sumBy (fun (w, _, _) -> w)
-    let meanX = (points |> Array.sumBy (fun (w, x, _) -> w * x)) / sumW
-    let meanY = (points |> Array.sumBy (fun (w, _, y) -> w * y)) / sumW
-    let sxx = points |> Array.sumBy (fun (w, x, _) -> w * (x - meanX) * (x - meanX))
-    let sxy = points |> Array.sumBy (fun (w, x, y) -> w * (x - meanX) * (y - meanY))
 
-    if sxx = 0.0 then
-      meanY
+    // A whole neighbourhood can end up with zero total weight — e.g. a tight cluster of
+    // duplicate x-values (same-day readings) where the robustifying iterations bisquare-zero
+    // every remaining weight. There's no weighted information left at that point, so fall
+    // back to the plain (unweighted) mean of the neighbourhood's y-values instead of
+    // dividing 0.0/0.0 into NaN.
+    if sumW = 0.0 then
+      points |> Array.averageBy (fun (_, _, y) -> y)
     else
-      let b = sxy / sxx
-      let a = meanY - b * meanX
-      a + b * xi
+      let meanX = (points |> Array.sumBy (fun (w, x, _) -> w * x)) / sumW
+      let meanY = (points |> Array.sumBy (fun (w, _, y) -> w * y)) / sumW
+      let sxx = points |> Array.sumBy (fun (w, x, _) -> w * (x - meanX) * (x - meanX))
+      let sxy = points |> Array.sumBy (fun (w, x, y) -> w * (x - meanX) * (y - meanY))
+
+      if sxx = 0.0 then
+        meanY
+      else
+        let b = sxy / sxx
+        let a = meanY - b * meanX
+        a + b * xi
 
   /// Smooths `ys` against `xs` using Cleveland's LOWESS: a tricube-weighted local linear
   /// regression refined by robustifying iterations that downweight outlier residuals.

--- a/mise.toml
+++ b/mise.toml
@@ -16,3 +16,24 @@ run = 'find . -name "*.sh" -not -path "./.husky/_/*" | xargs -r shellcheck'
 
 [tasks.lint]
 depends = ["lint:md", "lint:js", "lint:shell"]
+
+[tasks."test:e2e-setup"]
+description = "One-time local setup: installs the Playwright Chromium browser used by BpMonitor.Web.E2E.Tests"
+dir = "code"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+dotnet build BpMonitor.Web.E2E.Tests --configuration Release
+output_dir="$(pwd)/BpMonitor.Web.E2E.Tests/bin/Release/net10.0"
+if command -v pwsh >/dev/null 2>&1; then
+  pwsh "$output_dir/playwright.ps1" install chromium
+else
+  tmp_fsx=$(mktemp --suffix=.fsx)
+  cat > "$tmp_fsx" <<EOF
+#r "$output_dir/Microsoft.Playwright.dll"
+Microsoft.Playwright.Program.Main([| "install"; "chromium" |]) |> ignore
+EOF
+  dotnet fsi "$tmp_fsx"
+  rm -f "$tmp_fsx"
+fi
+'''


### PR DESCRIPTION
## Summary

- The `/recent` chart's LOWESS trend line could show gaps when readings cluster on the same calendar day: the robustifying iterations could zero out every weight in a point's local neighbourhood, leaving `weightedLinearFitAt` divide `0.0/0.0` into `NaN`, which breaks the Plotly line trace at that point.
- Adds a `sumW = 0.0` guard (falling back to the unweighted mean), mirroring the existing `sxx = 0.0` guard.
- Adds a deterministic regression test reproducing the NaN with a minimal clustered dataset, plus an FsCheck property asserting `smooth` never returns NaN/Infinity for any finite series and bandwidth.
- Adds a `mise run test:e2e-setup` task to install Playwright's Chromium locally, replacing the manual one-off instructions in AGENTS.md.