### PR TITLE
🔧 chore: extract inline JS from views into dedicated wwwroot files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ dotnet test --configuration Release --max-parallel-test-modules 2
 
 All non-dotnet linter versions are pinned in `mise.toml` (repo root); it also hosts one-time dev setup tasks like the Playwright Chromium install. Run `mise install` once after cloning.
 
-- `biome.json` — Biome JS linter config (scoped to `wwwroot/theme.js` and `wwwroot/theme-label.js`)
+- `biome.json` — Biome JS linter config (scoped to `wwwroot/theme.js`, `wwwroot/theme-label.js`, `wwwroot/recent-scrubber.js`, `wwwroot/trends-scroll.js`)
 - `.markdownlint-cli2.yaml` — markdownlint config
 - Run `mise run lint` to run all non-dotnet linters; `mise run lint:js` / `lint:md` / `lint:shell` individually
 - Run `mise run test:e2e-setup` once locally before the first `BpMonitor.Web.E2E.Tests` run (installs Playwright's Chromium)

--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,9 @@
   "files": {
     "includes": [
       "code/BpMonitor.Web/wwwroot/theme.js",
-      "code/BpMonitor.Web/wwwroot/theme-label.js"
+      "code/BpMonitor.Web/wwwroot/theme-label.js",
+      "code/BpMonitor.Web/wwwroot/recent-scrubber.js",
+      "code/BpMonitor.Web/wwwroot/trends-scroll.js"
     ]
   },
   "linter": {

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -265,17 +265,19 @@ let ``recent value strip tags each cell with the reading's chart x-label, for th
   test <@ body.Contains $"data-x=\"{expectedX2}\"" @>
 
 [<Fact>]
-let ``recent chart wires a relayout listener to keep the value strip in sync with the x-axis`` () =
+let ``recent page loads the scrubber script that keeps the value strip in sync with the x-axis`` () =
   // TODOs.md: "Recent: when zooming/paning keep the value-strip in sync with the
   // displayed x-axis". On zoom/pan the chart's x-range narrows; the value strip needs
-  // to hide columns outside that range to stay aligned with what's plotted.
+  // to hide columns outside that range to stay aligned with what's plotted. The
+  // relayout-listener wiring itself now lives in wwwroot/recent-scrubber.js (loaded
+  // globally by ViewLayout); this just guards that the page references it.
   let tp = FakeTimeProvider(now)
   let ctx = TestHost.contextWithProvider (repoWith [ reading 1 1 ]) tp
   TestHost.run ReadingHandlers.recent ctx
 
   let body = TestHost.readBody ctx
 
-  test <@ body.Contains "plotly_relayout" @>
+  test <@ body.Contains "/recent-scrubber.js" @>
 
 [<Fact>]
 let ``recent value strip marks a reading above the goal range as 'above'`` () =

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -109,53 +109,8 @@ module ReadingViews =
 
     // Fig. 5's scrubber bar (Wegier et al. 2021): the chart's x-axis spike (Charts.fs
     // `recentXAxis`) already draws the moving vertical line; this links it to the value
-    // strip by boxing the hovered column. Follows the same poll-until-ready pattern as
-    // the chart's own errorBarScript (Charts.fs `errorBarScript`).
-    // TODOs.md: keep the value strip in sync with the chart's x-axis when zooming/panning.
-    // `plotly_relayout` fires with `xaxis.range[0]`/`[1]` on zoom/pan, or `xaxis.autorange`
-    // on a reset (e.g. double-click). Columns whose data-x falls outside the new range get
-    // `out-of-range` (display:none in app.css), so the fixed-layout table redistributes the
-    // remaining columns to stay aligned with what the chart is showing.
-    let scrubberScript =
-      Text.raw (
-        "<script>(function(){"
-        + "function setup(){"
-        + "var d=document.querySelector('.js-plotly-plot');"
-        + "if(!d||!d.on){setTimeout(setup,50);return;}"
-        + "d.on('plotly_hover',function(e){"
-        + "var x=e.points[0].x;"
-        + "document.querySelectorAll('.value-strip td.scrubbed').forEach(function(c){c.classList.remove('scrubbed');});"
-        + "document.querySelectorAll('.value-strip td[data-x=\"'+x+'\"]').forEach(function(c){c.classList.add('scrubbed');});"
-        + "});"
-        + "d.on('plotly_unhover',function(){"
-        + "document.querySelectorAll('.value-strip td.scrubbed').forEach(function(c){c.classList.remove('scrubbed');});"
-        + "});"
-        + "d.on('plotly_relayout',function(e){"
-        + "var cells=document.querySelectorAll('.value-strip td[data-x]');"
-        + "var lo=e['xaxis.range[0]'],hi=e['xaxis.range[1]'];"
-        + "if(lo===undefined&&Array.isArray(e['xaxis.range'])){lo=e['xaxis.range'][0];hi=e['xaxis.range'][1];}"
-        + "if(lo===undefined&&e['xaxis.autorange']===undefined&&d.layout&&d.layout.xaxis){"
-        + "if(d.layout.xaxis.autorange){lo=undefined;}"
-        + "else if(d.layout.xaxis.range){lo=d.layout.xaxis.range[0];hi=d.layout.xaxis.range[1];}"
-        + "}"
-        + "if(lo===undefined||hi===undefined){"
-        + "cells.forEach(function(c){c.classList.remove('out-of-range');});"
-        + "return;"
-        + "}"
-        + "var loT=new Date(String(lo).replace(' ','T')).getTime();"
-        + "var hiT=new Date(String(hi).replace(' ','T')).getTime();"
-        + "if(isNaN(loT)||isNaN(hiT))return;"
-        + "cells.forEach(function(c){"
-        + "var t=new Date(c.dataset.x.replace(' ','T')).getTime();"
-        + "if(isNaN(t))return;"
-        + "c.classList.toggle('out-of-range',t<loT||t>hiT);"
-        + "});"
-        + "});"
-        + "}"
-        + "setTimeout(setup,0);"
-        + "})()</script>"
-      )
-
+    // strip by boxing the hovered column. Behavior lives in wwwroot/recent-scrubber.js
+    // (loaded globally by ViewLayout, self-guards on `.value-strip`'s presence).
     ViewLayout.layout
       Routes.recent
       activeMember.Name
@@ -164,9 +119,7 @@ module ReadingViews =
       [ Elem.h1 [] [ Text.raw "Recent" ]
         Elem.div
           [ Attr.class' "chart-container" ]
-          [ valueStrip
-            Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ]
-            scrubberScript ] ]
+          [ valueStrip; Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ] ]
 
   /// Shared add/edit form. `action` is the POST target; `errors` are rendered
   /// above the fields when re-displaying after a failed submit.

--- a/code/BpMonitor.Web/TrendViews.fs
+++ b/code/BpMonitor.Web/TrendViews.fs
@@ -101,12 +101,9 @@ module TrendViews =
       [ Attr.id "trends-panel" ]
       [ Elem.div [ Attr.class' "trends-window-buttons" ] ([ Weekly; Monthly; Yearly ] |> List.map granButton)
         Elem.div [ Attr.class' "trends-subperiod-buttons" ] (periods |> List.map periodButton)
-        yield! content
-        // Scroll the active sub-period pill into view (runs after htmx swaps in this fragment).
-        Elem.script
-          []
-          [ Text.raw
-              "(function(){var a=document.querySelector('.trends-subperiod-buttons [aria-current=\"page\"]');if(a)a.scrollIntoView({inline:'nearest',block:'nearest'});})()" ] ]
+        // Active sub-period pill is scrolled into view by wwwroot/trends-scroll.js
+        // (loaded globally by ViewLayout, re-runs on htmx:afterSettle for this swap).
+        yield! content ]
 
   /// The /trends full page. Pre-renders the Weekly/current panel (including toggle buttons).
   let trends

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -44,6 +44,10 @@ module ViewLayout =
          // Runs once on initial load; survives hx-boost navigations because it lives in <head>.
          // No defer/async — render-blocking prevents flash of the wrong theme (FOUC).
          Elem.script [ Attr.src "/theme.js" ] []
+         // Behavior-only (no FOUC concern); each self-guards on the page elements it
+         // needs and re-runs on htmx:afterSettle to survive hx-boost swaps.
+         Elem.script [ Attr.src "/recent-scrubber.js" ] []
+         Elem.script [ Attr.src "/trends-scroll.js" ] []
          Elem.link [ Attr.rel "stylesheet"; Attr.href "/pico.min.css" ]
          Elem.link [ Attr.rel "stylesheet"; Attr.href "/app.css" ]
          // Vendored from Plotly.NET's embedded resource (see scripts/extract-plotly-js.fsx) —

--- a/code/BpMonitor.Web/wwwroot/recent-scrubber.js
+++ b/code/BpMonitor.Web/wwwroot/recent-scrubber.js
@@ -1,0 +1,83 @@
+// Fig. 5's scrubber bar (Wegier et al. 2021): the chart's x-axis spike (Charts.fs
+// `recentXAxis`) already draws the moving vertical line; this links it to the value
+// strip by boxing the hovered column. Follows the same poll-until-ready pattern as
+// the chart's own errorBarScript (BpMonitor.Charts/Charts.fs).
+//
+// The strip lists every loaded reading (the chart's load window — bounded but wider
+// than the visible focus). Each cell is tagged with the same x-label the chart uses
+// for that reading (Charts.fs `seriesOf` formats x as Formats.formatLocal r.Timestamp),
+// so a hovered chart point can be matched back to its strip column via `data-x`.
+//
+// Columns outside the visible focus window start hidden via `out-of-range` (see
+// ReadingViews.fs `valueStrip`); `plotly_relayout` fires with `xaxis.range[0]`/`[1]`
+// on zoom/pan, or `xaxis.autorange` on a reset (e.g. double-click), and this keeps
+// the value strip in sync as the user pans/zooms the chart.
+function setupRecentScrubber() {
+  if (!document.querySelector(".value-strip")) return;
+
+  function setup() {
+    var d = document.querySelector(".js-plotly-plot");
+    if (!d?.on) {
+      setTimeout(setup, 50);
+      return;
+    }
+
+    d.on("plotly_hover", (e) => {
+      var x = e.points[0].x;
+      document.querySelectorAll(".value-strip td.scrubbed").forEach((c) => {
+        c.classList.remove("scrubbed");
+      });
+      document.querySelectorAll(`.value-strip td[data-x="${x}"]`).forEach((c) => {
+        c.classList.add("scrubbed");
+      });
+    });
+
+    d.on("plotly_unhover", () => {
+      document.querySelectorAll(".value-strip td.scrubbed").forEach((c) => {
+        c.classList.remove("scrubbed");
+      });
+    });
+
+    d.on("plotly_relayout", (e) => {
+      var cells = document.querySelectorAll(".value-strip td[data-x]");
+      var lo = e["xaxis.range[0]"];
+      var hi = e["xaxis.range[1]"];
+
+      if (lo === undefined && Array.isArray(e["xaxis.range"])) {
+        lo = e["xaxis.range"][0];
+        hi = e["xaxis.range"][1];
+      }
+
+      if (lo === undefined && e["xaxis.autorange"] === undefined && d.layout?.xaxis) {
+        if (d.layout.xaxis.autorange) {
+          lo = undefined;
+        } else if (d.layout.xaxis.range) {
+          lo = d.layout.xaxis.range[0];
+          hi = d.layout.xaxis.range[1];
+        }
+      }
+
+      if (lo === undefined || hi === undefined) {
+        cells.forEach((c) => {
+          c.classList.remove("out-of-range");
+        });
+        return;
+      }
+
+      var loT = new Date(String(lo).replace(" ", "T")).getTime();
+      var hiT = new Date(String(hi).replace(" ", "T")).getTime();
+      if (Number.isNaN(loT) || Number.isNaN(hiT)) return;
+
+      cells.forEach((c) => {
+        var t = new Date(c.dataset.x.replace(" ", "T")).getTime();
+        if (Number.isNaN(t)) return;
+        c.classList.toggle("out-of-range", t < loT || t > hiT);
+      });
+    });
+  }
+
+  setTimeout(setup, 0);
+}
+
+document.addEventListener("DOMContentLoaded", setupRecentScrubber);
+document.addEventListener("htmx:afterSettle", setupRecentScrubber);

--- a/code/BpMonitor.Web/wwwroot/trends-scroll.js
+++ b/code/BpMonitor.Web/wwwroot/trends-scroll.js
@@ -1,0 +1,11 @@
+// Scrolls the active sub-period pill into view. The trends panel is an htmx-swapped
+// fragment, so this re-runs on htmx:afterSettle (not just DOMContentLoaded) to catch
+// every swap — same pattern as theme.js for surviving hx-boost navigations.
+function scrollActiveSubPeriodIntoView() {
+  if (!document.querySelector(".trends-subperiod-buttons")) return;
+  var active = document.querySelector('.trends-subperiod-buttons [aria-current="page"]');
+  if (active) active.scrollIntoView({ inline: "nearest", block: "nearest" });
+}
+
+document.addEventListener("DOMContentLoaded", scrollActiveSubPeriodIntoView);
+document.addEventListener("htmx:afterSettle", scrollActiveSubPeriodIntoView);


### PR DESCRIPTION
## Summary

Extracted two inline `<script>` blocks from server-rendered F# views into static assets (`wwwroot/recent-scrubber.js` and `wwwroot/trends-scroll.js`), following the existing `theme.js` pattern. This improves readability, enables biome linting/syntax highlighting, and removes error-prone string concatenation.

- **Scrubber bar** (ReadingViews.fs): `plotly_hover`/`unhover`/`relayout` listener that keeps the value-strip table in sync with chart hover and zoom/pan
- **Trends scroll** (TrendViews.fs): scrolls the active sub-period pill into view after htmx fragment swaps

Both scripts load globally in `<head>` (via ViewLayout), self-guard on their target elements' presence, and re-run on `htmx:afterSettle` to survive hx-boost navigations. Left `BpMonitor.Charts/errorBarScript` untouched (coupled to chart HTML, stays a library concern).

**Behavior unchanged.** Tests updated to assert script references instead of inline text. All 391 tests passing; biome lint clean. Verified via E2E that hover/unhover scrubbing, relayout out-of-range toggling, and trends-scroll behavior all work identically to before.