### PR TITLE
✨ feat: remove Recent page's chart collapse and hide value strip on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Recent page's chart no longer sits behind a "Blood Pressure Graph" collapse toggle — it now renders directly under the page heading
+
 ## [1.7.0-rc2] - 2026-06-23
 
 ### Fixed

--- a/TODOs.md
+++ b/TODOs.md
@@ -6,11 +6,8 @@ Some science behind the visualization:
 [Home blood pressure data visualization for the management of hypertension: using human factors and design principles](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8340525/)
 (as reference, I included the paper in the docs folder: [pdf](./docs/resources/12911_2021_Article_1598.pdf))
 
-- [ ] Landing page, add all nav buttons
 - [ ] Recent: disable everything except pane, restore
 - [ ] Recent: paning, load all data, but focus on last 7/30 days
-- [ ] Recent: remove collapse
-- [ ] Recent: hide value-strip?
 
 ## Some ideas for the future
 

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -56,13 +56,13 @@ let ``recent renders a chart`` () =
   test <@ body.Contains "Plotly.newPlot" @>
 
 [<Fact>]
-let ``recent chart is open by default`` () =
+let ``recent renders the chart without a details wrapper`` () =
   let tp = FakeTimeProvider(now)
   let ctx = TestHost.contextWithProvider (repoWith []) tp
   TestHost.run ReadingHandlers.recent ctx
 
   let body = TestHost.readBody ctx
-  test <@ body.Contains "<details open" @>
+  test <@ not (body.Contains "<details") && body.Contains "class=\"chart-container\"" @>
 
 [<Fact>]
 let ``recent renders the chart with the authenticated member's goal range`` () =
@@ -100,13 +100,13 @@ let ``recent heading does not repeat the member's name (already shown in the nav
   test <@ body.Contains "<h1>Recent</h1>" @>
 
 [<Fact>]
-let ``recent chart toggle label matches the history page's`` () =
+let ``recent renders the chart without the collapse wrapper used on history`` () =
   let tp = FakeTimeProvider(now)
   let ctx = TestHost.contextWithProvider (repoWith []) tp
   TestHost.run ReadingHandlers.recent ctx
 
   let body = TestHost.readBody ctx
-  test <@ body.Contains "Blood Pressure Graph<" && not (body.Contains "(last 30 days)") @>
+  test <@ not (body.Contains "Blood Pressure Graph") && body.Contains "class=\"chart\"" @>
 
 [<Fact>]
 let ``recent shows a sys/dias value strip listing every reading in the chart window, oldest first`` () =

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -122,14 +122,11 @@ module ReadingViews =
       activeMember.IsAdmin
       "Recent"
       [ Elem.h1 [] [ Text.raw "Recent" ]
-        Elem.details
-          [ Attr.create "open" "" ]
-          [ Elem.summary [ Attr.class' "chart-toggle" ] [ Text.raw "Blood Pressure Graph" ]
-            Elem.div
-              [ Attr.class' "chart-container" ]
-              [ valueStrip
-                Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ]
-                scrubberScript ] ] ]
+        Elem.div
+          [ Attr.class' "chart-container" ]
+          [ valueStrip
+            Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ]
+            scrubberScript ] ]
 
   /// Shared add/edit form. `action` is the POST target; `errors` are rendered
   /// above the fields when re-displaying after a failed submit.

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -276,6 +276,11 @@ g.errorbars path.yerror {
     --chart-height: 380px;
   }
 
+  /* Value strip's fixed-layout columns get too cramped to read at this width. */
+  .value-strip {
+    display: none;
+  }
+
   /* Stats table: full width, tighter column padding */
   .trends-stats {
     width: 100%;
@@ -566,6 +571,7 @@ form.inline button {
   width: 100%;
   table-layout: fixed;
   border-collapse: collapse;
+  border: 1px solid var(--pico-muted-border-color);
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- Removes the "Blood Pressure Graph" details/summary collapse toggle on the Recent page so the chart renders directly under the heading
- Adds a gray border to the value strip table matching the chart's border color
- Hides the value strip on mobile (≤600px), where its fixed-layout columns get too cramped to read