### PR TITLE
🐛 fix: cap Recent's loaded reading history to the last 12 months

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Recent page's chart no longer sits behind a "Blood Pressure Graph" collapse toggle — it now renders directly under the page heading
 - Recent and History charts: removed the lasso, autoscale and box-select buttons from Plotly's toolbar, and locked the y-axis so zoom can no longer stretch or compress the blood-pressure scale (only the x-axis is zoomable)
-- Recent page now loads your full reading history into the chart and value strip, opening focused on the last 30 days — pan left to see older readings instead of them being hidden entirely
+- Recent page now loads the last 12 months of readings into the chart and value strip, opening focused on the last 30 days — pan left to see older readings instead of them being hidden entirely
 
 ## [1.7.0-rc2] - 2026-06-23
 

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -58,6 +58,26 @@ let ``recent loads a reading older than 30 days but marks its value-strip cell o
   test <@ not (cells["125"].Contains "out-of-range") @>
 
 [<Fact>]
+let ``recent excludes a reading older than the load window entirely, even though it's out-of-range either way`` () =
+  // Code review (PR #289): loading the member's *entire* lifetime history into every
+  // /recent response makes the LOWESS trend line's O(n^2) precompute and the page
+  // payload grow unboundedly with account age. Capping the load to a generous-but-finite
+  // window keeps panning useful while bounding that cost — readings older than the load
+  // window are dropped entirely (not just hidden via out-of-range).
+  let tp = FakeTimeProvider(now)
+  let beyondLoadWindow = { reading 400 1 with Systolic = 199 }
+  let withinLoadWindow = { reading 100 2 with Systolic = 188 }
+
+  let ctx =
+    TestHost.contextWithProvider (repoWith [ beyondLoadWindow; withinLoadWindow ]) tp
+
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ not (body.Contains "199") @>
+  test <@ body.Contains "188" @>
+
+[<Fact>]
 let ``recent renders a chart`` () =
   let tp = FakeTimeProvider(now)
   let ctx = TestHost.contextWithProvider (repoWith simpsonReadings) tp

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -78,15 +78,23 @@ module ReadingHandlers =
 
   let private recentChartWindowDays = 30
 
+  // Panning needs more than the 30-day focus window loaded, but truly all-time data makes
+  // the LOWESS trend line's O(n^2) precompute (and the page payload) grow unboundedly with
+  // account age. A year is generous for panning while keeping both bounded.
+  let private recentLoadWindowDays = 365
+
   let recent: HttpContext -> Task =
     withMember (fun m ctx ->
       let now = (timeProvider ctx).GetUtcNow()
       let cutoff = now.AddDays(-float recentChartWindowDays)
 
-      let allReadings = (repo ctx).GetAll(m.Id) |> List.sortByDescending _.Timestamp
+      let loadedReadings =
+        (repo ctx).GetAll(m.Id)
+        |> ReadingStats.between (now.AddDays(-float recentLoadWindowDays)) now
+        |> List.sortByDescending _.Timestamp
 
-      let chartHtml = BpChart.toHtmlRecent m.Goal recentChartWindowDays now allReadings
-      htmlResponse (ReadingViews.recent m chartHtml allReadings cutoff) ctx)
+      let chartHtml = BpChart.toHtmlRecent m.Goal recentChartWindowDays now loadedReadings
+      htmlResponse (ReadingViews.recent m chartHtml loadedReadings cutoff) ctx)
 
   let trends: HttpContext -> Task =
     withMember (fun m ctx ->


### PR DESCRIPTION
## Summary

- Follow-up to #289 (code review finding): loading the member's entire lifetime reading history into every `/recent` response made the LOWESS trend line's O(n²) precompute, and the page payload, grow unboundedly with account age
- Bounds the load to the last 12 months via the existing `ReadingStats.between` helper — panning still works for realistic use, but cost is capped instead of scaling with total account history