### PR TITLE
✨ feat: add "Last 7/30 days" zoom shortcut buttons to the recent chart

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,7 @@
       "code/BpMonitor.Web/wwwroot/theme.js",
       "code/BpMonitor.Web/wwwroot/theme-label.js",
       "code/BpMonitor.Web/wwwroot/recent-scrubber.js",
+      "code/BpMonitor.Web/wwwroot/recent-zoom.js",
       "code/BpMonitor.Web/wwwroot/trends-scroll.js"
     ]
   },

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -302,6 +302,22 @@ let ``recent value strip marks a reading below the goal range as 'below'`` () =
   test <@ body.Contains "value-strip-value below" @>
 
 [<Fact>]
+let ``recent renders zoom shortcut buttons for the last 7 and 30 days, anchored to now`` () =
+  let tp = FakeTimeProvider(now)
+  let ctx = TestHost.contextWithProvider (repoWith []) tp
+  TestHost.run ReadingHandlers.recent ctx
+
+  let body = TestHost.readBody ctx
+  let hi = Formats.formatLocal now
+  let lo7 = Formats.formatLocal (now.AddDays(-7.0))
+  let lo30 = Formats.formatLocal (now.AddDays(-30.0))
+
+  test <@ body.Contains $"data-lo=\"{lo7}\" data-hi=\"{hi}\"" @>
+  test <@ body.Contains $"data-lo=\"{lo30}\" data-hi=\"{hi}\"" @>
+  test <@ body.Contains "Last 7 days" @>
+  test <@ body.Contains "Last 30 days" @>
+
+[<Fact>]
 let ``recent value strip leaves an in-range reading's cells unmarked`` () =
   // reading helper's defaults (Systolic = 120, Diastolic = 80) are inside GoalRange.defaults.
   let r = reading 1 1

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -83,6 +83,11 @@ module ReadingHandlers =
   // account age. A year is generous for panning while keeping both bounded.
   let private recentLoadWindowDays = 365
 
+  // Shortcut buttons rendered above the chart (ReadingViews.fs `zoomButtons`); adding a
+  // new shortcut only means adding an entry here, not touching either function's signature.
+  let private recentZoomShortcutDays =
+    [ "Last 7 days", 7.0; "Last 30 days", float recentChartWindowDays ]
+
   let recent: HttpContext -> Task =
     withMember (fun m ctx ->
       let now = (timeProvider ctx).GetUtcNow()
@@ -96,7 +101,7 @@ module ReadingHandlers =
       let chartHtml =
         BpChart.toHtmlRecent m.Goal recentChartWindowDays windowStart now loadedReadings
 
-      htmlResponse (ReadingViews.recent m chartHtml loadedReadings windowStart) ctx)
+      htmlResponse (ReadingViews.recent m chartHtml loadedReadings windowStart now recentZoomShortcutDays) ctx)
 
   let trends: HttpContext -> Task =
     withMember (fun m ctx ->

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -59,6 +59,8 @@ module ReadingViews =
     (chartHtml: string)
     (allReadings: BloodPressureReading list)
     (windowStart: System.DateTimeOffset)
+    (now: System.DateTimeOffset)
+    (zoomShortcutDays: (string * float) list)
     : XmlNode =
     let valueStrip =
       // The strip lists every loaded reading (the chart's load window, see ReadingHandlers
@@ -107,6 +109,25 @@ module ReadingViews =
                 [ row "Systolic" _.Systolic (GoalRange.classifySystolic activeMember.Goal)
                   row "Diastolic" _.Diastolic (GoalRange.classifyDiastolic activeMember.Goal) ] ] ]
 
