### PR TITLE
♻️ refactor(web): dedup trends/export handlers; polish style and routes constants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ dotnet test --configuration Release --max-parallel-test-modules 2
 
 All non-dotnet linter versions are pinned in `mise.toml` (repo root); it also hosts one-time dev setup tasks like the Playwright Chromium install. Run `mise install` once after cloning.
 
-- `biome.json` — Biome JS linter config (scoped to `wwwroot/theme.js`, `wwwroot/theme-label.js`, `wwwroot/recent-scrubber.js`, `wwwroot/trends-scroll.js`)
+- `biome.json` — Biome JS linter config (scoped to `wwwroot/theme.js`, `wwwroot/theme-label.js`, `wwwroot/recent-scrubber.js`, `wwwroot/trends-scroll.js`, `wwwroot/recent-zoom.js`)
 - `.markdownlint-cli2.yaml` — markdownlint config
 - Run `mise run lint` to run all non-dotnet linters; `mise run lint:js` / `lint:md` / `lint:shell` individually
 - Run `mise run test:e2e-setup` once locally before the first `BpMonitor.Web.E2E.Tests` run (installs Playwright's Chromium)

--- a/code/BpMonitor.Web/AuthHandlers.fs
+++ b/code/BpMonitor.Web/AuthHandlers.fs
@@ -87,8 +87,7 @@ module AuthHandlers =
   // Login / logout
   // ---------------------------------------------------------------------------
 
-  let loginPage: HttpContext -> Task =
-    fun ctx -> htmlResponse (LoginViews.loginPage []) ctx
+  let loginPage: HttpContext -> Task = htmlResponse (LoginViews.loginPage [])
 
   // `onFailure` lets callers choose what to render on a bad password (loginPage vs. loginMember).
   let private claimedLogin

--- a/code/BpMonitor.Web/HandlerHelpers.fs
+++ b/code/BpMonitor.Web/HandlerHelpers.fs
@@ -78,19 +78,20 @@ module HandlerHelpers =
   let sortedReadings (memberId: int) (ctx: HttpContext) =
     (repo ctx).GetAll(memberId) |> List.sortByDescending _.Timestamp
 
+  let private logBadRouteId (handlerName: string) (ctx: HttpContext) =
+    (logger ctx)
+      .LogWarning(
+        "{Handler}: bad route value for {RouteId}",
+        handlerName,
+        routeStr ctx "id" |> Option.defaultValue "<missing>"
+      )
+
   /// Resolves the "id" route segment to an int, logging and returning 400 for a noninteger id.
   let withRouteId (handlerName: string) (handler: int -> HttpContext -> Task) : HttpContext -> Task =
     fun ctx ->
-      let log = logger ctx
-
       match routeInt ctx "id" with
       | None ->
-        log.LogWarning(
-          "{Handler}: bad route value for {RouteId}",
-          handlerName,
-          routeStr ctx "id" |> Option.defaultValue "<missing>"
-        )
-
+        logBadRouteId handlerName ctx
         badRequest ctx
       | Some id -> handler id ctx
 
@@ -98,20 +99,13 @@ module HandlerHelpers =
   /// 400 for a noninteger id or 404 when no member with that id exists.
   let withRouteMember (handlerName: string) (handler: FamilyMember -> HttpContext -> Task) : HttpContext -> Task =
     fun ctx ->
-      let log = logger ctx
-
       match routeInt ctx "id" with
       | None ->
-        log.LogWarning(
-          "{Handler}: bad route value for {RouteId}",
-          handlerName,
-          routeStr ctx "id" |> Option.defaultValue "<missing>"
-        )
-
+        logBadRouteId handlerName ctx
         badRequest ctx
       | Some id ->
         match (memberRepo ctx).GetById(id) with
         | None ->
-          log.LogWarning("{Handler}: member {Id} not found", handlerName, id)
+          (logger ctx).LogWarning("{Handler}: member {Id} not found", handlerName, id)
           notFound ctx
         | Some m -> handler m ctx

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -122,7 +122,5 @@ let main args =
   with ex ->
     Log.Fatal(ex, "BpMonitor.Web terminated unexpectedly")
 
+    Log.CloseAndFlush()
     1
-    |> fun exitCode ->
-      Log.CloseAndFlush()
-      exitCode

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -135,29 +135,42 @@ module ReadingHandlers =
         (ReadingViews.recentChartContainer m chartHtml allReadings windowStart now recentZoomShortcutDays false)
         ctx)
 
