### PR TITLE
🎨 style: reduce trend trace line thickness in recent chart

### DIFF
--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -538,7 +538,7 @@ module BpChart =
       let smoothed = Lowess.smooth lowessBandwidth xs (values |> List.map float)
 
       [ Chart.Line(x = labels, y = smoothed, Name = name, ShowLegend = true)
-        |> Chart.withLineStyle (Color = color, Width = 3.5)
+        |> Chart.withLineStyle (Color = color, Width = 2.5)
         // The smoothed value is derived, not measured — skip its hover entry in the
         // /recent chart's unified hover so the tooltip only ever shows real readings.
         |> GenericChart.mapTrace (Trace2DStyle.Scatter(HoverInfo = StyleParam.HoverInfo.Skip)) ]


### PR DESCRIPTION
## Summary
- Thins the LOWESS trend line in the `/recent` chart from `Width = 3.5` to `2.5` for a lighter visual weight.