### PR TITLE
✨ feat: load all readings into Recent, focus on last 30 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Recent page's chart no longer sits behind a "Blood Pressure Graph" collapse toggle — it now renders directly under the page heading
 - Recent and History charts: removed the lasso, autoscale and box-select buttons from Plotly's toolbar, and locked the y-axis so zoom can no longer stretch or compress the blood-pressure scale (only the x-axis is zoomable)
+- Recent page now loads your full reading history into the chart and value strip, opening focused on the last 30 days — pan left to see older readings instead of them being hidden entirely
 
 ## [1.7.0-rc2] - 2026-06-23
 

--- a/TODOs.md
+++ b/TODOs.md
@@ -7,7 +7,7 @@ Some science behind the visualization:
 (as reference, I included the paper in the docs folder: [pdf](./docs/resources/12911_2021_Article_1598.pdf))
 
 - [x] Recent: when zooming/paning keep the value-strip in sync with the displayed x-axis
-- [ ] Recent: paning, load all data, but focus the x-axis and the value-strip on last 30 days
+- [x] Recent: paning, load all data, but focus the x-axis and the value-strip on last 30 days
 
 ## Some ideas for the future
 

--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -55,6 +55,10 @@ let private readings =
     reading 29 122 80 71 29 9 None
     reading 30 128 84 74 30 8 None ]
 
+/// `now` for /recent's x-axis range — past the latest test reading (day 30) so every
+/// fixture above falls inside the chart's initial 30-day window.
+let private now = Timestamp.local 2026 2 1 12 0 0
+
 [<Fact>]
 let ``toHtml renders a goal-range band shaped rectangle for systolic and diastolic bounds`` () =
   let goal: GoalRange =
@@ -170,14 +174,14 @@ let private asAggregated (rs: BloodPressureReading list) =
 let ``toHtmlRecent renders a dashed line segment when a gap exceeds 10% of the window as missing days`` () =
   // Window = 10 days; threshold = 1.0 missing day. Gap of 6 days → 5 missing days → dashed.
   let sparse = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 7 9 None ]
-  let html = BpChart.toHtmlRecent GoalRange.defaults 10 sparse
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 now sparse
   test <@ html.Contains("\"dash\":\"dash\"") @>
 
 [<Fact>]
 let ``toHtmlRecent connects readings with a solid line when the gap stays within 10% of the window`` () =
   // Window = 10 days; threshold = 1.0 missing day. Gap of 1 day → 0 missing days → solid.
   let dense = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 2 9 None ]
-  let html = BpChart.toHtmlRecent GoalRange.defaults 10 dense
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 now dense
   test <@ not (html.Contains("\"dash\":\"dash\"")) @>
 
 [<Fact>]
