### PR TITLE
♻️ refactor(web-tests): extract shared member factories and reduce goal-band duplication

### DIFF
--- a/code/BpMonitor.Web.Tests/HandlerTestHelpers.fs
+++ b/code/BpMonitor.Web.Tests/HandlerTestHelpers.fs
@@ -1,6 +1,7 @@
 module HandlerTestHelpers
 
 open System
+open Xunit
 open BpMonitor.Core
 open BpMonitor.Data
 
@@ -16,6 +17,27 @@ let sample: BloodPressureReading =
     Comments = None
     CreatedAt = DateTimeOffset.MinValue
     ModifiedAt = DateTimeOffset.MinValue }
+
+/// A default admin member with Id=defaultMemberId. Mirrors the member pre-set in TestHost.context.
+let sampleMember: FamilyMember =
+  { Id = defaultMemberId
+    Name = "Me"
+    IsAdmin = true
+    IsActive = true
+    PasswordHash = None
+    Goal = GoalRange.defaults
+    CreatedAt = DateTimeOffset.MinValue
+    ModifiedAt = DateTimeOffset.MinValue }
+
+/// Creates an active admin member with a custom goal range for chart-assertion tests.
+let memberWithGoal (goal: GoalRange) : FamilyMember = { sampleMember with Goal = goal }
+
+/// Asserts that the goal-band y0/y1 values for the given range all appear in the HTML body.
+let assertGoalBands (goal: GoalRange) (body: string) =
+  Assert.Contains($"\"y0\":{goal.SystolicMin}", body)
+  Assert.Contains($"\"y1\":{goal.SystolicMax}", body)
+  Assert.Contains($"\"y0\":{goal.DiastolicMin}", body)
+  Assert.Contains($"\"y1\":{goal.DiastolicMax}", body)
 
 let repoWith readings : IReadingRepository =
   InMemoryReadingRepository(Some readings)

--- a/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
@@ -8,15 +8,7 @@ open BpMonitor.Core
 open BpMonitor.Web
 open HandlerTestHelpers
 
-let private unclaimedMember: FamilyMember =
-  { Id = 1
-    Name = "Me"
-    IsAdmin = true
-    IsActive = true
-    PasswordHash = None
-    Goal = GoalRange.defaults
-    CreatedAt = DateTimeOffset.MinValue
-    ModifiedAt = DateTimeOffset.MinValue }
+let private unclaimedMember = sampleMember
 
 let private claimedMember (hash: string) : FamilyMember =
   { unclaimedMember with

--- a/code/BpMonitor.Web.Tests/MemberHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/MemberHandlerTests.fs
@@ -99,18 +99,11 @@ let ``updateMember rejects demoting the last active admin with 422`` () =
 
 [<Fact>]
 let ``updateMember allows demoting one admin when another active admin exists`` () =
-  let secondAdmin: FamilyMember =
-    { Id = 2
-      Name = "Alice"
-      IsAdmin = true
-      IsActive = true
-      PasswordHash = None
-      Goal = GoalRange.defaults
-      CreatedAt = DateTimeOffset.MinValue
-      ModifiedAt = DateTimeOffset.MinValue }
-
   let repo = repoWith []
-  let ctx = TestHost.contextWithMembers repo [ adminMember 1 "Me"; secondAdmin ]
+
+  let ctx =
+    TestHost.contextWithMembers repo [ adminMember 1 "Me"; adminMember 2 "Alice" ]
+
   TestHost.setRouteId ctx 1
 
   // Demote member 1 to non-admin; member 2 remains active admin → invariant holds.

--- a/code/BpMonitor.Web.Tests/PlotlyVendoringTests.fs
+++ b/code/BpMonitor.Web.Tests/PlotlyVendoringTests.fs
@@ -10,15 +10,7 @@ open Falco.Markup
 open BpMonitor.Core
 open BpMonitor.Web
 
-let private defaultMember: FamilyMember =
-  { Id = 1
-    Name = "Me"
-    IsAdmin = true
-    IsActive = true
-    PasswordHash = None
-    Goal = GoalRange.defaults
-    CreatedAt = DateTimeOffset.MinValue
-    ModifiedAt = DateTimeOffset.MinValue }
+let private defaultMember = HandlerTestHelpers.sampleMember
 
 [<Fact>]
 let ``layout loads plotly.js from a local path, not the CDN`` () =

--- a/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
@@ -34,23 +34,9 @@ let ``history renders the chart with the authenticated member's goal range`` () 
       DiastolicMin = 65
       DiastolicMax = 88 }
 
-  let m =
-    FamilyMember.create "Me" true
-    |> Result.defaultWith (fun _ -> failwith "invalid member")
-    |> fun m ->
-        { m with
-            Id = defaultMemberId
-            Goal = goal }
-
-  let repo = repoWith [ sample ]
-  let ctx = TestHost.contextWithMembers repo [ m ]
+  let ctx = TestHost.contextWithMembers (repoWith [ sample ]) [ memberWithGoal goal ]
   TestHost.run ReadingHandlers.history ctx
