### PR TITLE
🔧 chore: apply ReSharper code cleanup (qualifiers, indexers, grammar)

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -6,10 +6,7 @@ Some science behind the visualization:
 [Home blood pressure data visualization for the management of hypertension: using human factors and design principles](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8340525/)
 (as reference, I included the paper in the docs folder: [pdf](./docs/resources/12911_2021_Article_1598.pdf))
 
-- [x] Recent: when zooming/paning keep the value-strip in sync with the displayed x-axis
-- [x] Recent: paning, load all data, but focus the x-axis and the value-strip on last 30 days
-
 ## Some ideas for the future
 
 - Exploratory data analysis using [Jupyter Notebooks](https://jupyter.org/).
-  This can be integrated some how into this application, or more realistically, a separate application.
+  This can be integrated somehow into this application or more realistically, a separate application.

--- a/code/BpMonitor.Arch.Tests/ArchitectureTests.fs
+++ b/code/BpMonitor.Arch.Tests/ArchitectureTests.fs
@@ -27,7 +27,7 @@ let private architecture =
 // injected into every instrumented assembly. ArchUnitNET sees the same tracker type
 // across multiple assemblies and incorrectly reports cross-assembly dependencies.
 // Filter out Microsoft.CodeCoverage types to prevent these false positives.
-let private appTypes (assembly: System.Reflection.Assembly) =
+let private appTypes (assembly: Assembly) =
   ArchRuleDefinition
     .Types()
     .That()

--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -55,7 +55,7 @@ let private readings =
     reading 29 122 80 71 29 9 None
     reading 30 128 84 74 30 8 None ]
 
-/// `now` for /recent's x-axis range — past the latest test reading (day 30) so every
+/// `now` for /recent's x-axis range — past the latest test reading (day 30), so every
 /// fixture above falls inside the chart's initial 30-day window.
 let private now = Timestamp.local 2026 2 1 12 0 0
 let private windowStart10 = now.AddDays(-10.0)

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -14,10 +14,10 @@ module BpChart =
   // faded line, background band) is a derived alpha of it, so retuning a series' hue
   // only ever needs a change in one place.
   let private opaque (r, g, b) =
-    Color.fromString (sprintf "#%02X%02X%02X" r g b)
+    Color.fromString $"#%02X{r}%02X{g}%02X{b}"
 
   let private withAlpha (alpha: float) (r, g, b) =
-    Color.fromString (sprintf "rgba(%d,%d,%d,%g)" r g b alpha)
+    Color.fromString $"rgba(%d{r},%d{g},%d{b},%g{alpha})"
 
   let private systolicRgb = (0, 132, 113)
   let private diastolicRgb = (156, 101, 43)
@@ -25,7 +25,7 @@ module BpChart =
   let private systolicColor = opaque systolicRgb
   let private diastolicColor = opaque diastolicRgb
 
-  // The /recent chart fades the raw per-reading line so the LOWESS trend line (kept at
+  // The /recent chart fades the raw per-reading line, so the LOWESS trend line (kept at
   // full strength) stands out as the visual focus — Wegier et al. 2021, "Smoothing data".
   let private systolicFadedColor = withAlpha 0.22 systolicRgb
   let private diastolicFadedColor = withAlpha 0.22 diastolicRgb
@@ -52,7 +52,7 @@ module BpChart =
     [ band goal.SystolicMin goal.SystolicMax systolicBandColor
       band goal.DiastolicMin goal.DiastolicMax diastolicBandColor ]
 
-  // Compact margins, matching the trends chart: with no chart title, Plotly's default
+  // Compact margins, matching the trends' chart: with no chart title, Plotly's default
   // top margin (100) would otherwise sit empty above the plot.
   let private compactMargin =
     Margin.init (Left = 48, Right = 16, Top = 24, Bottom = 56)
@@ -437,7 +437,7 @@ module BpChart =
   // Wegier et al. 2021 (docs/resources/12911_2021_Article_1598.pdf, "Missing data"):
   // a gap is "missing data" once the days it skips exceed 10% of the displayed window;
   // such gaps render dashed, ordinary gaps render solid. Consecutive same-style gaps are
-  // merged into a single multi-point trace (a "run") instead of one trace per gap, keeping
+  // merged into a single multipoint trace (a "run") instead of one trace per gap, keeping
   // the trace count proportional to the number of dash/solid transitions rather than to N.
   // /recent's load window is wider than its visible focus window (see ReadingHandlers'
   // `recentLoadWindowDays`), so this threshold — tuned for the 30-day focus window — also