@@ -186,12 +190,12 @@ let ``toHtmlRecent judges gaps by calendar days, not raw elapsed time`` () =
   // (missingDays = 3, not > 3), so it must render solid even though the readings are
   // 9:00 → 10:00, i.e., raw elapsed time (4.0417 days) would cross the threshold if used directly.
   let readings = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 5 10 None ]
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
   test <@ not (html.Contains("\"dash\":\"dash\"")) @>
 
 [<Fact>]
 let ``toHtmlRecent names each line trace after its series for hover text`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 10 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 now readings
 
   let lineNameCount =
     Regex.Matches(html, "\"name\":\"(Systolic|Diastolic)\",\"showlegend\":[a-z]*,\"mode\":\"lines\\+markers\"").Count
@@ -210,7 +214,7 @@ let ``toHtmlRecent does not drop any reading, even when split across dash/solid 
       reading 5 124 80 70 11 9 None
       reading 6 125 80 70 12 9 None ]
 
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
 
   let coveredLabels (name: string) =
     Regex.Matches(html, $"\"name\":\"{name}\".*?\"x\":\\[([^\\]]*)\\]")
@@ -224,12 +228,12 @@ let ``toHtmlRecent does not drop any reading, even when split across dash/solid 
 
 [<Fact>]
 let ``toHtmlRecent renders a horizontal centered legend at the bottom, like the trends chart`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
   test <@ html.Contains("\"legend\":{\"orientation\":\"h\",\"x\":0.5,\"xanchor\":\"center\"}") @>
 
 [<Fact>]
 let ``toHtmlRecent uses compact margins, like the trends chart, now that it has no title`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
   test <@ html.Contains("\"margin\":{\"l\":48,\"r\":16,\"t\":24,\"b\":56}") @>
 
 [<Fact>]
@@ -242,7 +246,7 @@ let ``toHtmlRecent shows exactly one legend entry per series, even when split ac
       reading 5 124 80 70 11 9 None
       reading 6 125 80 70 12 9 None ]
 
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
 
   // Each trace object ends at the first "}}" (closing its "line" object then itself), so
   // bounding the match there keeps "name"/"showlegend" from leaking into the next trace.
@@ -256,13 +260,13 @@ let ``toHtmlRecent shows exactly one legend entry per series, even when split ac
 
 [<Fact>]
 let ``toHtmlRecent renders a smoothed trend line for systolic and diastolic`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
   test <@ html.Contains("\"name\":\"Systolic (trend)\"") @>
   test <@ html.Contains("\"name\":\"Diastolic (trend)\"") @>
 
 [<Fact>]
 let ``toHtmlRecent skips hover for the LOWESS trend trace, since its value is smoothed not measured`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
 
   let hasHoverSkip (exactName: string) =
     Regex.IsMatch(html, $"\"name\":\"{Regex.Escape(exactName)}\".*?\"hoverinfo\":\"skip\"")
@@ -273,7 +277,7 @@ let ``toHtmlRecent skips hover for the LOWESS trend trace, since its value is sm
 [<Fact>]
 let ``toHtmlRecent omits the trend line when there are too few readings to smooth meaningfully`` () =
   let sparse = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 2 9 None ]
-  let html = BpChart.toHtmlRecent GoalRange.defaults 10 sparse
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 now sparse
   test <@ not (html.Contains("(trend)")) @>
 
 [<Fact>]
@@ -281,7 +285,7 @@ let ``toHtmlRecent fades the raw measurement line so the LOWESS trend line stand
   // Wegier et al. 2021, "Smoothing data": "The line graph of (raw) measurements was
   // then faded slightly to help the smoothing line stand out." — the raw series should
   // render at reduced opacity (rgba alpha < 1) while the trend series keeps full color.
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
 
   let traceLineColor (exactName: string) =
     let m =
@@ -299,8 +303,19 @@ let ``toHtmlRecent fades the raw measurement line so the LOWESS trend line stand
 let ``toHtmlRecent shows a spikeline on the x-axis, to scrub through the chart and value strip`` () =
   // Wegier et al. 2021, "Scrubber bar": a vertical line tracks the cursor's horizontal
   // position across the display. Plotly's x-axis spikes give this for free.
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
   test <@ html.Contains("\"showspikes\":true") @>
+
+[<Fact>]
+let ``toHtmlRecent opens focused on the last windowDays, even though all readings are loaded`` () =
+  // TODOs.md: "Recent: paning, load all data, but focus the x-axis and the value-strip
+  // on last 30 days". The chart loads every reading (so panning left reveals older
+  // history), but its initial x-axis range only spans [now-windowDays, now] rather than
+  // autoranging to fit all loaded data.
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let rangeLow = Formats.formatLocal (now.AddDays(-30.0))
+  let rangeHigh = Formats.formatLocal now
+  test <@ html.Contains($"\"range\":[\"{rangeLow}\",\"{rangeHigh}\"]") @>
 
 [<Fact>]
 let ``toHtml (history) does not show a spikeline`` () =
@@ -327,12 +342,12 @@ let ``toHtml locks the y-axis range so zoom/select tools can only ever change th
 let ``toHtmlRecent removes the lasso, autoscale and box-select modebar buttons, so the y-axis scale can't be visually distorted``
   ()
   =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
   test <@ html.Contains("\"modeBarButtonsToRemove\":[\"lasso2d\",\"autoScale2d\",\"select2d\"]") @>
 
 [<Fact>]
 let ``toHtmlRecent locks the y-axis range so zoom/select tools can only ever change the x-axis`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
   test <@ Regex.IsMatch(html, "\"yaxis\":\\{.*?\"range\":\\[0,200\\],\"fixedrange\":true") @>
 
 [<Fact>]

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -81,13 +81,17 @@ module BpChart =
   // Keep in sync with `--color-scrubber` in wwwroot/app.css (the matching scrubber box).
   let private scrubberColor = Color.fromString "#00C853"
 
