### PR TITLE
🔧 chore: modernize JS — var → const/let, enforce Biome best practices

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,14 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "useConst": "error",
+        "useTemplate": "error",
+        "noUselessElse": "error",
+        "useSingleVarDeclarator": "error",
+        "useCollapsedElseIf": "error"
+      }
     }
   },
   "formatter": {

--- a/code/BpMonitor.Web/wwwroot/recent-scrubber.js
+++ b/code/BpMonitor.Web/wwwroot/recent-scrubber.js
@@ -18,11 +18,11 @@
 // Event delegation on the strip container avoids flicker when the pointer moves
 // between the stacked Systolic/Diastolic cells of the same column.
 function setupRecentScrubber() {
-  var strip = document.querySelector(".value-strip");
+  const strip = document.querySelector(".value-strip");
   if (!strip) return;
 
   function setup() {
-    var d = document.querySelector(".js-plotly-plot");
+    const d = document.querySelector(".js-plotly-plot");
     if (!d?.on) {
       setTimeout(setup, 50);
       return;
@@ -30,7 +30,7 @@ function setupRecentScrubber() {
 
     // chart → strip: box the value-strip column matching the hovered chart point.
     d.on("plotly_hover", (e) => {
-      var x = e.points[0].x;
+      const x = e.points[0].x;
       document.querySelectorAll(".value-strip td.scrubbed").forEach((c) => {
         c.classList.remove("scrubbed");
       });
@@ -56,18 +56,18 @@ function setupRecentScrubber() {
     // correct x pixel without any timezone conversion (Plotly's own d2l parses the
     // same date strings it stored in the trace data). The plotly_hover event fires
     // naturally, so the existing chart→strip listener adds .scrubbed for free.
-    var lastX = null;
+    let lastX = null;
     strip.addEventListener("mouseover", (e) => {
-      var cell = e.target.closest("td[data-x]");
+      const cell = e.target.closest("td[data-x]");
       if (!cell || cell.dataset.x === lastX) return;
       lastX = cell.dataset.x;
-      var xaxis = d._fullLayout?.xaxis;
+      const xaxis = d._fullLayout?.xaxis;
       if (!xaxis?.d2l || !xaxis?.l2p) return;
-      var dragRect = d.querySelector(".draglayer .xy > rect");
+      const dragRect = d.querySelector(".draglayer .xy > rect");
       if (!dragRect) return;
-      var br = dragRect.getBoundingClientRect();
-      var xPx = xaxis.l2p(xaxis.d2l(cell.dataset.x));
-      var yPx = (d._fullLayout?.yaxis?.l2p?.(120)) ?? br.height / 2;
+      const br = dragRect.getBoundingClientRect();
+      const xPx = xaxis.l2p(xaxis.d2l(cell.dataset.x));
+      const yPx = (d._fullLayout?.yaxis?.l2p?.(120)) ?? br.height / 2;
       dragRect.dispatchEvent(
         new MouseEvent("mousemove", {
           bubbles: true,
@@ -81,7 +81,7 @@ function setupRecentScrubber() {
       lastX = null;
       // Dispatch mouseout on the drag layer to trigger Plotly's unhover path;
       // also clear .scrubbed directly so the box never lingers.
-      var dragRect = d.querySelector(".draglayer .xy > rect");
+      const dragRect = d.querySelector(".draglayer .xy > rect");
       if (dragRect)
         dragRect.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
       document.querySelectorAll(".value-strip td.scrubbed").forEach((c) => {
@@ -90,9 +90,9 @@ function setupRecentScrubber() {
     });
 
     d.on("plotly_relayout", (e) => {
-      var cells = document.querySelectorAll(".value-strip td[data-x]");
-      var lo = e["xaxis.range[0]"];
-      var hi = e["xaxis.range[1]"];
+      const cells = document.querySelectorAll(".value-strip td[data-x]");
+      let lo = e["xaxis.range[0]"];
+      let hi = e["xaxis.range[1]"];
 
       if (lo === undefined && Array.isArray(e["xaxis.range"])) {
         lo = e["xaxis.range"][0];
@@ -115,12 +115,12 @@ function setupRecentScrubber() {
         return;
       }
 
-      var loT = new Date(String(lo).replace(" ", "T")).getTime();
-      var hiT = new Date(String(hi).replace(" ", "T")).getTime();
+      const loT = new Date(String(lo).replace(" ", "T")).getTime();
+      const hiT = new Date(String(hi).replace(" ", "T")).getTime();
       if (Number.isNaN(loT) || Number.isNaN(hiT)) return;
 
       cells.forEach((c) => {
-        var t = new Date(c.dataset.x.replace(" ", "T")).getTime();
+        const t = new Date(c.dataset.x.replace(" ", "T")).getTime();
         if (Number.isNaN(t)) return;
         c.classList.toggle("out-of-range", t < loT || t > hiT);
       });

--- a/code/BpMonitor.Web/wwwroot/recent-zoom.js
+++ b/code/BpMonitor.Web/wwwroot/recent-zoom.js
@@ -5,11 +5,11 @@
 // Plotly.relayout — same call pattern as theme.js. The existing plotly_relayout
 // listener in recent-scrubber.js re-syncs the value strip automatically.
 function setupRecentZoomButtons() {
-  var buttons = document.querySelectorAll(".recent-zoom-button");
+  const buttons = document.querySelectorAll(".recent-zoom-button");
   if (buttons.length === 0) return;
 
   function setup() {
-    var d = document.querySelector(".js-plotly-plot");
+    const d = document.querySelector(".js-plotly-plot");
     if (!d?.on) {
       setTimeout(setup, 50);
       return;

--- a/code/BpMonitor.Web/wwwroot/theme-label.js
+++ b/code/BpMonitor.Web/wwwroot/theme-label.js
@@ -1,2 +1,2 @@
 // Re-runs on every body render (initial + hx-boost swaps) to sync the button icons.
-(()=> {var n=document.documentElement.getAttribute('data-theme')==='dark'?'☀️':'🌙';document.querySelectorAll('.theme-toggle').forEach((b) => { b.textContent=n; });})();
+(()=> {const n=document.documentElement.getAttribute('data-theme')==='dark'?'☀️':'🌙';document.querySelectorAll('.theme-toggle').forEach((b) => { b.textContent=n; });})();

--- a/code/BpMonitor.Web/wwwroot/theme.js
+++ b/code/BpMonitor.Web/wwwroot/theme.js
@@ -1,13 +1,13 @@
 // Runs once on initial load; survives hx-boost navigations because it lives in <head>.
 (()=> {
-  var t=localStorage.getItem('theme')||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');
+  const t=localStorage.getItem('theme')||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');
   document.documentElement.setAttribute('data-theme',t);
 })();
 
 function applyChartTheme(theme) {
   if (typeof Plotly === 'undefined') return;
-  var isDark = theme === 'dark';
-  var axisLineColor = isDark ? '#c2cfd6' : '#444';
+  const isDark = theme === 'dark';
+  const axisLineColor = isDark ? '#c2cfd6' : '#444';
   document.querySelectorAll('.js-plotly-plot').forEach((d) => {
     Plotly.relayout(d, {
       paper_bgcolor: 'rgba(0,0,0,0)',
@@ -23,7 +23,8 @@ function applyChartTheme(theme) {
 }
 
 window.toggleTheme=()=> {
-  var h=document.documentElement,n=h.getAttribute('data-theme')==='dark'?'light':'dark';
+  const h=document.documentElement;
+  const n=h.getAttribute('data-theme')==='dark'?'light':'dark';
   h.setAttribute('data-theme',n);
   localStorage.setItem('theme',n);
   document.querySelectorAll('.theme-toggle').forEach((b) => { b.textContent=n==='dark'?'☀️':'🌙'; });

--- a/code/BpMonitor.Web/wwwroot/trends-scroll.js
+++ b/code/BpMonitor.Web/wwwroot/trends-scroll.js
@@ -3,22 +3,22 @@
 // just DOMContentLoaded) to catch every swap — same pattern as theme.js for surviving
 // hx-boost navigations.
 function scrollActiveSubPeriodIntoView() {
-  var row = document.querySelector(".trends-subperiod-buttons");
+  const row = document.querySelector(".trends-subperiod-buttons");
   if (!row) return;
-  var active = row.querySelector('[aria-current="page"]');
+  const active = row.querySelector('[aria-current="page"]');
   if (active) active.scrollIntoView({ inline: "center", block: "nearest" });
 }
 
 // Toggles edge-fade affordances (CSS, app.css `.trends-subperiod-scroller`) on the
 // non-scrolling wrapper based on how far the pill row has been scrolled.
 function updateSubPeriodFades() {
-  var row = document.querySelector(".trends-subperiod-buttons");
-  var scroller = document.querySelector(".trends-subperiod-scroller");
+  const row = document.querySelector(".trends-subperiod-buttons");
+  const scroller = document.querySelector(".trends-subperiod-scroller");
   if (!row || !scroller) return;
 
-  var tolerancePx = 1;
-  var canScrollLeft = row.scrollLeft > tolerancePx;
-  var canScrollRight = row.scrollLeft + row.clientWidth < row.scrollWidth - tolerancePx;
+  const tolerancePx = 1;
+  const canScrollLeft = row.scrollLeft > tolerancePx;
+  const canScrollRight = row.scrollLeft + row.clientWidth < row.scrollWidth - tolerancePx;
 
   scroller.classList.toggle("can-scroll-left", canScrollLeft);
   scroller.classList.toggle("can-scroll-right", canScrollRight);


### PR DESCRIPTION
## Summary

Replace all `var` with `const` (immutable) or `let` (reassigned only for lastX, lo, hi). Add five Biome linter rules to enforce best practices:
- useConst: catch any future let that could be const
- useTemplate: ban string concatenation, enforce template literals
- noUselessElse: flatten control flow after return/throw
- useSingleVarDeclarator: one declaration per statement
- useCollapsedElseIf: prefer else if over else { if }

Linter passes cleanly with no violations.