@@ -479,7 +479,7 @@ module BpChart =
     |> List.map (fun (style, startGap, endGap) -> startGap, endGap + 1, style)
 
   /// One trace per dash/solid run for a series; only the first run carries the legend
-  /// entry, all runs show markers so every reading still gets a point. Falls back to a
+  /// entry, all runs show markers, so every reading still gets a point. Falls back to a
   /// single trace when there's nothing to split (0 or 1 readings).
   let private seriesTraces
     (color: Color)
@@ -506,8 +506,8 @@ module BpChart =
         )
         |> Chart.withLineStyle (Color = color))
 
-  // Fraction of points in each point's local LOWESS neighbourhood. A wide bandwidth
-  // (e.g. 0.5) averages over so many points that real local structure — a dip right
+  // Fraction of points in each point's local LOWESS neighborhood. A wide bandwidth
+  // (e.g., 0.5) averages over so many points that real local structure — a dip right
   // before a gap, a spike right after one — gets smoothed away into one broad hump,
   // unlike the responsive trend line in Wegier et al. 2021's Fig. 5. A narrow
   // bandwidth keeps the day-to-day jitter damped while still tracking those shifts.

--- a/code/BpMonitor.Core.Tests/LowessPropertyTests.fs
+++ b/code/BpMonitor.Core.Tests/LowessPropertyTests.fs
@@ -6,7 +6,7 @@ open FsCheck.Xunit
 open BpMonitor.Core
 
 /// x/y series biased toward the conditions that can make a local LOWESS fit singular:
-/// x's drawn from a small discrete set make duplicate x-values (e.g. same-day readings on
+/// x's drawn from a small discrete set make duplicate x-values (e.g., same-day readings on
 /// the real /recent chart) likely, and a few outlier y's are large enough to get
 /// bisquare-zeroed during the robustifying iterations — together the combination that
 /// drove `weightedLinearFitAt`'s 0.0/0.0 division.

--- a/code/BpMonitor.Core.Tests/LowessTests.fs
+++ b/code/BpMonitor.Core.Tests/LowessTests.fs
@@ -79,7 +79,7 @@ let ``smooth downweights a single extreme outlier instead of being pulled toward
 let ``smooth never returns NaN, even when a cluster of duplicate x-values contains an outlier`` () =
   // Duplicate x-values arise in practice from same-day readings (the chart's x-axis is
   // calendar days). A tight cluster of duplicates containing one outlier can, across the
-  // robustifying iterations, drive every weight in a point's neighbourhood to zero —
+  // robustifying iterations, drive every weight in a point's neighborhood to zero —
   // leaving weightedLinearFitAt dividing 0.0/0.0. Reproduces the /recent chart's NaN-induced
   // trend-line gaps reported against real reading data clustered around same-day duplicates.
   let xs = [ 0.0; 1.0; 2.0; 3.0; 3.0; 3.0; 4.0; 4.0 ]

--- a/code/BpMonitor.Core.Tests/ReadingStatsTests.fs
+++ b/code/BpMonitor.Core.Tests/ReadingStatsTests.fs
@@ -72,9 +72,9 @@ let ``dailyAverages: two readings on same day are averaged`` () =
   let r2 = mkReading 2 140 90 80 (DateTimeOffset(day0.AddHours(20.0), TimeSpan.Zero))
   let result = ReadingStats.dailyAverages [ r1; r2 ]
   test <@ result.Length = 1 @>
-  test <@ result.[0].Systolic = 130 @>
-  test <@ result.[0].Diastolic = 85 @>
-  test <@ result.[0].HeartRate = 70 @>
+  test <@ result[0].Systolic = 130 @>
+  test <@ result[0].Diastolic = 85 @>
+  test <@ result[0].HeartRate = 70 @>
 
 [<Fact>]
 let ``dailyAverages: readings on different days produce one entry per day`` () =
@@ -88,7 +88,7 @@ let ``dailyAverages: result is sorted ascending by date`` () =
   let r1 = mkReading 1 130 85 70 (now.AddDays(-1.0))
   let r2 = mkReading 2 120 80 60 (now.AddDays(-3.0))
   let result = ReadingStats.dailyAverages [ r1; r2 ]