-  let private recentXAxis =
+  // The chart loads every reading (so panning left reveals older history), but opens
+  // focused on the last `windowDays` — set as the axis's initial `Range` rather than
+  // relying on autorange, which would zoom out to fit all loaded data instead.
+  let private recentXAxis (rangeLow: string) (rangeHigh: string) =
     LinearAxis.init (
       ShowGrid = false,
       ShowLine = true,
       LineColor = axisLineColor,
       Ticks = StyleParam.TickOptions.Outside,
       TickColor = axisLineColor,
+      Range = StyleParam.Range.ofMinMax (rangeLow, rangeHigh),
       ShowSpikes = true,
       SpikeColor = scrubberColor,
       SpikeThickness = 2,
@@ -187,10 +191,10 @@ module BpChart =
       HoverMode = StyleParam.HoverMode.X
     )
 
-  let private finishRecent (chart: GenericChart) =
+  let private finishRecent (rangeLow: string) (rangeHigh: string) (chart: GenericChart) =
     chart
     |> Chart.withLayout (finishRecentLayout ())
-    |> Chart.withXAxis recentXAxis
+    |> Chart.withXAxis (recentXAxis rangeLow rangeHigh)
     |> Chart.withYAxis (yAxis ())
     |> Chart.withConfig interactiveConfig
     |> GenericChart.toChartHTML
@@ -528,9 +532,16 @@ module BpChart =
         // /recent chart's unified hover so the tooltip only ever shows real readings.
         |> GenericChart.mapTrace (Trace2DStyle.Scatter(HoverInfo = StyleParam.HoverInfo.Skip)) ]
 
-  let private renderRecent (goal: GoalRange) (windowDays: int) (readings: BloodPressureReading list) : string =
+  let private renderRecent
+    (goal: GoalRange)
+    (windowDays: int)
+    (now: System.DateTimeOffset)
+    (readings: BloodPressureReading list)
+    : string =
     let readings, timestamps, systolic, diastolic = seriesOf readings
     let dashes = dashPattern windowDays readings
+    let rangeLow = Formats.formatLocal (now.AddDays(-float windowDays))
+    let rangeHigh = Formats.formatLocal now
 
     [ yield! seriesTraces systolicFadedColor "Systolic" dashes timestamps systolic
       yield! seriesTraces diastolicFadedColor "Diastolic" dashes timestamps diastolic
@@ -546,6 +557,6 @@ module BpChart =
       X = 0.5,
       XAnchor = StyleParam.XAnchorPosition.Center
     )
-    |> finishRecent
+    |> finishRecent rangeLow rangeHigh
 
-  let toHtmlRecent (goal: GoalRange) (windowDays: int) = renderRecent goal windowDays
+  let toHtmlRecent (goal: GoalRange) (windowDays: int) (now: System.DateTimeOffset) = renderRecent goal windowDays now

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -37,14 +37,25 @@ let ``recent returns 200`` () =
   test <@ ctx.Response.StatusCode = 200 @>
 
 [<Fact>]
-let ``recent omits a reading older than 30 days`` () =
+let ``recent loads a reading older than 30 days but marks its value-strip cell out-of-range`` () =
+  // TODOs.md: "Recent: paning, load all data, but focus the x-axis and the value-strip
+  // on last 30 days". The old reading must still be present (so panning back reveals it)
+  // but its value-strip cell starts hidden via the existing out-of-range/relayout wiring.
   let tp = FakeTimeProvider(now)
-  let r = reading 31 1
-  let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
+  let oldReading = { reading 31 1 with Systolic = 130 }
+  let recentReading = { reading 1 2 with Systolic = 125 }
+  let ctx = TestHost.contextWithProvider (repoWith [ oldReading; recentReading ]) tp
   TestHost.run ReadingHandlers.recent ctx
 
   let body = TestHost.readBody ctx
