### PR TITLE
🔧 chore: dedupe Recent's window-boundary computation, document dashPattern scope

### DIFF
--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -58,6 +58,8 @@ let private readings =
 /// `now` for /recent's x-axis range — past the latest test reading (day 30) so every
 /// fixture above falls inside the chart's initial 30-day window.
 let private now = Timestamp.local 2026 2 1 12 0 0
+let private windowStart10 = now.AddDays(-10.0)
+let private windowStart30 = now.AddDays(-30.0)
 
 [<Fact>]
 let ``toHtml renders a goal-range band shaped rectangle for systolic and diastolic bounds`` () =
@@ -174,14 +176,14 @@ let private asAggregated (rs: BloodPressureReading list) =
 let ``toHtmlRecent renders a dashed line segment when a gap exceeds 10% of the window as missing days`` () =
   // Window = 10 days; threshold = 1.0 missing day. Gap of 6 days → 5 missing days → dashed.
   let sparse = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 7 9 None ]
-  let html = BpChart.toHtmlRecent GoalRange.defaults 10 now sparse
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 windowStart10 now sparse
   test <@ html.Contains("\"dash\":\"dash\"") @>
 
 [<Fact>]
 let ``toHtmlRecent connects readings with a solid line when the gap stays within 10% of the window`` () =
   // Window = 10 days; threshold = 1.0 missing day. Gap of 1 day → 0 missing days → solid.
   let dense = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 2 9 None ]
-  let html = BpChart.toHtmlRecent GoalRange.defaults 10 now dense
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 windowStart10 now dense
   test <@ not (html.Contains("\"dash\":\"dash\"")) @>
 
 [<Fact>]