-
-  let body = TestHost.readBody ctx
-  test <@ body.Contains "\"y0\":100" @>
-  test <@ body.Contains "\"y1\":135" @>
-  test <@ body.Contains "\"y0\":65" @>
-  test <@ body.Contains "\"y1\":88" @>
+  assertGoalBands goal (TestHost.readBody ctx)
 
 [<Fact>]
 let ``newReading returns 200 and prefills timestamp with local time`` () =

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -28,6 +28,22 @@ let private reading daysAgo (id: int) : BloodPressureReading =
     CreatedAt = now
     ModifiedAt = now }
 
+// Three readings used by value-strip ordering and table-layout tests.
+let private stripR1 =
+  { reading 3 1 with
+      Systolic = 130
+      Diastolic = 82 }
+
+let private stripR2 =
+  { reading 2 2 with
+      Systolic = 142
+      Diastolic = 91 }
+
+let private stripR3 =
+  { reading 1 3 with
+      Systolic = 118
+      Diastolic = 76 }
+
 [<Fact>]
 let ``recent returns 200`` () =
   let tp = FakeTimeProvider(now)
@@ -124,23 +140,13 @@ let ``recent renders the chart with the authenticated member's goal range`` () =
       DiastolicMin = 65
       DiastolicMax = 88 }
 
-  let m =
-    FamilyMember.create "Me" true
-    |> Result.defaultWith (fun _ -> failwith "invalid member")
-    |> fun m ->
-        { m with
-            Id = defaultMemberId
-            Goal = goal }
-
   let tp = FakeTimeProvider(now)
-  let ctx = TestHost.contextWithMembersAndProvider (repoWith simpsonReadings) [ m ] tp
-  TestHost.run ReadingHandlers.recent ctx
 
-  let body = TestHost.readBody ctx
-  test <@ body.Contains "\"y0\":100" @>
-  test <@ body.Contains "\"y1\":135" @>
-  test <@ body.Contains "\"y0\":65" @>
-  test <@ body.Contains "\"y1\":88" @>
+  let ctx =
+    TestHost.contextWithMembersAndProvider (repoWith simpsonReadings) [ memberWithGoal goal ] tp
+
+  TestHost.run ReadingHandlers.recent ctx
+  assertGoalBands goal (TestHost.readBody ctx)
 
 [<Fact>]
 let ``recent heading does not repeat the member's name (already shown in the navbar)`` () =
@@ -163,23 +169,7 @@ let ``recent renders the chart without the collapse wrapper used on history`` ()
 [<Fact>]
 let ``recent shows a sys/dias value strip listing every reading in the chart window, oldest first`` () =
   let tp = FakeTimeProvider(now)
-
-  let r1 =
-    { reading 3 1 with
-        Systolic = 130
-        Diastolic = 82 }
-
-  let r2 =
-    { reading 2 2 with
-        Systolic = 142
-        Diastolic = 91 }
-
-  let r3 =
-    { reading 1 3 with
-        Systolic = 118
-        Diastolic = 76 }
-
-  let ctx = TestHost.contextWithProvider (repoWith [ r1; r2; r3 ]) tp
+  let ctx = TestHost.contextWithProvider (repoWith [ stripR1; stripR2; stripR3 ]) tp
   TestHost.run ReadingHandlers.recent ctx
 
   let body = TestHost.readBody ctx
@@ -205,23 +195,7 @@ let ``recent shows a sys/dias value strip listing every reading in the chart win
 [<Fact>]
 let ``recent value strip uses a table so each reading's sys/dias values align in the same column`` () =
   let tp = FakeTimeProvider(now)
-
-  let r1 =
-    { reading 3 1 with
-        Systolic = 130
-        Diastolic = 82 }
-
-  let r2 =
-    { reading 2 2 with
-        Systolic = 142
-        Diastolic = 91 }
-
-  let r3 =
-    { reading 1 3 with
-        Systolic = 118
-        Diastolic = 76 }
-
-  let ctx = TestHost.contextWithProvider (repoWith [ r1; r2; r3 ]) tp
+  let ctx = TestHost.contextWithProvider (repoWith [ stripR1; stripR2; stripR3 ]) tp
   TestHost.run ReadingHandlers.recent ctx
 
   let body = TestHost.readBody ctx
@@ -231,7 +205,7 @@ let ``recent value strip uses a table so each reading's sys/dias values align in
 
   let cellValues =
     System.Text.RegularExpressions.Regex.Matches(strip, "<td[^>]*>(\\d+)</td>")
-    |> Seq.map (fun m -> m.Groups[1].Value)
+    |> Seq.map _.Groups[1].Value
     |> List.ofSeq
 
   test <@ strip.Contains "<table" @>

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -90,8 +90,8 @@ let ``recent excludes a reading older than the load window entirely, even though
   TestHost.run ReadingHandlers.recent ctx
 
   let body = TestHost.readBody ctx
-  test <@ not (body.Contains "199") @>
-  test <@ body.Contains "188" @>
+  test <@ not (body.Contains ">199<") @>
+  test <@ body.Contains ">188<" @>
 
 [<Fact>]
 let ``recent excludes a future-dated reading entirely, since the load window's upper bound is 'now'`` () =