-  test <@ result.[0].Timestamp < result.[1].Timestamp @>
+  test <@ result[0].Timestamp < result[1].Timestamp @>
 
 [<Fact>]
 let ``dailyAverages: timestamp is midnight of the local date`` () =
@@ -106,14 +106,14 @@ let ``weeklyAverages: empty list returns empty`` () =
 
 [<Fact>]
 let ``weeklyAverages: readings in same ISO week are averaged into one entry`` () =
-  // 2026-W24: Mon 2026-06-08 .. Sun 2026-06-14
+  // 2026-W24: Mon 2026-06-08 ... Sun 2026-06-14
   let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
   let r2 = mkReading 2 140 90 80 (DateTimeOffset(2026, 6, 10, 9, 0, 0, TimeSpan.Zero))
   let result = ReadingStats.weeklyAverages [ r1; r2 ]
   test <@ result.Length = 1 @>
-  test <@ result.[0].Systolic = 130 @>
-  test <@ result.[0].Diastolic = 85 @>
-  test <@ result.[0].HeartRate = 70 @>
+  test <@ result[0].Systolic = 130 @>
+  test <@ result[0].Diastolic = 85 @>
+  test <@ result[0].HeartRate = 70 @>
 
 [<Fact>]
 let ``weeklyAverages: readings in different weeks produce one entry per week`` () =
@@ -127,7 +127,7 @@ let ``weeklyAverages: result is sorted ascending`` () =
   let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero)) // W24
   let r2 = mkReading 2 130 85 70 (DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)) // W23
   let result = ReadingStats.weeklyAverages [ r1; r2 ]
-  test <@ result.[0].Timestamp < result.[1].Timestamp @>
+  test <@ result[0].Timestamp < result[1].Timestamp @>
 
 [<Fact>]
 let ``weeklyAverages: timestamp is Monday midnight of the ISO week`` () =
@@ -150,7 +150,7 @@ let ``monthlyAverages: readings in same month are averaged into one entry`` () =
   let r2 = mkReading 2 140 90 80 (DateTimeOffset(2026, 6, 20, 9, 0, 0, TimeSpan.Zero))
   let result = ReadingStats.monthlyAverages [ r1; r2 ]
   test <@ result.Length = 1 @>
-  test <@ result.[0].Systolic = 130 @>
+  test <@ result[0].Systolic = 130 @>
 
 [<Fact>]
 let ``monthlyAverages: readings in different months produce one entry per month`` () =
@@ -164,7 +164,7 @@ let ``monthlyAverages: result is sorted ascending`` () =
   let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.Zero))
   let r2 = mkReading 2 130 85 70 (DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero))
   let result = ReadingStats.monthlyAverages [ r1; r2 ]
-  test <@ result.[0].Timestamp < result.[1].Timestamp @>
+  test <@ result[0].Timestamp < result[1].Timestamp @>
 
 [<Fact>]
 let ``monthlyAverages: timestamp is first of month midnight`` () =

--- a/code/BpMonitor.Core.Tests/TrendPeriodTests.fs
+++ b/code/BpMonitor.Core.Tests/TrendPeriodTests.fs
@@ -5,7 +5,7 @@ open Xunit
 open Swensen.Unquote
 open BpMonitor.Core
 
-// Fixed "now" = Tuesday 2026-06-09 12:00 UTC (ISO week 24 of 2026, June, 2026)
+// Fixed "now" = Tuesday 2026-06-09 12:00 UTC (ISO week 24 of 2026, June 2026)
 let private now = DateTimeOffset(2026, 6, 9, 12, 0, 0, TimeSpan.Zero)
 
 // ── slug / parseGranularity ────────────────────────────────────────────────────

--- a/code/BpMonitor.Core/DemoData.fs
+++ b/code/BpMonitor.Core/DemoData.fs
@@ -108,7 +108,7 @@ module DemoData =
 
   // Clamps raw vitals into range and parses them into a reading. Shared by every
   // generator below (the random-jitter Simpson profiles and Ned Flanders' scripted
-  // narrative alike) so there's one place that builds an `unvalidated` record.
+  // narrative alike), so there's one place that builds an `unvalidated` record.
   let private buildReading
     (ranges: ReadingRanges)
     (systolic: int)
@@ -351,8 +351,8 @@ module DemoData =
     let bigGapDays = 5.0
     let stepDays = (29.0 - bigGapDays) / float (totalPoints - 2)
 