+    // Shortcut buttons that snap the chart's x-axis to a fixed window via
+    // Plotly.relayout (wwwroot/recent-zoom.js). Each button's range is rendered
+    // server-side from the same `now` the handler passed to the chart, so the format
+    // (Formats.formatLocal) and anchor always match exactly. The existing
+    // recent-scrubber.js `plotly_relayout` listener re-syncs the value strip's
+    // out-of-range cells automatically when relayout fires.
+    let hiFormatted = Formats.formatLocal now
+
+    let zoomButton (label: string) (days: float) =
+      Elem.button
+        [ Attr.type' "button"
+          Attr.class' "recent-zoom-button"
+          Attr.create "data-lo" (Formats.formatLocal (now.AddDays(-days)))
+          Attr.create "data-hi" hiFormatted ]
+        [ Text.raw label ]
+
+    let zoomButtons =
+      Elem.div [ Attr.class' "recent-zoom-buttons" ] [ for label, days in zoomShortcutDays -> zoomButton label days ]
+
     // Fig. 5's scrubber bar (Wegier et al. 2021): the chart's x-axis spike (Charts.fs
     // `recentXAxis`) already draws the moving vertical line; this links it to the value
     // strip by boxing the hovered column. Behavior lives in wwwroot/recent-scrubber.js
@@ -119,7 +140,9 @@ module ReadingViews =
       [ Elem.h1 [] [ Text.raw "Recent" ]
         Elem.div
           [ Attr.class' "chart-container" ]
-          [ valueStrip; Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ] ]
+          [ zoomButtons
+            valueStrip
+            Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ] ]
 
   /// Shared add/edit form. `action` is the POST target; `errors` are rendered
   /// above the fields when re-displaying after a failed submit.

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -47,6 +47,7 @@ module ViewLayout =
          // Behavior-only (no FOUC concern); each self-guards on the page elements it
          // needs and re-runs on htmx:afterSettle to survive hx-boost swaps.
          Elem.script [ Attr.src "/recent-scrubber.js" ] []
+         Elem.script [ Attr.src "/recent-zoom.js" ] []
          Elem.script [ Attr.src "/trends-scroll.js" ] []
          Elem.link [ Attr.rel "stylesheet"; Attr.href "/pico.min.css" ]
          Elem.link [ Attr.rel "stylesheet"; Attr.href "/app.css" ]

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -655,15 +655,20 @@ form.inline button {
 
 /* ── Trends page ────────────────────────────────────────────────────────── */
 
-/* Granularity selector row (Weekly / Monthly / Yearly) */
-.trends-window-buttons {
+/* Granularity selector row (Weekly / Monthly / Yearly). Shared with the Recent
+   page's zoom-shortcut row (ReadingViews.fs `zoomButtons`,
+   wwwroot/recent-zoom.js) — same pill layout, just an <a role="button"> here
+   vs a <button> there. */
+.trends-window-buttons,
+.recent-zoom-buttons {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
   margin-bottom: 0.75rem;
 }
 
-.trends-window-buttons a[role="button"] {
+.trends-window-buttons a[role="button"],
+.recent-zoom-buttons button {
   padding: 0.25rem 0.9rem;
   font-size: 0.9rem;
   margin: 0;

--- a/code/BpMonitor.Web/wwwroot/recent-zoom.js
+++ b/code/BpMonitor.Web/wwwroot/recent-zoom.js
@@ -1,0 +1,29 @@
+// "Last 7 days" / "Last 30 days" shortcut buttons (ReadingViews.fs `zoomButtons`).
+// Each button carries its target range as data-lo/data-hi (server-rendered via
+// Formats.formatLocal, anchored to the same `now` the chart's own initial range
+// uses), so clicking it just replays the chart's own range format through
+// Plotly.relayout — same call pattern as theme.js. The existing plotly_relayout
+// listener in recent-scrubber.js re-syncs the value strip automatically.
+function setupRecentZoomButtons() {
+  var buttons = document.querySelectorAll(".recent-zoom-button");
+  if (buttons.length === 0) return;
+
+  function setup() {
+    var d = document.querySelector(".js-plotly-plot");
+    if (!d?.on) {
+      setTimeout(setup, 50);
+      return;
+    }
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        Plotly.relayout(d, { "xaxis.range": [button.dataset.lo, button.dataset.hi] });
+      });
+    });
+  }
+
+  setup();
+}
+
+document.addEventListener("DOMContentLoaded", setupRecentZoomButtons);
+document.addEventListener("htmx:afterSettle", setupRecentZoomButtons);


### PR DESCRIPTION
## Summary
- Adds "Last 7 days" / "Last 30 days" shortcut buttons above the Recent chart that snap the x-axis to a fixed window via `Plotly.relayout`
- Each button's range is rendered server-side from the same `now`/window values the chart itself uses, so the format and anchor always match exactly
- Shared button-row styling consolidated with the Trends page's existing granularity selector (`.trends-window-buttons`)