### PR TITLE
✨ feat: keep Recent's value-strip in sync with the chart x-axis on zoom/pan

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -6,14 +6,8 @@ Some science behind the visualization:
 [Home blood pressure data visualization for the management of hypertension: using human factors and design principles](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8340525/)
 (as reference, I included the paper in the docs folder: [pdf](./docs/resources/12911_2021_Article_1598.pdf))
 
-- [x] change plotly's modebar on pages Recent and History:
-  - lasso: remove/disable
-  - autoscale: remove/disable
-  - zoom: never change y-axis
-  - box-select: never change y-axis
-  - zoom-in: never change y-axis
-  - zoom-out: never change y-axis
-- [ ] Recent: paning, load all data, but focus on last 7/30 days
+- [x] Recent: when zooming/paning keep the value-strip in sync with the displayed x-axis
+- [ ] Recent: paning, load all data, but focus the x-axis and the value-strip on last 30 days
 
 ## Some ideas for the future
 

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -213,6 +213,19 @@ let ``recent value strip tags each cell with the reading's chart x-label, for th
   test <@ body.Contains $"data-x=\"{expectedX2}\"" @>
 
 [<Fact>]
+let ``recent chart wires a relayout listener to keep the value strip in sync with the x-axis`` () =
+  // TODOs.md: "Recent: when zooming/paning keep the value-strip in sync with the
+  // displayed x-axis". On zoom/pan the chart's x-range narrows; the value strip needs
+  // to hide columns outside that range to stay aligned with what's plotted.
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith [ reading 1 1 ]) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+
+  test <@ body.Contains "plotly_relayout" @>
+
+[<Fact>]
 let ``recent value strip marks a reading above the goal range as 'above'`` () =
   // Default goal range (GoalRange.defaults): systolic max 140. 142 > 140.
   let r = { reading 1 1 with Systolic = 142 }

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -97,6 +97,11 @@ module ReadingViews =
     // `recentXAxis`) already draws the moving vertical line; this links it to the value
     // strip by boxing the hovered column. Follows the same poll-until-ready pattern as
     // the chart's own errorBarScript (Charts.fs `errorBarScript`).
+    // TODOs.md: keep the value strip in sync with the chart's x-axis when zooming/panning.
+    // `plotly_relayout` fires with `xaxis.range[0]`/`[1]` on zoom/pan, or `xaxis.autorange`
+    // on a reset (e.g. double-click). Columns whose data-x falls outside the new range get
+    // `out-of-range` (display:none in app.css), so the fixed-layout table redistributes the
+    // remaining columns to stay aligned with what the chart is showing.
     let scrubberScript =
       Text.raw (
         "<script>(function(){"
@@ -110,6 +115,27 @@ module ReadingViews =
         + "});"
         + "d.on('plotly_unhover',function(){"
         + "document.querySelectorAll('.value-strip td.scrubbed').forEach(function(c){c.classList.remove('scrubbed');});"
+        + "});"
+        + "d.on('plotly_relayout',function(e){"
+        + "var cells=document.querySelectorAll('.value-strip td[data-x]');"
+        + "var lo=e['xaxis.range[0]'],hi=e['xaxis.range[1]'];"
+        + "if(lo===undefined&&Array.isArray(e['xaxis.range'])){lo=e['xaxis.range'][0];hi=e['xaxis.range'][1];}"
+        + "if(lo===undefined&&e['xaxis.autorange']===undefined&&d.layout&&d.layout.xaxis){"
+        + "if(d.layout.xaxis.autorange){lo=undefined;}"
+        + "else if(d.layout.xaxis.range){lo=d.layout.xaxis.range[0];hi=d.layout.xaxis.range[1];}"
+        + "}"
+        + "if(lo===undefined||hi===undefined){"
+        + "cells.forEach(function(c){c.classList.remove('out-of-range');});"
+        + "return;"
+        + "}"
+        + "var loT=new Date(String(lo).replace(' ','T')).getTime();"
+        + "var hiT=new Date(String(hi).replace(' ','T')).getTime();"
+        + "if(isNaN(loT)||isNaN(hiT))return;"
+        + "cells.forEach(function(c){"
+        + "var t=new Date(c.dataset.x.replace(' ','T')).getTime();"
+        + "if(isNaN(t))return;"
+        + "c.classList.toggle('out-of-range',t<loT||t>hiT);"
+        + "});"
         + "});"
         + "}"
         + "setTimeout(setup,0);"

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -629,6 +629,14 @@ form.inline button {
     inset 0 -2px 0 var(--color-scrubber);
 }
 
+/* Keeps the value strip in sync with the chart's x-axis on zoom/pan (TODOs.md): toggled
+   by the same inline script's `plotly_relayout` handler. Removing (not just hiding) the
+   cell from layout lets the fixed-layout table redistribute the remaining columns to fill
+   the width, matching the chart's narrowed x-range. */
+.value-strip td.out-of-range {
+  display: none;
+}
+
 /* ── Trends page ────────────────────────────────────────────────────────── */
 
 /* Granularity selector row (Weekly / Monthly / Yearly) */


### PR DESCRIPTION
## Summary
- Wires a `plotly_relayout` listener alongside the Recent page's existing hover scrubber so value-strip columns outside the chart's current x-range are hidden, keeping the strip and chart aligned on zoom/pan (and restored on reset/autorange).