-    // How much further back a point sits once it's past the gap: one ordinary step
-    // is replaced by the (longer) gap, so everything past it shifts back by the
+    // How much further back a point sits once it's past the gap: the (longer) gap
+    // replaces one ordinary step, so everything past it shifts back by the
     // difference. Index j's days-ago is then a single formula: a uniform `j * stepDays`
     // ramp, with that one extra shift applied from the gap onward.
     let gapShift = bigGapDays - stepDays

--- a/code/BpMonitor.Core/Lowess.fs
+++ b/code/BpMonitor.Core/Lowess.fs
@@ -32,10 +32,10 @@ module Lowess =
   let private weightedLinearFitAt (xi: float) (points: (float * float * float) array) =
     let sumW = points |> Array.sumBy (fun (w, _, _) -> w)
 
-    // A whole neighbourhood can end up with zero total weight — e.g. a tight cluster of
+    // A whole neighborhood can end up with zero total weight — e.g., a tight cluster of
     // duplicate x-values (same-day readings) where the robustifying iterations bisquare-zero
     // every remaining weight. There's no weighted information left at that point, so fall
-    // back to the plain (unweighted) mean of the neighbourhood's y-values instead of
+    // back to the plain (unweighted) mean of the neighborhood's y-values instead of
     // dividing 0.0/0.0 into NaN.
     if sumW = 0.0 then
       points |> Array.averageBy (fun (_, _, y) -> y)
@@ -65,10 +65,10 @@ module Lowess =
       let xs = List.toArray xs
       let ys = List.toArray ys
 
-      // Number of neighbours considered for each point's local fit.
+      // Number of neighbors considered for each point's local fit.
       let k = max 2 (int (ceil (bandwidth * float n)))
 
-      // Each point's k nearest neighbours depend only on `xs`, not on the robustness
+      // Each point's k nearest neighbors depend only on `xs`, not on the robustness
       // weights — so they're identical across every robustifying iteration. Computed
       // once here rather than re-sorting all n points per point on every iteration.
       let neighbours =

--- a/code/BpMonitor.Core/ReadingStats.fs
+++ b/code/BpMonitor.Core/ReadingStats.fs
@@ -1,7 +1,7 @@
 namespace BpMonitor.Core
 
 /// A period-averaged reading together with the number of raw readings that were
-/// folded into it. Used by the trends chart to distinguish single-reading periods
+/// folded into it. Used by the trends' chart to distinguish single-reading periods
 /// (circle marker) from multi-reading averages (diamond marker).
 type AggregatedReading =
   { Reading: BloodPressureReading
@@ -113,7 +113,7 @@ module ReadingStats =
 
   // ── summary ──────────────────────────────────────────────────────────────────
 
-  /// Summarises readings that have already been filtered to the given period.
+  /// Summarizes readings that have already been filtered to the given period.
   /// Count/min/avg/max are computed over the supplied list; period metadata stamped from the period.
   let summarizeRange (period: TrendPeriod) (rangeReadings: BloodPressureReading list) : WindowSummary =
     match rangeReadings with

--- a/code/BpMonitor.Core/TrendPeriod.fs
+++ b/code/BpMonitor.Core/TrendPeriod.fs
@@ -2,7 +2,7 @@ namespace BpMonitor.Core
 
 /// ISO-8601 week-numbering year + week (week 1..53).
 /// NB: Year is the ISO week-numbering year, which can differ from the calendar
-/// year near year boundaries (e.g. 29 Dec 2025 can belong to ISO week 2026-W01).
+/// year near year boundaries (e.g., 29 Dec 2025 can belong to ISO week 2026-W01).
 type IsoWeek = { Year: int; Week: int }
 
 /// Calendar year + month (month 1..12).
@@ -42,8 +42,8 @@ module TrendPeriod =
 
   let private parseIsoWeekKey (key: string) : IsoWeek option =
     match key.Split('-') with
-    | [| y; w |] when w.Length >= 2 && w.[0] = 'W' ->
-      match Int32.TryParse y, Int32.TryParse(w.[1..]) with
+    | [| y; w |] when w.Length >= 2 && w[0] = 'W' ->
+      match Int32.TryParse y, Int32.TryParse(w[1..]) with
       | (true, year), (true, week) when week >= 1 && week <= 53 -> Some { Year = year; Week = week }
       | _ -> None
     | _ -> None

--- a/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
@@ -34,7 +34,7 @@ let private createContext () =
   ctx
 
 let private createRepo (ctx: BpMonitorDbContext) : IReadingRepository =
-  EfReadingRepository(ctx, System.TimeProvider.System) :> IReadingRepository
+  EfReadingRepository(ctx, TimeProvider.System) :> IReadingRepository
 
 [<Fact>]
 let ``GetAll returns empty list when database is empty`` () =
@@ -182,4 +182,5 @@ let ``Update does not affect a reading belonging to a different member`` () =
         MemberId = 2 }
   )
   // Reading should remain unchanged for member 1
