### PR TITLE
✨ feat: make trends sub-period pills compact with horizontal scrolling

### DIFF
--- a/code/BpMonitor.Web/TrendViews.fs
+++ b/code/BpMonitor.Web/TrendViews.fs
@@ -100,9 +100,11 @@ module TrendViews =
     Elem.div
       [ Attr.id "trends-panel" ]
       [ Elem.div [ Attr.class' "trends-window-buttons" ] ([ Weekly; Monthly; Yearly ] |> List.map granButton)
-        Elem.div [ Attr.class' "trends-subperiod-buttons" ] (periods |> List.map periodButton)
-        // Active sub-period pill is scrolled into view by wwwroot/trends-scroll.js
-        // (loaded globally by ViewLayout, re-runs on htmx:afterSettle for this swap).
+        // Scroller wrapper hosts the edge-fade overlays (CSS) and is read by
+        // wwwroot/trends-scroll.js to toggle them and to center the active pill.
+        Elem.div
+          [ Attr.class' "trends-subperiod-scroller" ]
+          [ Elem.div [ Attr.class' "trends-subperiod-buttons" ] (periods |> List.map periodButton) ]
         yield! content ]
 
   /// The /trends full page. Pre-renders the Weekly/current panel (including toggle buttons).

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -703,6 +703,45 @@ form.inline button {
   border-color: var(--pico-primary);
 }
 
+/* Sub-period scroller — caps the row to roughly 5 natural-width pills so it stays
+   compact instead of stretching full-width; the rest scroll into view. Hosts the
+   edge-fade overlays below, which must sit on a non-scrolling parent. */
+.trends-subperiod-scroller {
+  position: relative;
+  max-width: min(100%, 30rem);
+  margin-bottom: 1.5rem;
+}
+
+/* Edge fades — hint that more pills exist off-screen. Hidden by default, shown via
+   .can-scroll-left/.can-scroll-right (toggled by wwwroot/trends-scroll.js). */
+.trends-subperiod-scroller::before,
+.trends-subperiod-scroller::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1.5rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 1;
+}
+
+.trends-subperiod-scroller::before {
+  left: 0;
+  background: linear-gradient(to right, var(--pico-background-color), transparent);
+}
+
+.trends-subperiod-scroller::after {
+  right: 0;
+  background: linear-gradient(to left, var(--pico-background-color), transparent);
+}
+
+.trends-subperiod-scroller.can-scroll-left::before,
+.trends-subperiod-scroller.can-scroll-right::after {
+  opacity: 1;
+}
+
 /* Sub-period pill row — horizontally scrollable, no wrapping */
 .trends-subperiod-buttons {
   display: flex;
@@ -710,7 +749,6 @@ form.inline button {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   gap: 0.5rem;
-  margin-bottom: 1.5rem;
   padding-bottom: 0.25rem; /* keep scrollbar from clipping pill border */
 }
 

--- a/code/BpMonitor.Web/wwwroot/trends-scroll.js
+++ b/code/BpMonitor.Web/wwwroot/trends-scroll.js
@@ -1,11 +1,44 @@
-// Scrolls the active sub-period pill into view. The trends panel is an htmx-swapped
-// fragment, so this re-runs on htmx:afterSettle (not just DOMContentLoaded) to catch
-// every swap — same pattern as theme.js for surviving hx-boost navigations.
+// Scrolls the active sub-period pill into view, centered in the ~5-pill window. The
+// trends panel is an htmx-swapped fragment, so this re-runs on htmx:afterSettle (not
+// just DOMContentLoaded) to catch every swap — same pattern as theme.js for surviving
+// hx-boost navigations.
 function scrollActiveSubPeriodIntoView() {
-  if (!document.querySelector(".trends-subperiod-buttons")) return;
-  var active = document.querySelector('.trends-subperiod-buttons [aria-current="page"]');
-  if (active) active.scrollIntoView({ inline: "nearest", block: "nearest" });
+  var row = document.querySelector(".trends-subperiod-buttons");
+  if (!row) return;
+  var active = row.querySelector('[aria-current="page"]');
+  if (active) active.scrollIntoView({ inline: "center", block: "nearest" });
 }
 
-document.addEventListener("DOMContentLoaded", scrollActiveSubPeriodIntoView);
-document.addEventListener("htmx:afterSettle", scrollActiveSubPeriodIntoView);
+// Toggles edge-fade affordances (CSS, app.css `.trends-subperiod-scroller`) on the
+// non-scrolling wrapper based on how far the pill row has been scrolled.
+function updateSubPeriodFades() {
+  var row = document.querySelector(".trends-subperiod-buttons");
+  var scroller = document.querySelector(".trends-subperiod-scroller");
+  if (!row || !scroller) return;
+
+  var tolerancePx = 1;
+  var canScrollLeft = row.scrollLeft > tolerancePx;
+  var canScrollRight = row.scrollLeft + row.clientWidth < row.scrollWidth - tolerancePx;
+
+  scroller.classList.toggle("can-scroll-left", canScrollLeft);
+  scroller.classList.toggle("can-scroll-right", canScrollRight);
+}
+
+function refreshSubPeriodScroller() {
+  scrollActiveSubPeriodIntoView();
+  updateSubPeriodFades();
+}
+
+document.addEventListener("DOMContentLoaded", refreshSubPeriodScroller);
+document.addEventListener("htmx:afterSettle", refreshSubPeriodScroller);
+window.addEventListener("resize", updateSubPeriodFades);
+
+document.addEventListener(
+  "scroll",
+  (event) => {
+    if (event.target?.classList?.contains("trends-subperiod-buttons")) {
+      updateSubPeriodFades();
+    }
+  },
+  true,
+);


### PR DESCRIPTION
## Summary

- Cap the sub-period pill row to ~5 natural-width pills (max-width: 30rem) instead of stretching full-width on desktop
- Pills beyond the visible window are scrollable via swipe/drag on all screen sizes
- Soft gradient edge fades (left/right) appear when more pills exist off-screen, providing a visual hint
- Active pill centers in the window on load and after htmx swaps

This makes the trends page layout calmer horizontally and mobile-friendly without cramping label text.

- Verified: 406/406 tests pass, frontend E2E confirms scroller works at desktop (large window, fade behavior) and mobile (375px) viewports