### PR TITLE
✨ feat: add icon buttons for trends, recent, settings, exports and members to landing page

### DIFF
--- a/code/BpMonitor.Web.Tests/ViewTests.fs
+++ b/code/BpMonitor.Web.Tests/ViewTests.fs
@@ -37,6 +37,49 @@ let ``landing renders links to add and history`` () =
   // the Home nav link is marked active on the landing page
   test <@ html.Contains "href=\"/\" aria-current=\"page\"" @>
 
+/// Counts non-overlapping occurrences of `needle` in `haystack`. Used below because these
+/// routes already appear once in the sidebar nav — the landing action buttons must add a
+/// second occurrence, not merely reuse the sidebar's.
+let private occurrences (needle: string) (haystack: string) : int =
+  let rec count (start: int) (acc: int) =
+    let idx = haystack.IndexOf(needle, start)
+
+    if idx < 0 then
+      acc
+    else
+      count (idx + needle.Length) (acc + 1)
+
+  count 0 0
+
+[<Fact>]
+let ``landing renders action buttons for trends, recent, settings and both exports`` () =
+  let html = renderHtml (ReadingViews.landing defaultMember)
+
+  test <@ occurrences "href=\"/trends\"" html = 2 @>
+  test <@ occurrences "href=\"/recent\"" html = 2 @>
+  test <@ occurrences "href=\"/settings\"" html = 2 @>
+  test <@ occurrences "href=\"/export\"" html = 2 @>
+  test <@ occurrences "href=\"/export.csv\"" html = 2 @>
+
+[<Fact>]
+let ``landing export action buttons do not get hx-boosted`` () =
+  let html = renderHtml (ReadingViews.landing defaultMember)
+  // the sidebar already carries hx-boost="false" on its two export links;
+  // the landing action buttons must add two more, not rely on the sidebar's.
+  test <@ occurrences "hx-boost=\"false\"" html = 4 @>
+
+[<Fact>]
+let ``admin sees a Members action button on landing`` () =
+  let admin = { defaultMember with IsAdmin = true }
+  let html = renderHtml (ReadingViews.landing admin)
+  test <@ occurrences "href=\"/members\"" html = 2 @>
+
+[<Fact>]
+let ``non-admin does not see a Members action button on landing`` () =
+  let nonAdmin = { defaultMember with IsAdmin = false }
+  let html = renderHtml (ReadingViews.landing nonAdmin)
+  test <@ occurrences "href=\"/members\"" html = 0 @>
+
 [<Fact>]
 let ``layout renders a topbar with menu button, title and theme toggle`` () =
   let html = renderHtml (ReadingViews.landing defaultMember)

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -5,6 +5,19 @@ open BpMonitor.Core
 
 /// Server-rendered HTML views for reading-related pages (landing, history, add/edit form).
 module ReadingViews =
+  /// A landing-page action button: an icon glyph followed by its label.
+  let private actionButton (href: string) (glyph: string) (label: string) : XmlNode =
+    Elem.a
+      [ Attr.href href; Attr.role "button" ]
+      [ Elem.span [ Attr.class' "icon" ] [ Text.raw glyph ]; Text.raw label ]
+
+  /// Same as `actionButton`, but opts the link out of hx-boost so file-download
+  /// responses (exports) aren't AJAX-swapped into the page.
+  let private downloadActionButton (href: string) (glyph: string) (label: string) : XmlNode =
+    Elem.a
+      [ Attr.href href; Attr.role "button"; Attr.create "hx-boost" "false" ]
+      [ Elem.span [ Attr.class' "icon" ] [ Text.raw glyph ]; Text.raw label ]
+
   /// Landing page: a simple hub linking to the app's main destinations.
   let landing (m: FamilyMember) : XmlNode =
     ViewLayout.layout
@@ -15,9 +28,16 @@ module ReadingViews =
       [ Elem.h1 [] [ Text.raw "BpMonitor" ]
         Elem.p [] [ Text.raw "Track and review your blood pressure readings." ]
         Elem.div
-          [ Attr.class' "actions" ]
-          [ Elem.a [ Attr.href "/add"; Attr.role "button" ] [ Text.raw "Add reading" ]
-            Elem.a [ Attr.href Routes.history; Attr.role "button" ] [ Text.raw "History" ] ] ]
+          [ Attr.class' "home-actions" ]
+          [ actionButton Routes.add "➕" "Add reading"
+            actionButton Routes.history "📜" "History"
+            actionButton Routes.trends "📈" "Trends"
+            actionButton Routes.recent "🕒" "Recent"
+            actionButton Routes.settings "⚙️" "Settings"
+            downloadActionButton Routes.exportJson "⬇️" "Export JSON"
+            downloadActionButton Routes.exportCsv "⬇️" "Export CSV"
+            if m.IsAdmin then
+              actionButton Routes.members "👥" "Members" ] ]
 
   /// History: chart above the readings table.
   let history (activeMember: FamilyMember) (chartHtml: string) (readings: BloodPressureReading list) : XmlNode =

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -161,6 +161,7 @@ li:has(.sidebar-collapse) {
   flex-direction: column;
   min-height: 100vh;
   padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 main {
@@ -449,6 +450,23 @@ td.col-center {
 
 .actions > * {
   margin-bottom: 0;
+}
+
+/* Landing page launch pad: a responsive grid of action buttons (distinct from
+   .actions, which is the form submit/cancel row shared by login/member/reading forms). */
+.home-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  gap: 1rem;
+}
+
+.home-actions a[role="button"] {
+  text-align: center;
+  margin-bottom: 0;
+}
+
+.home-actions .icon {
+  margin-right: 0.4rem;
 }
 
 footer.container {


### PR DESCRIPTION
## Summary
- Landing page now links to all eight app destinations (Add, History, Trends, Recent, Settings, Export JSON, Export CSV, Members) as icon-labeled buttons, not just Add/History
- Members button gated to admins, matching the sidebar's existing rule
- Export buttons opt out of hx-boost so downloads aren't AJAX-swapped
- Buttons laid out as a responsive grid (`.home-actions`) that doesn't crowd the right edge of the content area