+  // ReSharper disable once FSharpRedundantDotInIndexer
   test <@ (repo.GetAll 1).[0].Systolic = 120 @>

--- a/code/BpMonitor.Data.Tests/SchemaMigrationsTests.fs
+++ b/code/BpMonitor.Data.Tests/SchemaMigrationsTests.fs
@@ -144,7 +144,8 @@ let ``apply adds missing columns to an existing Readings table without MemberId`
   use insertCmd = connection.CreateCommand()
 
   insertCmd.CommandText <-
-    "INSERT INTO \"Readings\" (Systolic, Diastolic, HeartRate, Timestamp) VALUES (120, 80, 70, '2026-01-01 09:00:00 +00:00')"
+    "-- noinspection SqlInsertValues
+    INSERT INTO \"Readings\" (Systolic, Diastolic, HeartRate, Timestamp) VALUES (120, 80, 70, '2026-01-01 09:00:00 +00:00')"
 
   insertCmd.ExecuteNonQuery() |> ignore
 

--- a/code/BpMonitor.Data/EfFamilyMemberRepository.fs
+++ b/code/BpMonitor.Data/EfFamilyMemberRepository.fs
@@ -62,7 +62,7 @@ type EfFamilyMemberRepository(ctx: BpMonitorDbContext, timeProvider: System.Time
         // Detach any tracked entity with the same Id to avoid EF tracking conflicts.
         ctx.ChangeTracker.Entries<MemberRecord>()
         |> Seq.tryFind (fun e -> e.Entity.Id = m.Id)
-        |> Option.iter (fun e -> e.State <- Microsoft.EntityFrameworkCore.EntityState.Detached)
+        |> Option.iter (fun e -> e.State <- EntityState.Detached)
 
         ctx.Members.Update(MemberMapping.toEntity m.CreatedAt now m) |> ignore
         ctx.SaveChanges() |> ignore

--- a/code/BpMonitor.Data/EfReadingRepository.fs
+++ b/code/BpMonitor.Data/EfReadingRepository.fs
@@ -80,7 +80,7 @@ type EfReadingRepository(ctx: BpMonitorDbContext, timeProvider: System.TimeProvi
       if existsForMember then
         ctx.ChangeTracker.Entries<ReadingRecord>()
         |> Seq.tryFind (fun e -> e.Entity.Id = reading.Id)
-        |> Option.iter (fun e -> e.State <- Microsoft.EntityFrameworkCore.EntityState.Detached)
+        |> Option.iter (fun e -> e.State <- EntityState.Detached)
 
         ctx.Readings.Update(reading |> Mapping.withModifiedAt now |> Mapping.toEntity)
         |> ignore

--- a/code/BpMonitor.Data/SchemaMigrations.fs
+++ b/code/BpMonitor.Data/SchemaMigrations.fs
@@ -66,7 +66,7 @@ module SchemaMigrations =
     |> ignore
 
   /// Ensures a default family member exists. Returns its Id, which is used as the
-  /// default value when back-filling the MemberId column on existing readings.
+  /// default value when backfilling the MemberId column on existing readings.
   let private ensureDefaultMember (ctx: BpMonitorDbContext) : int =
     let count =
       withConn ctx (fun conn -> scalarInt64 conn "SELECT COUNT(*) FROM \"Members\"")
@@ -128,7 +128,7 @@ module SchemaMigrations =
     // Ensure at least one default member exists and get its Id.
     let defaultMemberId = ensureDefaultMember ctx
 
-    // Back-fill existing readings with the default member Id.
+    // Backfill existing readings with the default member Id.
     addColumnIfMissing ctx "Readings" "MemberId" "INTEGER" (string defaultMemberId)
 
     // Promote the lowest-Id member to admin+active when no active admin exists yet.

--- a/code/BpMonitor.TestSupport/Verifier.fs
+++ b/code/BpMonitor.TestSupport/Verifier.fs
@@ -7,7 +7,7 @@ open VerifyTests
 
 /// Verify resolves the snapshot directory from the caller's source file.
 /// Since these helpers live outside the calling test project, callers must
-/// pass their own file path explicitly (e.g. via __SOURCE_DIRECTORY__ /
+/// pass their own file path explicitly (e.g., via __SOURCE_DIRECTORY__ /
 /// __SOURCE_FILE__) rather than relying on CallerFilePathAttribute, which
 /// would anchor to this module instead of the calling test file.
 

--- a/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
@@ -118,7 +118,7 @@ let ``loginSubmit claims unclaimed member and sets password hash`` () =
   test <@ ctx.Response.StatusCode = 302 @>
   let memberRepo = ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
   let saved = memberRepo.GetById(1) |> Option.get
-  test <@ BpMonitor.Core.FamilyMember.isClaimed saved @>
+  test <@ FamilyMember.isClaimed saved @>
   test <@ PasswordHashing.verify "correct-horse" (saved.PasswordHash |> Option.get) @>
 
 [<Fact>]
@@ -193,4 +193,4 @@ let ``resetPassword sets member to unclaimed`` () =
 
   let memberRepo = ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
   let saved = memberRepo.GetById(1) |> Option.get
-  test <@ not (BpMonitor.Core.FamilyMember.isClaimed saved) @>
+  test <@ not (FamilyMember.isClaimed saved) @>

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -39,7 +39,7 @@ let ``recent returns 200`` () =
 [<Fact>]
 let ``recent loads a reading older than 30 days but marks its value-strip cell out-of-range`` () =
   // TODOs.md: "Recent: paning, load all data, but focus the x-axis and the value-strip
-  // on last 30 days". The old reading must still be present (so panning back reveals it)
+  // on last 30 days". The old reading must still be present (so panning back reveals it),
   // but its value-strip cell starts hidden via the existing out-of-range/relayout wiring.
   let tp = FakeTimeProvider(now)
   let oldReading = { reading 31 1 with Systolic = 130 }

--- a/code/BpMonitor.Web.Tests/TestHost.fs
+++ b/code/BpMonitor.Web.Tests/TestHost.fs
@@ -58,14 +58,14 @@ let context (repo: IReadingRepository) : HttpContext =
   newCtx (buildServices repo memberRepo TimeProvider.System) (Some(buildPrincipal defaultMember))
 
 /// Variant of `context` that injects a custom TimeProvider — useful for testing
-/// handlers that read the current time (e.g. newReading timestamp prefill).
+/// handlers that read the current time (e.g., newReading timestamp prefill).
 let contextWithProvider (repo: IReadingRepository) (tp: TimeProvider) : HttpContext =
   let memberRepo = InMemoryFamilyMemberRepository(None) :> IFamilyMemberRepository
   newCtx (buildServices repo memberRepo tp) (Some(buildPrincipal defaultMember))
 
 /// Variant of `context` that uses a custom list of family members. The user
-/// principal is set to the first member in the list. Useful for multi-member
-/// scenarios (e.g. testing edit/update invariant enforcement).
+/// principal is set to be the first member in the list. Useful for multi-member
+/// scenarios (e.g., testing edit/update invariant enforcement).
 let contextWithMembers (repo: IReadingRepository) (members: FamilyMember list) : HttpContext =
   let memberRepo =
     InMemoryFamilyMemberRepository(Some members) :> IFamilyMemberRepository
@@ -74,8 +74,8 @@ let contextWithMembers (repo: IReadingRepository) (members: FamilyMember list) :
   newCtx (buildServices repo memberRepo TimeProvider.System) user
 
 /// Variant of `contextWithMembers` that also injects a custom TimeProvider —
-/// useful for testing handlers that need both a non-default member (e.g. a
-/// custom goal range) and control over the current time (e.g. trends windows).
+/// useful for testing handlers that need both a non-default member (e.g., a
+/// custom goal range) and control over the current time (e.g., trends windows).
 let contextWithMembersAndProvider
   (repo: IReadingRepository)
   (members: FamilyMember list)

--- a/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
@@ -154,7 +154,7 @@ let ``trendsPanel with gran=monthly returns monthly sub-period buttons`` () =
 let ``trendsPanel with gran + key uses that specific sub-period`` () =
   let tp = FakeTimeProvider(trendsNow)
 
-  // Reading in W23 (last week: 2026-06-01 .. 2026-06-07)
+  // Reading in W23 (last week: 2026-06-01 ... 2026-06-07)
   let r =
     { sample with
         Timestamp = Timestamp.utc 2026 6 3 9 0 0 // W23

--- a/code/BpMonitor.Web.Tests/ViewTests.fs
+++ b/code/BpMonitor.Web.Tests/ViewTests.fs
@@ -65,7 +65,7 @@ let ``landing renders action buttons for trends, recent, settings and both expor
 let ``landing export action buttons do not get hx-boosted`` () =
   let html = renderHtml (ReadingViews.landing defaultMember)
   // the sidebar already carries hx-boost="false" on its two export links;
-  // the landing action buttons must add two more, not rely on the sidebar's.
+  // the landing action buttons must add two more, not rely on the sidebar.
   test <@ occurrences "hx-boost=\"false\"" html = 4 @>
 
 [<Fact>]

--- a/code/BpMonitor.Web/AuthHandlers.fs
+++ b/code/BpMonitor.Web/AuthHandlers.fs
@@ -73,7 +73,7 @@ module AuthHandlers =
         handler ctx
 
   /// Resolves the authenticated member and passes it to `handler`. If the member
-  /// cannot be resolved (e.g. stale principal after account removal) redirects to
+  /// cannot be resolved (e.g., stale principal after account removal), redirects to
   /// /login instead of throwing. Mirrors `protect` but hands the member to the handler.
   let withMember (handler: FamilyMember -> HttpContext -> Task) : HttpContext -> Task =
     fun ctx ->
@@ -90,7 +90,7 @@ module AuthHandlers =
   let loginPage: HttpContext -> Task =
     fun ctx -> htmlResponse (LoginViews.loginPage []) ctx
 
-  // `onFailure` lets callers choose what to render on a bad password (loginPage vs loginMember).
+  // `onFailure` lets callers choose what to render on a bad password (loginPage vs. loginMember).
   let private claimedLogin
     (m: FamilyMember)
     (password: string)

--- a/code/BpMonitor.Web/Binding.fs
+++ b/code/BpMonitor.Web/Binding.fs
@@ -42,7 +42,7 @@ module Binding =
     | _ -> Error $"Timestamp: '{s}' is not a valid date/time"
 
   /// Parse-level conversion. Returns the unvalidated reading or the list of
-  /// parse errors (range checks happen afterwards via BloodPressureReading.parse).
+  /// parse errors (range checks happen afterward via BloodPressureReading.parse).
   let toUnvalidated (m: FormModel) : Validation<BloodPressureReadingUnvalidated, string> =
     validation {
       let! sys = tryInt "Systolic" m.Systolic |> Validation.ofResult

--- a/code/BpMonitor.Web/HandlerHelpers.fs
+++ b/code/BpMonitor.Web/HandlerHelpers.fs
@@ -78,7 +78,7 @@ module HandlerHelpers =
   let sortedReadings (memberId: int) (ctx: HttpContext) =
     (repo ctx).GetAll(memberId) |> List.sortByDescending _.Timestamp
 
-  /// Resolves the "id" route segment to an int, logging and returning 400 for a non-integer id.
+  /// Resolves the "id" route segment to an int, logging and returning 400 for a noninteger id.
   let withRouteId (handlerName: string) (handler: int -> HttpContext -> Task) : HttpContext -> Task =
     fun ctx ->
       let log = logger ctx
@@ -95,7 +95,7 @@ module HandlerHelpers =
       | Some id -> handler id ctx
 
   /// Resolves the "id" route segment to a FamilyMember, logging and returning
-  /// 400 for a non-integer id or 404 when no member with that id exists.
+  /// 400 for a noninteger id or 404 when no member with that id exists.
   let withRouteMember (handlerName: string) (handler: FamilyMember -> HttpContext -> Task) : HttpContext -> Task =
     fun ctx ->
       let log = logger ctx

--- a/code/BpMonitor.Web/MemberHandlers.fs
+++ b/code/BpMonitor.Web/MemberHandlers.fs
@@ -110,4 +110,4 @@ module MemberHandlers =
       (memberRepo ctx).Update({ m with PasswordHash = None })
       log.LogInformation("Admin reset password for member {Name} (Id={Id})", m.Name, m.Id)
       ctx.Response.Redirect Routes.members
-      System.Threading.Tasks.Task.CompletedTask)
+      Task.CompletedTask)

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -11,7 +11,7 @@ module ReadingViews =
       [ Attr.href href; Attr.role "button" ]
       [ Elem.span [ Attr.class' "icon" ] [ Text.raw glyph ]; Text.raw label ]
 
-  /// Same as `actionButton`, but opts the link out of hx-boost so file-download
+  /// Same as `actionButton`, but opts the link out of hx-boost, so file-download
   /// responses (exports) aren't AJAX-swapped into the page.
   let private downloadActionButton (href: string) (glyph: string) (label: string) : XmlNode =
     Elem.a
@@ -39,7 +39,7 @@ module ReadingViews =
             if m.IsAdmin then
               actionButton Routes.members "👥" "Members" ] ]
 
-  /// History: chart above the readings table.
+  /// History: chart above the readings' table.
   let history (activeMember: FamilyMember) (chartHtml: string) (readings: BloodPressureReading list) : XmlNode =
     ViewLayout.layout
       Routes.history

--- a/code/BpMonitor.Web/TrendViews.fs
+++ b/code/BpMonitor.Web/TrendViews.fs
@@ -7,7 +7,7 @@ open BpMonitor.Core
 module TrendViews =
   /// The swappable panel: granularity toggle + sub-period strip + stats + inline chart.
   /// Rendered as a fragment for htmx swaps (GET /trends/{gran} and GET /trends/{gran}/{key});
-  /// also used directly by the full /trends page so the buttons are always inside the swapped region.
+  /// also used directly by the full /trends page, so the buttons are always inside the swapped region.
   let trendsPanel
     (summary: WindowSummary)
     (periods: TrendPeriod list)

--- a/code/BpMonitor.Web/Version.fs
+++ b/code/BpMonitor.Web/Version.fs
@@ -6,7 +6,7 @@ module Version =
   open System
   open System.Reflection
 
-  /// Normalise a raw InformationalVersion string to a display version.
+  /// Normalize a raw InformationalVersion string to a display version.
   /// The .NET SDK appends +<sha> to the default "1.0.0" in git repos, so strip
   /// the suffix before checking the sentinel — but keep it for real versions.
   let parse (raw: string option) : string =

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -33,7 +33,7 @@ module ViewLayout =
       []
 
   /// Shared <head> element. `extras` allows callers to append additional nodes
-  /// (e.g. the htmx script that only the authenticated layout needs).
+  /// (e.g., the htmx script that only the authenticated layout needs).
   let private htmlHead (title: string) (extras: XmlNode list) : XmlNode =
     Elem.head
       []
@@ -42,7 +42,7 @@ module ViewLayout =
          Elem.title [] [ Text.raw title ]
          Elem.link [ Attr.rel "icon"; Attr.href "/favicon.svg"; Attr.type' "image/svg+xml" ]
          // Runs once on initial load; survives hx-boost navigations because it lives in <head>.
-         // No defer/async — render-blocking prevents flash of wrong theme (FOUC).
+         // No defer/async — render-blocking prevents flash of the wrong theme (FOUC).
          Elem.script [ Attr.src "/theme.js" ] []
          Elem.link [ Attr.rel "stylesheet"; Attr.href "/pico.min.css" ]
          Elem.link [ Attr.rel "stylesheet"; Attr.href "/app.css" ]
@@ -159,7 +159,7 @@ module ViewLayout =
       [ Elem.label [ Attr.for' name ] [ Text.raw labelText ]
         Elem.input [ Attr.type' inputType; Attr.id name; Attr.name name; Attr.value value ] ]
 
-  /// The readings table; wrapped in an id'd container so it can be targeted for
+  /// The readings' table; wrapped in an id'd container so it can be targeted for
   /// partial swaps later.
   let readingsTable (readings: BloodPressureReading list) : XmlNode =
     let header =

--- a/code/BpMonitor.sln.DotSettings
+++ b/code/BpMonitor.sln.DotSettings
@@ -2,6 +2,9 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=errorbar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=errorbars/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=granularities/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=htmx/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lowess/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=redisplays/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Wegier/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=xaxis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=yerror/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
## Summary
- Removes redundant type qualifiers and `sprintf`/`.[n]` indexer usage in favor of interpolated strings and `[n]`
- Tightens comma usage and spelling in comments/docs
- Adds a few words to the solution dictionary