### PR TITLE
♻️ refactor(core): deduplicate validators and stats helpers; cover isClaimed

### DIFF
--- a/code/BpMonitor.Core.Tests/DemoDataTests.fs
+++ b/code/BpMonitor.Core.Tests/DemoDataTests.fs
@@ -76,25 +76,19 @@ let ``same anchor produces identical results (deterministic)`` () =
 
 // ── member profiles are distinct ──────────────────────────────────────────────
 
+let private meanSys (result: (MemberSpec * BloodPressureReading list) list) name =
+  let _, readings = result |> List.find (fun (s, _) -> s.Name = name)
+  readings |> List.averageBy (fun r -> float r.Systolic)
+
 [<Fact>]
 let ``Homer mean systolic is higher than Marge mean systolic`` () =
   let result = DemoData.simpsons ranges now
-
-  let meanSys name =
-    let _, readings = result |> List.find (fun (s, _) -> s.Name = name)
-    readings |> List.averageBy (fun r -> float r.Systolic)
-
-  test <@ meanSys "Homer Simpson" > meanSys "Marge Simpson" @>
+  test <@ meanSys result "Homer Simpson" > meanSys result "Marge Simpson" @>
 
 [<Fact>]
 let ``Marge mean systolic is higher than Bart mean systolic`` () =
   let result = DemoData.simpsons ranges now
-
-  let meanSys name =
-    let _, readings = result |> List.find (fun (s, _) -> s.Name = name)
-    readings |> List.averageBy (fun r -> float r.Systolic)
-
-  test <@ meanSys "Marge Simpson" > meanSys "Bart Simpson" @>
+  test <@ meanSys result "Marge Simpson" > meanSys result "Bart Simpson" @>
 
 // ── Ned Flanders: a Fig. 5-style narrative (Wegier et al. 2021) ───────────────
 // Elevated BP, a multi-day gap in home monitoring, then visibly improved control

--- a/code/BpMonitor.Core.Tests/FamilyMemberTests.fs
+++ b/code/BpMonitor.Core.Tests/FamilyMemberTests.fs
@@ -89,3 +89,17 @@ let ``hasActiveAdmin is true when at least one member is admin and active`` () =
         ModifiedAt = System.DateTimeOffset.MinValue } ]
 
   test <@ FamilyMember.hasActiveAdmin members = true @>
+
+[<Fact>]
+let ``isClaimed returns false when PasswordHash is None`` () =
+  match FamilyMember.create "Alice" true with
+  | Error _ -> failwith "unexpected error"
+  | Ok m -> test <@ FamilyMember.isClaimed m = false @>
+
+[<Fact>]
+let ``isClaimed returns true when PasswordHash is set`` () =
+  match FamilyMember.create "Alice" true with
+  | Error _ -> failwith "unexpected error"
+  | Ok m ->
+    let claimed = { m with PasswordHash = Some "hashed" }
+    test <@ FamilyMember.isClaimed claimed = true @>

--- a/code/BpMonitor.Core/BloodPressureReading.fs
+++ b/code/BpMonitor.Core/BloodPressureReading.fs
@@ -58,32 +58,28 @@ module ReadingRanges =
 module BloodPressureReading =
   open FsToolkit.ErrorHandling
 
-  let private validateSystolic ranges (input: BloodPressureReadingUnvalidated) : Validation<int, ValidationError> =
-    if input.Systolic >= ranges.SystolicMin && input.Systolic <= ranges.SystolicMax then
-      Validation.ok input.Systolic
-    else
-      Validation.error (SystolicOutOfRange input.Systolic)
+  let private validateField
+    (selector: BloodPressureReadingUnvalidated -> int)
+    (min: int)
+    (max: int)
+    (errorCtor: int -> ValidationError)
+    (input: BloodPressureReadingUnvalidated)
+    : Validation<int, ValidationError> =
+    let value = selector input
 
-  let private validateDiastolic ranges (input: BloodPressureReadingUnvalidated) : Validation<int, ValidationError> =
-    if input.Diastolic >= ranges.DiastolicMin && input.Diastolic <= ranges.DiastolicMax then
-      Validation.ok input.Diastolic
+    if value >= min && value <= max then
+      Validation.ok value
     else