+  let private renderTrendsData
+    (gran: Granularity)
+    (period: TrendPeriod)
+    (now: System.DateTimeOffset)
+    (m: FamilyMember)
+    (allReadings: BloodPressureReading list)
+    =
+    let windowed = allReadings |> ReadingStats.between period.Start period.EndExclusive
+    let summary = ReadingStats.summarizeRange period windowed
+    let periods = TrendPeriod.available gran now
+
+    let periodsWithData =
+      periods
+      |> List.filter (fun p ->
+        allReadings
+        |> ReadingStats.between p.Start p.EndExclusive
+        |> List.isEmpty
+        |> not)
+      |> List.map _.Key
+      |> Set.ofList
+
+    let tableReadings = windowed |> List.sortByDescending _.Timestamp
+
+    let chartHtml =
+      BpChart.toHtmlDashed m.Goal gran (ReadingStats.aggregate gran windowed)
+
+    summary, periods, periodsWithData, tableReadings, chartHtml
+
   let trends: HttpContext -> Task =
     withMember (fun m ctx ->
       let now = (timeProvider ctx).GetUtcNow()
       let allReadings = (repo ctx).GetAll(m.Id)
       let period = TrendPeriod.current Weekly now
-      let windowed = allReadings |> ReadingStats.between period.Start period.EndExclusive
-      let summary = ReadingStats.summarizeRange period windowed
-      let periods = TrendPeriod.available Weekly now
 
-      let periodsWithData =
-        periods
-        |> List.filter (fun p ->
-          allReadings
-          |> ReadingStats.between p.Start p.EndExclusive
-          |> List.isEmpty
-          |> not)
-        |> List.map _.Key
-        |> Set.ofList
-
-      let tableReadings = windowed |> List.sortByDescending _.Timestamp
-
-      let chartHtml =
-        BpChart.toHtmlDashed m.Goal Weekly (ReadingStats.aggregate Weekly windowed)
+      let summary, periods, periodsWithData, tableReadings, chartHtml =
+        renderTrendsData Weekly period now m allReadings
 
       htmlResponse (TrendViews.trends m summary periods periodsWithData tableReadings chartHtml) ctx)
 
@@ -174,24 +187,8 @@ module ReadingHandlers =
           |> Option.bind (fun k -> TrendPeriod.ofKey gran k now)
           |> Option.defaultWith (fun () -> TrendPeriod.current gran now)
 
-        let windowed = allReadings |> ReadingStats.between period.Start period.EndExclusive
-        let summary = ReadingStats.summarizeRange period windowed
-        let periods = TrendPeriod.available gran now
-
-        let periodsWithData =
-          periods
-          |> List.filter (fun p ->
-            allReadings
-            |> ReadingStats.between p.Start p.EndExclusive
-            |> List.isEmpty
-            |> not)
-          |> List.map _.Key
-          |> Set.ofList
-
-        let tableReadings = windowed |> List.sortByDescending _.Timestamp
-
-        let chartHtml =
-          BpChart.toHtmlDashed m.Goal gran (ReadingStats.aggregate gran windowed)
+        let summary, periods, periodsWithData, tableReadings, chartHtml =
+          renderTrendsData gran period now m allReadings
 
         htmlResponse (TrendViews.trendsPanel summary periods periodsWithData tableReadings chartHtml) ctx)
 
@@ -300,16 +297,19 @@ module ReadingHandlers =
   // Export
   // ---------------------------------------------------------------------------
 
