### PR TITLE
✨ feat: let value-strip drive chart scrubber on hover

### DIFF
--- a/code/BpMonitor.Web/wwwroot/recent-scrubber.js
+++ b/code/BpMonitor.Web/wwwroot/recent-scrubber.js
@@ -12,8 +12,14 @@
 // ReadingViews.fs `valueStrip`); `plotly_relayout` fires with `xaxis.range[0]`/`[1]`
 // on zoom/pan, or `xaxis.autorange` on a reset (e.g. double-click), and this keeps
 // the value strip in sync as the user pans/zooms the chart.
+//
+// The link is symmetric: hovering the strip drives the chart's spike via
+// Plotly.Fx.hover (strip → chart), mirroring the existing chart → strip direction.
+// Event delegation on the strip container avoids flicker when the pointer moves
+// between the stacked Systolic/Diastolic cells of the same column.
 function setupRecentScrubber() {
-  if (!document.querySelector(".value-strip")) return;
+  var strip = document.querySelector(".value-strip");
+  if (!strip) return;
 
   function setup() {
     var d = document.querySelector(".js-plotly-plot");
@@ -22,6 +28,7 @@ function setupRecentScrubber() {
       return;
     }
 
+    // chart → strip: box the value-strip column matching the hovered chart point.
     d.on("plotly_hover", (e) => {
       var x = e.points[0].x;
       document.querySelectorAll(".value-strip td.scrubbed").forEach((c) => {
@@ -33,6 +40,50 @@ function setupRecentScrubber() {
     });
 
     d.on("plotly_unhover", () => {
+      document.querySelectorAll(".value-strip td.scrubbed").forEach((c) => {
+        c.classList.remove("scrubbed");
+      });
+    });
+
+    // strip → chart: hovering the strip moves the chart's spike to that column.
+    // `out-of-range` cells are display:none and cannot be hovered, so no guard
+    // needed for them. `lastX` avoids redundant dispatches when the pointer moves
+    // between the stacked Systolic/Diastolic cells of the same column.
+    //
+    // We trigger Plotly's own hover machinery by dispatching a synthetic mousemove
+    // on the chart's drag-layer rect at the pixel position of the data point.
+    // The axis converters d2l/l2p (date-to-linear and linear-to-pixel) give the
+    // correct x pixel without any timezone conversion (Plotly's own d2l parses the
+    // same date strings it stored in the trace data). The plotly_hover event fires
+    // naturally, so the existing chart→strip listener adds .scrubbed for free.
+    var lastX = null;
+    strip.addEventListener("mouseover", (e) => {
+      var cell = e.target.closest("td[data-x]");
+      if (!cell || cell.dataset.x === lastX) return;
+      lastX = cell.dataset.x;
+      var xaxis = d._fullLayout?.xaxis;
+      if (!xaxis?.d2l || !xaxis?.l2p) return;
+      var dragRect = d.querySelector(".draglayer .xy > rect");
+      if (!dragRect) return;
+      var br = dragRect.getBoundingClientRect();
+      var xPx = xaxis.l2p(xaxis.d2l(cell.dataset.x));
+      var yPx = (d._fullLayout?.yaxis?.l2p?.(120)) ?? br.height / 2;
+      dragRect.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          cancelable: true,
+          clientX: br.left + xPx,
+          clientY: br.top + yPx,
+        }),
+      );
+    });
+    strip.addEventListener("mouseleave", () => {
+      lastX = null;
+      // Dispatch mouseout on the drag layer to trigger Plotly's unhover path;
+      // also clear .scrubbed directly so the box never lingers.
+      var dragRect = d.querySelector(".draglayer .xy > rect");
+      if (dragRect)
+        dragRect.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
       document.querySelectorAll(".value-strip td.scrubbed").forEach((c) => {
         c.classList.remove("scrubbed");
       });


### PR DESCRIPTION
## Summary
- Add strip→chart hover wiring: hovering a value-strip cell now moves the chart's spike via a synthetic mousemove on Plotly's drag layer
- Makes scrubber control symmetric (previously one-directional, chart→strip only)
- Uses Plotly's axis converters (d2l/l2p) for correct pixel positioning without timezone conversion
- All 406 tests pass, including E2E verification of the strip→chart hover path