@@ -111,8 +111,8 @@ let ``recent excludes a future-dated reading entirely, since the load window's u
   TestHost.run ReadingHandlers.recent ctx
 
   let body = TestHost.readBody ctx
-  test <@ not (body.Contains "177") @>
-  test <@ body.Contains "166" @>
+  test <@ not (body.Contains ">177<") @>
+  test <@ body.Contains ">166<" @>
 
 [<Fact>]
 let ``recent renders a chart`` () =
@@ -323,7 +323,7 @@ let ``recentFull includes a reading older than the load window`` () =
   TestHost.run ReadingHandlers.recentFull ctx
 
   let body = TestHost.readBody ctx
-  test <@ body.Contains "199" @>
+  test <@ body.Contains ">199<" @>
 
 [<Fact>]
 let ``recentFull returns the chart fragment without the page shell, and omits the load-full button`` () =

--- a/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
@@ -52,14 +52,6 @@ let ``trends renders the chart with the authenticated member's goal range`` () =
       DiastolicMin = 65
       DiastolicMax = 88 }
 
-  let m =
-    FamilyMember.create "Me" true
-    |> Result.defaultWith (fun _ -> failwith "invalid member")
-    |> fun m ->
-        { m with
-            Id = defaultMemberId
-            Goal = goal }
-
   let r =
     { sample with
         Timestamp = trendsNow.AddDays(-1.0)
@@ -68,14 +60,12 @@ let ``trends renders the chart with the authenticated member's goal range`` () =
         HeartRate = 70 }
 
   let tp = FakeTimeProvider(trendsNow)
-  let ctx = TestHost.contextWithMembersAndProvider (repoWith [ r ]) [ m ] tp
-  TestHost.run ReadingHandlers.trends ctx
 
-  let body = TestHost.readBody ctx
-  test <@ body.Contains "\"y0\":100" @>
-  test <@ body.Contains "\"y1\":135" @>
-  test <@ body.Contains "\"y0\":65" @>
-  test <@ body.Contains "\"y1\":88" @>
+  let ctx =
+    TestHost.contextWithMembersAndProvider (repoWith [ r ]) [ memberWithGoal goal ] tp
+
+  TestHost.run ReadingHandlers.trends ctx
+  assertGoalBands goal (TestHost.readBody ctx)
 
 [<Fact>]
 let ``trendsPanel renders the chart with the authenticated member's goal range`` () =
@@ -85,14 +75,6 @@ let ``trendsPanel renders the chart with the authenticated member's goal range``
       DiastolicMin = 65
       DiastolicMax = 88 }
 
-  let m =
-    FamilyMember.create "Me" true
-    |> Result.defaultWith (fun _ -> failwith "invalid member")
-    |> fun m ->
-        { m with
-            Id = defaultMemberId
-            Goal = goal }
-
   let r =
     { sample with
         Timestamp = trendsNow.AddDays(-1.0)
@@ -101,15 +83,13 @@ let ``trendsPanel renders the chart with the authenticated member's goal range``
         HeartRate = 70 }
 
   let tp = FakeTimeProvider(trendsNow)
-  let ctx = TestHost.contextWithMembersAndProvider (repoWith [ r ]) [ m ] tp
+
+  let ctx =
+    TestHost.contextWithMembersAndProvider (repoWith [ r ]) [ memberWithGoal goal ] tp
+
   setRouteGran ctx "weekly"
   TestHost.run ReadingHandlers.trendsPanel ctx
-
-  let body = TestHost.readBody ctx
-  test <@ body.Contains "\"y0\":100" @>
-  test <@ body.Contains "\"y1\":135" @>
-  test <@ body.Contains "\"y0\":65" @>
-  test <@ body.Contains "\"y1\":88" @>
+  assertGoalBands goal (TestHost.readBody ctx)
 
 [<Fact>]
 let ``trendsPanel with gran=weekly returns fragment with sub-period buttons and stats`` () =


### PR DESCRIPTION
## Summary
- `HandlerTestHelpers.fs`: add `sampleMember` (reusable default member fixture), `memberWithGoal` (custom goal range factory), and `assertGoalBands` (4-assertion helper for goal-band chart tests)
- `LoginHandlerTests.fs`: replace 8-field `unclaimedMember` literal with `sampleMember`
- `PlotlyVendoringTests.fs`: replace 8-field `defaultMember` literal with `HandlerTestHelpers.sampleMember`
- `MemberHandlerTests.fs`: replace inline `secondAdmin` record literal with `adminMember 2 "Alice"` (existing helper)
- `ReadingHandlerTests.fs`, `TrendHandlerTests.fs`, `RecentHandlerTests.fs`: replace the copy-pasted "build member with custom goal + 4 y0/y1 body assertions" pattern with `memberWithGoal`/`assertGoalBands`
- `RecentHandlerTests.fs`: hoist duplicated `stripR1/stripR2/stripR3` readings to module level (were re-declared verbatim in two tests)
- `RecentHandlerTests.fs`: use `_.Groups[1].Value` shorthand (AGENTS.md style convention)