-      Validation.error (DiastolicOutOfRange input.Diastolic)
-
-  let private validateHeartRate ranges (input: BloodPressureReadingUnvalidated) : Validation<int, ValidationError> =
-    if input.HeartRate >= ranges.HeartRateMin && input.HeartRate <= ranges.HeartRateMax then
-      Validation.ok input.HeartRate
-    else
-      Validation.error (HeartRateOutOfRange input.HeartRate)
+      Validation.error (errorCtor value)
 
   let parse
     (ranges: ReadingRanges)
     (input: BloodPressureReadingUnvalidated)
     : Validation<BloodPressureReading, ValidationError> =
     validation {
-      let! sys = validateSystolic ranges input
-      and! dia = validateDiastolic ranges input
-      and! hr = validateHeartRate ranges input
+      let! sys = validateField _.Systolic ranges.SystolicMin ranges.SystolicMax SystolicOutOfRange input
+      and! dia = validateField _.Diastolic ranges.DiastolicMin ranges.DiastolicMax DiastolicOutOfRange input
+      and! hr = validateField _.HeartRate ranges.HeartRateMin ranges.HeartRateMax HeartRateOutOfRange input
 
       return
         { Id = 0

--- a/code/BpMonitor.Core/ReadingStats.fs
+++ b/code/BpMonitor.Core/ReadingStats.fs
@@ -40,6 +40,18 @@ module ReadingStats =
     readings
     |> List.filter (fun r -> r.Timestamp >= startIncl && r.Timestamp < endExcl)
 
+  // ── stat helpers ─────────────────────────────────────────────────────────────
+
+  /// Returns (min, max) for the given field selector.
+  let private rangeOf (selector: BloodPressureReading -> int) rs =
+    rs |> List.minBy selector |> selector, rs |> List.maxBy selector |> selector
+
+  /// Returns (min, avg, max) for the given field selector over n readings.
+  let private statsOf (selector: BloodPressureReading -> int) n rs =
+    rs |> List.minBy selector |> selector,
+    rs |> List.sumBy selector |> (fun s -> s / n),
+    rs |> List.maxBy selector |> selector
+
   // ── aggregation ──────────────────────────────────────────────────────────────
 
   /// Groups readings by `keyOf`, sorts by key, and produces one AggregatedReading per
@@ -57,6 +69,8 @@ module ReadingStats =
       let n = List.length rs
       let date = dateOf key
       let offset = TimeZoneInfo.Local.GetUtcOffset(date)
+      let minSys, maxSys = rangeOf _.Systolic rs
+      let minDia, maxDia = rangeOf _.Diastolic rs
 
       { Reading =
           { Id = 0
@@ -69,10 +83,10 @@ module ReadingStats =
             CreatedAt = DateTimeOffset.MinValue
             ModifiedAt = DateTimeOffset.MinValue }
         Count = n
-        MinSystolic = rs |> List.minBy _.Systolic |> _.Systolic
-        MaxSystolic = rs |> List.maxBy _.Systolic |> _.Systolic
-        MinDiastolic = rs |> List.minBy _.Diastolic |> _.Diastolic
-        MaxDiastolic = rs |> List.maxBy _.Diastolic |> _.Diastolic })
+        MinSystolic = minSys
+        MaxSystolic = maxSys
+        MinDiastolic = minDia
+        MaxDiastolic = maxDia })
 
   let private dailyAveragesWithCount =
     buildAggregated (fun r -> r.Timestamp.ToLocalTime().Date) id
@@ -133,17 +147,20 @@ module ReadingStats =
         MaxHeartRate = 0 }
     | rs ->
       let n = List.length rs
+      let minSys, avgSys, maxSys = statsOf _.Systolic n rs
+      let minDia, avgDia, maxDia = statsOf _.Diastolic n rs
+      let minHr, avgHr, maxHr = statsOf _.HeartRate n rs
 
       { Granularity = period.Granularity
         PeriodKey = period.Key
         Label = period.Label
         Count = n
-        MinSystolic = rs |> List.minBy _.Systolic |> _.Systolic
-        AvgSystolic = rs |> List.sumBy _.Systolic |> (fun s -> s / n)
-        MaxSystolic = rs |> List.maxBy _.Systolic |> _.Systolic
-        MinDiastolic = rs |> List.minBy _.Diastolic |> _.Diastolic
-        AvgDiastolic = rs |> List.sumBy _.Diastolic |> (fun s -> s / n)
-        MaxDiastolic = rs |> List.maxBy _.Diastolic |> _.Diastolic
-        MinHeartRate = rs |> List.minBy _.HeartRate |> _.HeartRate
-        AvgHeartRate = rs |> List.sumBy _.HeartRate |> (fun s -> s / n)
-        MaxHeartRate = rs |> List.maxBy _.HeartRate |> _.HeartRate }
+        MinSystolic = minSys
+        AvgSystolic = avgSys
+        MaxSystolic = maxSys
+        MinDiastolic = minDia
+        AvgDiastolic = avgDia
+        MaxDiastolic = maxDia
+        MinHeartRate = minHr
+        AvgHeartRate = avgHr
+        MaxHeartRate = maxHr }


### PR DESCRIPTION
## Summary
- `BloodPressureReading.fs`: collapse three byte-identical validators (`validateSystolic`/`validateDiastolic`/`validateHeartRate`) into a single `validateField` helper
- `ReadingStats.fs`: extract `rangeOf` (min/max) and `statsOf` (min/avg/max) private helpers to remove repeated field-selector triples in `buildAggregated` and `summarizeRange`
- `FamilyMemberTests.fs`: add two tests covering `FamilyMember.isClaimed` (previously uncovered)
- `DemoDataTests.fs`: hoist duplicated local `meanSys` function to module level