### PR TITLE
✨ feat: add verify-frontend skill for E2E-based UI change verification

### DIFF
--- a/.claude/skills/verify-frontend/SKILL.md
+++ b/.claude/skills/verify-frontend/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: verify-frontend
+description: Verify a frontend/UI change by driving a real browser against a real BpMonitor.Web instance, using a throwaway xunit test in BpMonitor.Web.E2E.Tests. Invoke after making any change to wwwroot/, Views, or page-rendering handlers, before reporting the change as complete.
+---
+
+# Verify Frontend
+
+Confirm a frontend change actually works by reusing `BpMonitor.Web.E2E.Tests`'
+existing infrastructure — not ad-hoc Playwright scripts or screenshot tools.
+`WebAppFixture` already boots a real out-of-process `BpMonitor.Web` instance
+(fresh temp SQLite file) and launches a real headless Chromium browser; reuse
+it instead of reinventing browser automation per session.
+
+## Steps
+
+1. **Check Chromium is installed.** If `mise run test:e2e-setup` hasn't been
+   run on this machine, the test will fail to launch the browser — run it
+   once if needed.
+2. **Add a throwaway `[<Fact>]`** to `code/BpMonitor.Web.E2E.Tests/SmokeTests.fs`
+   (or a scratch file in the same project), inside a type that implements
+   `IClassFixture<WebAppFixture>`. Reuse `TestAccount.claimAndLogin` to get an
+   authenticated session, then navigate to the page the change touched and
+   assert on the specific thing that should now be true (text content, an
+   element existing, a redirect happening).
+3. **Run only that test:**
+
+   ```bash
+   cd code
+   dotnet test BpMonitor.Web.E2E.Tests --filter "FullyQualifiedName~<unique-name-fragment>"
+   ```
+
+   This exercises the same path CI does — real HTTP, real routing, real
+   htmx/CSS — so a pass here is a real signal.
+4. **For visual/CSS changes** where an assertion alone won't tell the full
+   story, launch headed instead of headless for that one run:
+   `playwright.Chromium.LaunchAsync(BrowserTypeLaunchOptions(Headless = false))`
+   (temporarily edit `WebAppFixture.InitializeAsync`, then revert).
+5. **Delete the scratch test** once the change is confirmed. It existed only
+   to prove the change works — don't leave it in the permanent suite unless
+   it earns a place as real regression coverage (a deliberate decision, not a
+   byproduct of verification).
+
+## When NOT to use this
+
+- Backend-only changes with no rendered output — ordinary unit/integration
+  tests cover those.
+- Changes already covered by an existing `SmokeTests.fs` test that exercises
+  the same path — rerun that test instead of writing a new one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ The following are available as slash commands (defined in `.claude/skills/`):
 | Setup Tooling | `/setup-tooling` | Audit and configure code quality infrastructure |
 | Model Advisor | auto-loaded | Model selection reference |
 | Status Bar | auto-loaded | Status bar configuration reference |
+| Verify Frontend | `/verify-frontend` | Verify a frontend change via a throwaway E2E test against a real browser |
 
 ## Project Structure
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,7 @@ code/
 | Architecture | Clean Architecture (Core has zero dependencies on other projects) |
 | Architecture tests | ArchUnit (via `BpMonitor.Arch.Tests`) |
 | E2E tests | Playwright .NET (via `BpMonitor.Web.E2E.Tests`) — drives a real Chromium browser against a real out-of-process `BpMonitor.Web` instance with a fresh temp SQLite file |
+| Verifying frontend changes | `verify-frontend` skill — adds a throwaway xunit test against `WebAppFixture`, runs it, then deletes it; avoids ad-hoc browser automation |
 | Test runner | xUnit v3 on Microsoft.Testing.Platform (MTP) — all 8 test projects run in parallel via `dotnet test` (default `--max-parallel-test-modules` = CPU count) |
 | Test coverage | `Microsoft.Testing.Extensions.CodeCoverage` (18.0.6); run with `dotnet test -- --coverage --coverage-output-format cobertura`; outputs one GUID-named `.cobertura.xml` per project into `TestResults/` |
 


### PR DESCRIPTION
## Summary
- Adds a `verify-frontend` project skill: verify frontend/UI changes by adding a throwaway xunit test against `WebAppFixture` in `BpMonitor.Web.E2E.Tests`, running it, then deleting it — replacing ad-hoc Playwright/chromium-cli usage
- Documents the skill in `AGENTS.md`'s skills table and `docs/architecture.md`'s tech stack table