@@ -190,12 +192,12 @@ let ``toHtmlRecent judges gaps by calendar days, not raw elapsed time`` () =
   // (missingDays = 3, not > 3), so it must render solid even though the readings are
   // 9:00 → 10:00, i.e., raw elapsed time (4.0417 days) would cross the threshold if used directly.
   let readings = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 5 10 None ]
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
   test <@ not (html.Contains("\"dash\":\"dash\"")) @>
 
 [<Fact>]
 let ``toHtmlRecent names each line trace after its series for hover text`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 10 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 windowStart10 now readings
 
   let lineNameCount =
     Regex.Matches(html, "\"name\":\"(Systolic|Diastolic)\",\"showlegend\":[a-z]*,\"mode\":\"lines\\+markers\"").Count
@@ -214,7 +216,7 @@ let ``toHtmlRecent does not drop any reading, even when split across dash/solid 
       reading 5 124 80 70 11 9 None
       reading 6 125 80 70 12 9 None ]
 
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
 
   let coveredLabels (name: string) =
     Regex.Matches(html, $"\"name\":\"{name}\".*?\"x\":\\[([^\\]]*)\\]")
@@ -228,12 +230,12 @@ let ``toHtmlRecent does not drop any reading, even when split across dash/solid 
 
 [<Fact>]
 let ``toHtmlRecent renders a horizontal centered legend at the bottom, like the trends chart`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
   test <@ html.Contains("\"legend\":{\"orientation\":\"h\",\"x\":0.5,\"xanchor\":\"center\"}") @>
 
 [<Fact>]
 let ``toHtmlRecent uses compact margins, like the trends chart, now that it has no title`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
   test <@ html.Contains("\"margin\":{\"l\":48,\"r\":16,\"t\":24,\"b\":56}") @>
 
 [<Fact>]
@@ -246,7 +248,7 @@ let ``toHtmlRecent shows exactly one legend entry per series, even when split ac
       reading 5 124 80 70 11 9 None
       reading 6 125 80 70 12 9 None ]
 
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
 
   // Each trace object ends at the first "}}" (closing its "line" object then itself), so
   // bounding the match there keeps "name"/"showlegend" from leaking into the next trace.
@@ -260,13 +262,13 @@ let ``toHtmlRecent shows exactly one legend entry per series, even when split ac
 
 [<Fact>]
 let ``toHtmlRecent renders a smoothed trend line for systolic and diastolic`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
   test <@ html.Contains("\"name\":\"Systolic (trend)\"") @>
   test <@ html.Contains("\"name\":\"Diastolic (trend)\"") @>
 
 [<Fact>]
 let ``toHtmlRecent skips hover for the LOWESS trend trace, since its value is smoothed not measured`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
 
   let hasHoverSkip (exactName: string) =
     Regex.IsMatch(html, $"\"name\":\"{Regex.Escape(exactName)}\".*?\"hoverinfo\":\"skip\"")
@@ -277,7 +279,7 @@ let ``toHtmlRecent skips hover for the LOWESS trend trace, since its value is sm
 [<Fact>]
 let ``toHtmlRecent omits the trend line when there are too few readings to smooth meaningfully`` () =
   let sparse = [ reading 1 120 80 70 1 9 None; reading 2 130 85 74 2 9 None ]
-  let html = BpChart.toHtmlRecent GoalRange.defaults 10 now sparse
+  let html = BpChart.toHtmlRecent GoalRange.defaults 10 windowStart10 now sparse
   test <@ not (html.Contains("(trend)")) @>
 
 [<Fact>]
@@ -285,7 +287,7 @@ let ``toHtmlRecent fades the raw measurement line so the LOWESS trend line stand
   // Wegier et al. 2021, "Smoothing data": "The line graph of (raw) measurements was
   // then faded slightly to help the smoothing line stand out." — the raw series should
   // render at reduced opacity (rgba alpha < 1) while the trend series keeps full color.
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
 
   let traceLineColor (exactName: string) =
     let m =
@@ -303,7 +305,7 @@ let ``toHtmlRecent fades the raw measurement line so the LOWESS trend line stand
 let ``toHtmlRecent shows a spikeline on the x-axis, to scrub through the chart and value strip`` () =
   // Wegier et al. 2021, "Scrubber bar": a vertical line tracks the cursor's horizontal
   // position across the display. Plotly's x-axis spikes give this for free.
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
   test <@ html.Contains("\"showspikes\":true") @>
 
 [<Fact>]
@@ -312,7 +314,7 @@ let ``toHtmlRecent opens focused on the last windowDays, even though all reading
   // on last 30 days". The chart loads every reading (so panning left reveals older
   // history), but its initial x-axis range only spans [now-windowDays, now] rather than
   // autoranging to fit all loaded data.
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
   let rangeLow = Formats.formatLocal (now.AddDays(-30.0))
   let rangeHigh = Formats.formatLocal now
   test <@ html.Contains($"\"range\":[\"{rangeLow}\",\"{rangeHigh}\"]") @>
@@ -342,12 +344,12 @@ let ``toHtml locks the y-axis range so zoom/select tools can only ever change th
 let ``toHtmlRecent removes the lasso, autoscale and box-select modebar buttons, so the y-axis scale can't be visually distorted``
   ()
   =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
   test <@ html.Contains("\"modeBarButtonsToRemove\":[\"lasso2d\",\"autoScale2d\",\"select2d\"]") @>
 
 [<Fact>]
 let ``toHtmlRecent locks the y-axis range so zoom/select tools can only ever change the x-axis`` () =
-  let html = BpChart.toHtmlRecent GoalRange.defaults 30 now readings
+  let html = BpChart.toHtmlRecent GoalRange.defaults 30 windowStart30 now readings
   test <@ Regex.IsMatch(html, "\"yaxis\":\\{.*?\"range\":\\[0,200\\],\"fixedrange\":true") @>
 
 [<Fact>]

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -432,6 +432,10 @@ module BpChart =
   // such gaps render dashed, ordinary gaps render solid. Consecutive same-style gaps are
   // merged into a single multi-point trace (a "run") instead of one trace per gap, keeping
   // the trace count proportional to the number of dash/solid transitions rather than to N.
+  // /recent's load window is wider than its visible focus window (see ReadingHandlers'
+  // `recentLoadWindowDays`), so this threshold — tuned for the 30-day focus window — also
+  // governs gaps the user only sees by panning back; that's intentional (consistent styling
+  // across however much history is loaded), not an oversight.
   let private isGapDashed (windowDays: int) (gapDays: int) =
     let missingDays = gapDays - 1
     float missingDays > 0.10 * float windowDays
@@ -535,13 +539,14 @@ module BpChart =
   let private renderRecent
     (goal: GoalRange)
     (windowDays: int)
-    (now: System.DateTimeOffset)
+    (windowStart: System.DateTimeOffset)
+    (windowEnd: System.DateTimeOffset)
     (readings: BloodPressureReading list)
     : string =
     let readings, timestamps, systolic, diastolic = seriesOf readings
     let dashes = dashPattern windowDays readings
-    let rangeLow = Formats.formatLocal (now.AddDays(-float windowDays))
-    let rangeHigh = Formats.formatLocal now
+    let rangeLow = Formats.formatLocal windowStart
+    let rangeHigh = Formats.formatLocal windowEnd
 
     [ yield! seriesTraces systolicFadedColor "Systolic" dashes timestamps systolic
       yield! seriesTraces diastolicFadedColor "Diastolic" dashes timestamps diastolic
@@ -559,4 +564,14 @@ module BpChart =
     )
     |> finishRecent rangeLow rangeHigh
 
-  let toHtmlRecent (goal: GoalRange) (windowDays: int) (now: System.DateTimeOffset) = renderRecent goal windowDays now
+  // `windowStart`/`windowEnd` are computed once by the caller (the same instant the
+  // value strip's out-of-range cutoff is computed from) rather than re-derived here from
+  // `now`/`windowDays`, so the chart's visible range and the value strip's hidden cells
+  // can never drift apart from a duplicated AddDays computation.
+  let toHtmlRecent
+    (goal: GoalRange)
+    (windowDays: int)
+    (windowStart: System.DateTimeOffset)
+    (windowEnd: System.DateTimeOffset)
+    =
+    renderRecent goal windowDays windowStart windowEnd

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -78,6 +78,27 @@ let ``recent excludes a reading older than the load window entirely, even though
   test <@ body.Contains "188" @>
 
 [<Fact>]
+let ``recent excludes a future-dated reading entirely, since the load window's upper bound is 'now'`` () =
+  // Code review (PR #289): the value strip's out-of-range check only covered the lower
+  // bound (`< cutoff`), so a reading dated after `now` (clock skew, or a manually entered
+  // future timestamp — BloodPressureReading.parse doesn't reject future dates) rendered as
+  // if in-range even though it's beyond the chart's `rangeHigh = now` upper bound. The
+  // load-window filter added in PR #290 (`ReadingStats.between` has an exclusive upper
+  // bound at `now`) already excludes such readings entirely — this test pins that down.
+  let tp = FakeTimeProvider(now)
+  let futureReading = { reading -1 1 with Systolic = 177 }
+  let inRangeReading = { reading 1 2 with Systolic = 166 }
+
+  let ctx =
+    TestHost.contextWithProvider (repoWith [ futureReading; inRangeReading ]) tp
+
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  test <@ not (body.Contains "177") @>
+  test <@ body.Contains "166" @>
+
+[<Fact>]
 let ``recent renders a chart`` () =
   let tp = FakeTimeProvider(now)
   let ctx = TestHost.contextWithProvider (repoWith simpsonReadings) tp

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -86,15 +86,17 @@ module ReadingHandlers =
   let recent: HttpContext -> Task =
     withMember (fun m ctx ->
       let now = (timeProvider ctx).GetUtcNow()
-      let cutoff = now.AddDays(-float recentChartWindowDays)
+      let windowStart = now.AddDays(-float recentChartWindowDays)
 
       let loadedReadings =
         (repo ctx).GetAll(m.Id)
         |> ReadingStats.between (now.AddDays(-float recentLoadWindowDays)) now
         |> List.sortByDescending _.Timestamp
 
-      let chartHtml = BpChart.toHtmlRecent m.Goal recentChartWindowDays now loadedReadings
-      htmlResponse (ReadingViews.recent m chartHtml loadedReadings cutoff) ctx)
+      let chartHtml =
+        BpChart.toHtmlRecent m.Goal recentChartWindowDays windowStart now loadedReadings
+
+      htmlResponse (ReadingViews.recent m chartHtml loadedReadings windowStart) ctx)
 
   let trends: HttpContext -> Task =
     withMember (fun m ctx ->

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -58,12 +58,13 @@ module ReadingViews =
     (activeMember: FamilyMember)
     (chartHtml: string)
     (allReadings: BloodPressureReading list)
-    (cutoff: System.DateTimeOffset)
+    (windowStart: System.DateTimeOffset)
     : XmlNode =
     let valueStrip =
-      // The strip lists every loaded reading (chart now loads all of them so panning
-      // reveals older data); cells older than `cutoff` start hidden via `out-of-range`
-      // (see scrubberScript below, which un-hides them in sync as the user pans).
+      // The strip lists every loaded reading (the chart's load window, see ReadingHandlers
+      // — bounded but wider than the visible focus); cells older than `windowStart` start
+      // hidden via `out-of-range` (see scrubberScript below, which un-hides them in sync as
+      // the user pans).
       let chronological = allReadings |> List.sortBy _.Timestamp
 
       // Each cell is tagged with the same x-label the chart uses for this reading
@@ -90,7 +91,7 @@ module ReadingViews =
               // class the relayout listener below toggles on pan/zoom), so the initial
               // view matches the chart's initial x-axis range even though all readings
               // are loaded.
-              let staleClass = if r.Timestamp < cutoff then " out-of-range" else ""
+              let staleClass = if r.Timestamp < windowStart then " out-of-range" else ""
 
               Elem.td
                 [ Attr.class' (cellClass (classify v) + staleClass)


### PR DESCRIPTION
## Summary

- Follow-up to the #289 code review (remaining findings #3-#5): the chart's visible x-axis range and the value strip's hidden-cell cutoff were each independently re-derived from `now`/`windowDays` via separate `AddDays` calls in `ReadingHandlers.fs` and `Charts.fs` — now computed once in the handler and threaded through both
- Pins down with a test that the future-dated-reading edge case is already resolved as a side effect of #290's load-window cap (`ReadingStats.between`'s exclusive upper bound at `now` already excludes such readings)
- Documents that the dashed/solid gap threshold intentionally applies across the loaded window (now bounded to 12 months by #290), not just the visible 30-day focus