-  test <@ not (body.Contains "/readings/1/edit") @>
+
+  let cells =
+    System.Text.RegularExpressions.Regex.Matches(body, "<td class=\"([^\"]*)\"[^>]*>(\\d+)</td>")
+    |> Seq.map (fun m -> m.Groups[2].Value, m.Groups[1].Value)
+    |> Map.ofSeq
+
+  test <@ cells["130"].Contains "out-of-range" @>
+  test <@ not (cells["125"].Contains "out-of-range") @>
 
 [<Fact>]
 let ``recent renders a chart`` () =

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -81,15 +81,12 @@ module ReadingHandlers =
   let recent: HttpContext -> Task =
     withMember (fun m ctx ->
       let now = (timeProvider ctx).GetUtcNow()
-      let allReadings = (repo ctx).GetAll(m.Id)
+      let cutoff = now.AddDays(-float recentChartWindowDays)
 
-      let days30 =
-        allReadings
-        |> ReadingStats.between (now.AddDays(-float recentChartWindowDays)) now
-        |> List.sortByDescending _.Timestamp
+      let allReadings = (repo ctx).GetAll(m.Id) |> List.sortByDescending _.Timestamp
 
-      let chartHtml = BpChart.toHtmlRecent m.Goal recentChartWindowDays days30
-      htmlResponse (ReadingViews.recent m chartHtml days30) ctx)
+      let chartHtml = BpChart.toHtmlRecent m.Goal recentChartWindowDays now allReadings
+      htmlResponse (ReadingViews.recent m chartHtml allReadings cutoff) ctx)
 
   let trends: HttpContext -> Task =
     withMember (fun m ctx ->

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -53,11 +53,18 @@ module ReadingViews =
             Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ]
         ViewLayout.readingsTable readings ]
 
-  /// Recent: chart of the last 30 days with a sys/dias value strip.
-  let recent (activeMember: FamilyMember) (chartHtml: string) (days30: BloodPressureReading list) : XmlNode =
+  /// Recent: chart of all readings, focused on the last 30 days, with a sys/dias value strip.
+  let recent
+    (activeMember: FamilyMember)
+    (chartHtml: string)
+    (allReadings: BloodPressureReading list)
+    (cutoff: System.DateTimeOffset)
+    : XmlNode =
     let valueStrip =
-      // The strip lists the same readings as the chart below it (days30).
-      let chronological = days30 |> List.sortBy _.Timestamp
+      // The strip lists every loaded reading (chart now loads all of them so panning
+      // reveals older data); cells older than `cutoff` start hidden via `out-of-range`
+      // (see scrubberScript below, which un-hides them in sync as the user pans).
+      let chronological = allReadings |> List.sortBy _.Timestamp
 
       // Each cell is tagged with the same x-label the chart uses for this reading
       // (Charts.fs `seriesOf` formats x as Formats.formatLocal r.Timestamp), so the
@@ -79,8 +86,14 @@ module ReadingViews =
             for r in chronological ->
               let v = value r
 
+              // Cells outside the 30-day focus window start hidden (`out-of-range`, same
+              // class the relayout listener below toggles on pan/zoom), so the initial
+              // view matches the chart's initial x-axis range even though all readings
+              // are loaded.
+              let staleClass = if r.Timestamp < cutoff then " out-of-range" else ""
+
               Elem.td
-                [ Attr.class' (cellClass (classify v))
+                [ Attr.class' (cellClass (classify v) + staleClass)
                   Attr.create "data-x" (Formats.formatLocal r.Timestamp) ]
                 [ Text.raw (string v) ] ]
 


### PR DESCRIPTION
## Summary

- Recent's chart and value strip now load every reading (not just the last 30 days), opening focused on a 30-day x-axis range so panning left reveals older history
- Value-strip cells outside the 30-day window start hidden via the existing `out-of-range` class — the already-present zoom/pan listener reveals them in sync as the user pans
- Closes the `TODOs.md` item: "Recent: paning, load all data, but focus the x-axis and the value-strip on last 30 days"