### PR TITLE
✨ feat: add Wegier et al. 2021 citation below the recent chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Recent chart: added a caption crediting the Wegier et al. 2021 paper the chart layout is based on, linking to its DOI
+
 ### Changed
 
 - History and Recent charts: comment markers now render as a dark-red hexagon (matching Wegier et al. 2021's Fig. 5) instead of a teal circle, sit on a y-axis baseline labeled "Comments", and are no longer clipped by the x-axis

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -142,7 +142,11 @@ module ReadingViews =
           [ Attr.class' "chart-container" ]
           [ zoomButtons
             valueStrip
-            Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ] ] ]
+            Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ]
+            Elem.p
+              [ Attr.class' "chart-citation" ]
+              [ Text.raw "Chart layout inspired by "
+                Elem.a [ Attr.href "https://doi.org/10.1186/s12911-021-01598-4" ] [ Text.raw "Wegier et al. 2021" ] ] ] ]
 
   /// Shared add/edit form. `action` is the POST target; `errors` are rendered
   /// above the fields when re-displaying after a failed submit.

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -573,6 +573,13 @@ form.inline button {
   width: 100%;
 }
 
+/* Caption crediting the Fig. 5 chart layout this page's design is based on. */
+.chart-citation {
+  margin-top: 0.5rem;
+  font-size: 0.65rem;
+  color: var(--pico-muted-color);
+}
+
 /* Fig. 5-style "Blood Pressure Values" strip: a 2-row data table (Systolic/
    Diastolic) listing every value currently shown in the chart window. Fixed
    table layout stretches to the same width as the chart below it and


### PR DESCRIPTION
## Summary

- Adds a caption below the Recent chart crediting Wegier et al. 2021, whose Fig. 5 layout this chart is based on. The author text links to the paper's DOI.