+  let private download (contentType: string) (filename: string) (body: string) (ctx: HttpContext) : Task =
+    ctx.Response.ContentType <- contentType
+    ctx.Response.Headers.Append("Content-Disposition", $"attachment; filename=\"{filename}\"")
+    ctx.Response.WriteAsync body
+
   let exportJson: HttpContext -> Task =
     withMember (fun m ctx ->
-      let json = JsonExport.serialize ((repo ctx).GetAll(m.Id))
-      ctx.Response.ContentType <- "application/json; charset=utf-8"
-      ctx.Response.Headers.Append("Content-Disposition", "attachment; filename=\"bpmonitor-export.json\"")
-      ctx.Response.WriteAsync json)
+      download
+        "application/json; charset=utf-8"
+        "bpmonitor-export.json"
+        (JsonExport.serialize ((repo ctx).GetAll(m.Id)))
+        ctx)
 
   let exportCsv: HttpContext -> Task =
     withMember (fun m ctx ->
-      let csv = CsvExport.serialize ((repo ctx).GetAll(m.Id))
-      ctx.Response.ContentType <- "text/csv; charset=utf-8"
-      ctx.Response.Headers.Append("Content-Disposition", "attachment; filename=\"bpmonitor-export.csv\"")
-      ctx.Response.WriteAsync csv)
+      download "text/csv; charset=utf-8" "bpmonitor-export.csv" (CsvExport.serialize ((repo ctx).GetAll(m.Id))) ctx)

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -21,7 +21,7 @@ module ReadingViews =
   /// Landing page: a simple hub linking to the app's main destinations.
   let landing (m: FamilyMember) : XmlNode =
     ViewLayout.layout
-      "/"
+      Routes.home
       m.Name
       m.IsAdmin
       "BpMonitor"

--- a/code/BpMonitor.Web/TrendViews.fs
+++ b/code/BpMonitor.Web/TrendViews.fs
@@ -117,7 +117,7 @@ module TrendViews =
     (chartHtml: string)
     : XmlNode =
     ViewLayout.layout
-      "/trends"
+      Routes.trends
       m.Name
       m.IsAdmin
       "Trends"

--- a/code/BpMonitor.Web/Version.fs
+++ b/code/BpMonitor.Web/Version.fs
@@ -28,7 +28,7 @@ module Version =
     Assembly.GetEntryAssembly()
     |> Option.ofObj
     |> Option.bind (fun a -> a.GetCustomAttribute<AssemblyInformationalVersionAttribute>() |> Option.ofObj)
-    |> Option.map (fun a -> a.InformationalVersion)
+    |> Option.map _.InformationalVersion
     |> parse
 
   /// GitHub release page URL for a stamped version; None for the "dev" fallback.

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -121,7 +121,7 @@ module ViewLayout =
                   [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ]
                     themeToggleButton ""
                     Elem.form
-                      [ Attr.method "post"; Attr.action "/logout"; Attr.class' "inline" ]
+                      [ Attr.method "post"; Attr.action Routes.logout; Attr.class' "inline" ]
                       [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Logout" ] ] ] ]
             Elem.div
               [ Attr.class' "content" ]


### PR DESCRIPTION
## Summary
- `ReadingHandlers.fs`: extract `renderTrendsData` helper to remove the ~95% identical `periodsWithData`/`windowed`/`summary`/`chartHtml` blocks duplicated between `trends` and `trendsPanel`
- `ReadingHandlers.fs`: extract `download` helper to remove the duplicated content-type/Content-Disposition/WriteAsync pattern in `exportJson`/`exportCsv`
- `HandlerHelpers.fs`: extract `logBadRouteId` to deduplicate the identical `LogWarning` + `badRequest` branch shared by `withRouteId` and `withRouteMember`
- `Version.fs`: use `_.InformationalVersion` shorthand lambda (AGENTS.md style convention)
- `AuthHandlers.fs`: eta-reduce `loginPage` (trailing `ctx` was redundant)
- `Program.fs`: simplify failure-path exit to `Log.CloseAndFlush(); 1`
- `ViewLayout.fs`, `ReadingViews.fs`, `TrendViews.fs`: replace hardcoded `"/logout"`, `"/"`, `"/trends"` literals with existing `Routes.*` constants
- `AGENTS.md`: add `recent-zoom.js` to the biome scope list (was missing, present in `biome.json`)