### PR TITLE
🔧 chore(core-tests): consolidate test builders and generators

### DIFF
--- a/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
+++ b/code/BpMonitor.Core.Tests/BpMonitor.Core.Tests.fsproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <Compile Include="Generators.fs" />
+    <Compile Include="TestBuilders.fs" />
     <Compile Include="GoalRangeTests.fs" />
     <Compile Include="BloodPressureReadingTests.fs" />
     <Compile Include="BloodPressureReadingPropertyTests.fs" />

--- a/code/BpMonitor.Core.Tests/FamilyMemberTests.fs
+++ b/code/BpMonitor.Core.Tests/FamilyMemberTests.fs
@@ -3,6 +3,7 @@ module FamilyMemberTests
 open Xunit
 open Swensen.Unquote
 open BpMonitor.Core
+open TestBuilders
 
 [<Fact>]
 let ``create seeds default goal range`` () =
@@ -42,52 +43,17 @@ let ``hasActiveAdmin is false for empty list`` () =
 
 [<Fact>]
 let ``hasActiveAdmin is false when no member is admin`` () =
-  let members =
-    [ { Id = 1
-        Name = "A"
-        IsAdmin = false
-        IsActive = true
-        PasswordHash = None
-        Goal = GoalRange.defaults
-        CreatedAt = System.DateTimeOffset.MinValue
-        ModifiedAt = System.DateTimeOffset.MinValue } ]
-
+  let members = [ mkMember 1 "A" false true ]
   test <@ FamilyMember.hasActiveAdmin members = false @>
 
 [<Fact>]
 let ``hasActiveAdmin is false when admin member is inactive`` () =
-  let members =
-    [ { Id = 1
-        Name = "A"
-        IsAdmin = true
-        IsActive = false
-        PasswordHash = None
-        Goal = GoalRange.defaults
-        CreatedAt = System.DateTimeOffset.MinValue
-        ModifiedAt = System.DateTimeOffset.MinValue } ]
-
+  let members = [ mkMember 1 "A" true false ]
   test <@ FamilyMember.hasActiveAdmin members = false @>
 
 [<Fact>]
 let ``hasActiveAdmin is true when at least one member is admin and active`` () =
-  let members =
-    [ { Id = 1
-        Name = "A"
-        IsAdmin = false
-        IsActive = true
-        PasswordHash = None
-        Goal = GoalRange.defaults
-        CreatedAt = System.DateTimeOffset.MinValue
-        ModifiedAt = System.DateTimeOffset.MinValue }
-      { Id = 2
-        Name = "B"
-        IsAdmin = true
-        IsActive = true
-        PasswordHash = None
-        Goal = GoalRange.defaults
-        CreatedAt = System.DateTimeOffset.MinValue
-        ModifiedAt = System.DateTimeOffset.MinValue } ]
-
+  let members = [ mkMember 1 "A" false true; mkMember 2 "B" true true ]
   test <@ FamilyMember.hasActiveAdmin members = true @>
 
 [<Fact>]

--- a/code/BpMonitor.Core.Tests/Generators.fs
+++ b/code/BpMonitor.Core.Tests/Generators.fs
@@ -63,3 +63,21 @@ let mixedUnvalidatedGen: Gen<BloodPressureReadingUnvalidated> =
 /// An int strictly below the minimum or strictly above the maximum.
 let outOfRangeGen (lo: int) (hi: int) : Gen<int> =
   Gen.oneof [ Gen.choose (lo - 1000, lo - 1); Gen.choose (hi + 1, hi + 1000) ]
+
+/// x/y series biased toward conditions that make a local LOWESS fit singular:
+/// x's from a small discrete set create duplicate x-values, and outlier y's
+/// get bisquare-zeroed during robustifying iterations.
+let clusteredSeriesGen: Gen<float list * float list> =
+  gen {
+    let! n = Gen.choose (3, 25)
+    let! xs = Gen.choose (0, 10) |> Gen.map float |> Gen.listOfLength n
+
+    let! ys =
+      Gen.frequency
+        [ 8, Gen.choose (60, 180) |> Gen.map float
+          1, Gen.choose (-500, -200) |> Gen.map float
+          1, Gen.choose (500, 1000) |> Gen.map float ]
+      |> Gen.listOfLength n
+
+    return xs, ys
+  }

--- a/code/BpMonitor.Core.Tests/LowessPropertyTests.fs
+++ b/code/BpMonitor.Core.Tests/LowessPropertyTests.fs
@@ -4,26 +4,7 @@ open FsCheck
 open FsCheck.FSharp
 open FsCheck.Xunit
 open BpMonitor.Core
-
-/// x/y series biased toward the conditions that can make a local LOWESS fit singular:
-/// x's drawn from a small discrete set make duplicate x-values (e.g., same-day readings on
-/// the real /recent chart) likely, and a few outlier y's are large enough to get
-/// bisquare-zeroed during the robustifying iterations — together the combination that
-/// drove `weightedLinearFitAt`'s 0.0/0.0 division.
-let private clusteredSeriesGen: Gen<float list * float list> =
-  gen {
-    let! n = Gen.choose (3, 25)
-    let! xs = Gen.choose (0, 10) |> Gen.map float |> Gen.listOfLength n
-
-    let! ys =
-      Gen.frequency
-        [ 8, Gen.choose (60, 180) |> Gen.map float // plausible BP-like values
-          1, Gen.choose (-500, -200) |> Gen.map float // low outlier
-          1, Gen.choose (500, 1000) |> Gen.map float ] // high outlier
-      |> Gen.listOfLength n
-
-    return xs, ys
-  }
+open Generators
 
 [<Property>]
 let ``smooth never returns NaN or Infinity for any finite series and bandwidth`` () =

--- a/code/BpMonitor.Core.Tests/ReadingRepositoryContractTests.fs
+++ b/code/BpMonitor.Core.Tests/ReadingRepositoryContractTests.fs
@@ -4,6 +4,7 @@ open System
 open Xunit
 open Swensen.Unquote
 open BpMonitor.Core
+open TestBuilders
 
 type private StubRepository(initial: BloodPressureReading list) =
   let readings = ResizeArray<BloodPressureReading>(initial)
@@ -27,15 +28,7 @@ type private StubRepository(initial: BloodPressureReading list) =
       | None -> ()
 
 let private reading id memberId sys dia hr =
-  { Id = id
-    MemberId = memberId
-    Systolic = sys
-    Diastolic = dia
-    HeartRate = hr
-    Timestamp = Timestamp.utc 2026 1 1 9 0 0
-    Comments = None
-    CreatedAt = DateTimeOffset.MinValue
-    ModifiedAt = DateTimeOffset.MinValue }
+  mkReading id memberId sys dia hr (Timestamp.utc 2026 1 1 9 0 0)
 
 [<Fact>]
 let ``Update replaces the reading with the matching Id`` () =

--- a/code/BpMonitor.Core.Tests/ReadingStatsTests.fs
+++ b/code/BpMonitor.Core.Tests/ReadingStatsTests.fs
@@ -4,17 +4,7 @@ open System
 open Xunit
 open Swensen.Unquote
 open BpMonitor.Core
-
-let private mkReading id sys dia hr (ts: DateTimeOffset) =
-  { Id = id
-    MemberId = 1
-    Systolic = sys
-    Diastolic = dia
-    HeartRate = hr
-    Timestamp = ts
-    Comments = None
-    CreatedAt = DateTimeOffset.MinValue
-    ModifiedAt = DateTimeOffset.MinValue }
+open TestBuilders
 
 let private now = DateTimeOffset(2026, 6, 9, 12, 0, 0, TimeSpan.Zero)
 
@@ -26,23 +16,23 @@ let private currentWeeklyPeriod = TrendPeriod.current Weekly now
 [<Fact>]
 let ``between: reading exactly at start is included`` () =
   let start = now.AddDays(-7.0)
-  let r = mkReading 1 120 80 70 start
+  let r = mkReading 1 1 120 80 70 start
   test <@ ReadingStats.between start (now.AddDays(1.0)) [ r ] = [ r ] @>
 
 [<Fact>]
 let ``between: reading exactly at endExcl is excluded`` () =
   let endExcl = now
-  let r = mkReading 1 120 80 70 endExcl
+  let r = mkReading 1 1 120 80 70 endExcl
   test <@ ReadingStats.between (now.AddDays(-7.0)) endExcl [ r ] = [] @>
 
 [<Fact>]
 let ``between: reading inside range is included`` () =
-  let r = mkReading 1 120 80 70 (now.AddDays(-3.0))
+  let r = mkReading 1 1 120 80 70 (now.AddDays(-3.0))
   test <@ ReadingStats.between (now.AddDays(-7.0)) now [ r ] = [ r ] @>
 
 [<Fact>]
 let ``between: reading before range is excluded`` () =
-  let r = mkReading 1 120 80 70 (now.AddDays(-10.0))
+  let r = mkReading 1 1 120 80 70 (now.AddDays(-10.0))
   test <@ ReadingStats.between (now.AddDays(-7.0)) now [ r ] = [] @>
 
 [<Fact>]
@@ -57,7 +47,7 @@ let ``dailyAverages: empty list returns empty`` () =
 
 [<Fact>]
 let ``dailyAverages: single reading returns one entry with same values`` () =
-  let r = mkReading 1 130 85 68 (now.AddDays(-1.0))
+  let r = mkReading 1 1 130 85 68 (now.AddDays(-1.0))
   let result = ReadingStats.dailyAverages [ r ]
   test <@ result.Length = 1 @>
   let day = result[0]
@@ -68,8 +58,11 @@ let ``dailyAverages: single reading returns one entry with same values`` () =
 [<Fact>]
 let ``dailyAverages: two readings on same day are averaged`` () =
   let day0 = now.Date
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(day0.AddHours(8.0), TimeSpan.Zero))
-  let r2 = mkReading 2 140 90 80 (DateTimeOffset(day0.AddHours(20.0), TimeSpan.Zero))
+  let r1 = mkReading 1 1 120 80 60 (DateTimeOffset(day0.AddHours(8.0), TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 140 90 80 (DateTimeOffset(day0.AddHours(20.0), TimeSpan.Zero))
+
   let result = ReadingStats.dailyAverages [ r1; r2 ]
   test <@ result.Length = 1 @>
   test <@ result[0].Systolic = 130 @>
@@ -78,21 +71,21 @@ let ``dailyAverages: two readings on same day are averaged`` () =
 
 [<Fact>]
 let ``dailyAverages: readings on different days produce one entry per day`` () =
-  let r1 = mkReading 1 120 80 60 (now.AddDays(-2.0))
-  let r2 = mkReading 2 130 85 70 (now.AddDays(-1.0))
+  let r1 = mkReading 1 1 120 80 60 (now.AddDays(-2.0))
+  let r2 = mkReading 2 1 130 85 70 (now.AddDays(-1.0))
   let result = ReadingStats.dailyAverages [ r1; r2 ]
   test <@ result.Length = 2 @>
 
 [<Fact>]
 let ``dailyAverages: result is sorted ascending by date`` () =
-  let r1 = mkReading 1 130 85 70 (now.AddDays(-1.0))
-  let r2 = mkReading 2 120 80 60 (now.AddDays(-3.0))
+  let r1 = mkReading 1 1 130 85 70 (now.AddDays(-1.0))
+  let r2 = mkReading 2 1 120 80 60 (now.AddDays(-3.0))
   let result = ReadingStats.dailyAverages [ r1; r2 ]
   test <@ result[0].Timestamp < result[1].Timestamp @>
 
 [<Fact>]
 let ``dailyAverages: timestamp is midnight of the local date`` () =
-  let r = mkReading 1 120 80 60 (now.AddDays(-1.0))
+  let r = mkReading 1 1 120 80 60 (now.AddDays(-1.0))
   let day = ReadingStats.dailyAverages [ r ] |> List.exactlyOne
   let ts = day.Timestamp.ToLocalTime()
   let h, m, s = ts.Hour, ts.Minute, ts.Second
@@ -107,8 +100,12 @@ let ``weeklyAverages: empty list returns empty`` () =
 [<Fact>]
 let ``weeklyAverages: readings in same ISO week are averaged into one entry`` () =
   // 2026-W24: Mon 2026-06-08 ... Sun 2026-06-14
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 140 90 80 (DateTimeOffset(2026, 6, 10, 9, 0, 0, TimeSpan.Zero))
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 140 90 80 (DateTimeOffset(2026, 6, 10, 9, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.weeklyAverages [ r1; r2 ]
   test <@ result.Length = 1 @>
   test <@ result[0].Systolic = 130 @>
@@ -117,21 +114,31 @@ let ``weeklyAverages: readings in same ISO week are averaged into one entry`` ()
 
 [<Fact>]
 let ``weeklyAverages: readings in different weeks produce one entry per week`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)) // W23
-  let r2 = mkReading 2 130 85 70 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero)) // W24
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)) // W23
+
+  let r2 =
+    mkReading 2 1 130 85 70 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero)) // W24
+
   let result = ReadingStats.weeklyAverages [ r1; r2 ]
   test <@ result.Length = 2 @>
 
 [<Fact>]
 let ``weeklyAverages: result is sorted ascending`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero)) // W24
-  let r2 = mkReading 2 130 85 70 (DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)) // W23
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero)) // W24
+
+  let r2 =
+    mkReading 2 1 130 85 70 (DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)) // W23
+
   let result = ReadingStats.weeklyAverages [ r1; r2 ]
   test <@ result[0].Timestamp < result[1].Timestamp @>
 
 [<Fact>]
 let ``weeklyAverages: timestamp is Monday midnight of the ISO week`` () =
-  let r = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 10, 15, 0, 0, TimeSpan.Zero)) // W24 (Wednesday)
+  let r =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 10, 15, 0, 0, TimeSpan.Zero)) // W24 (Wednesday)
+
   let result = ReadingStats.weeklyAverages [ r ]
   let ts = result[0].Timestamp.ToLocalTime()
   let y, mo, d = ts.Year, ts.Month, ts.Day
@@ -146,29 +153,43 @@ let ``monthlyAverages: empty list returns empty`` () =
 
 [<Fact>]
 let ``monthlyAverages: readings in same month are averaged into one entry`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 5, 9, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 140 90 80 (DateTimeOffset(2026, 6, 20, 9, 0, 0, TimeSpan.Zero))
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 5, 9, 0, 0, TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 140 90 80 (DateTimeOffset(2026, 6, 20, 9, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.monthlyAverages [ r1; r2 ]
   test <@ result.Length = 1 @>
   test <@ result[0].Systolic = 130 @>
 
 [<Fact>]
 let ``monthlyAverages: readings in different months produce one entry per month`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 130 85 70 (DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.Zero))
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 130 85 70 (DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.monthlyAverages [ r1; r2 ]
   test <@ result.Length = 2 @>
 
 [<Fact>]
 let ``monthlyAverages: result is sorted ascending`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 130 85 70 (DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero))
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 130 85 70 (DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.monthlyAverages [ r1; r2 ]
   test <@ result[0].Timestamp < result[1].Timestamp @>
 
 [<Fact>]
 let ``monthlyAverages: timestamp is first of month midnight`` () =
-  let r = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero))
+  let r =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.monthlyAverages [ r ]
   let ts = result[0].Timestamp.ToLocalTime()
   let y, mo, d = ts.Year, ts.Month, ts.Day
@@ -178,52 +199,76 @@ let ``monthlyAverages: timestamp is first of month midnight`` () =
 
 [<Fact>]
 let ``aggregate Weekly delegates to dailyAverages`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 140 90 80 (DateTimeOffset(2026, 6, 8, 20, 0, 0, TimeSpan.Zero))
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 140 90 80 (DateTimeOffset(2026, 6, 8, 20, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.aggregate Weekly [ r1; r2 ]
   // Two readings on same day → one daily average
   test <@ result.Length = 1 @>
 
 [<Fact>]
 let ``aggregate Monthly delegates to weeklyAverages`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)) // W23
-  let r2 = mkReading 2 130 85 70 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero)) // W24
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)) // W23
+
+  let r2 =
+    mkReading 2 1 130 85 70 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero)) // W24
+
   let result = ReadingStats.aggregate Monthly [ r1; r2 ]
   // Two different weeks → two weekly averages
   test <@ result.Length = 2 @>
 
 [<Fact>]
 let ``aggregate Yearly delegates to monthlyAverages`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 130 85 70 (DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.Zero))
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 130 85 70 (DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.aggregate Yearly [ r1; r2 ]
   // Two different months → two monthly averages
   test <@ result.Length = 2 @>
 
 [<Fact>]
 let ``aggregate Weekly: two readings on same day yields Count=2`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 140 90 80 (DateTimeOffset(2026, 6, 8, 20, 0, 0, TimeSpan.Zero))
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 140 90 80 (DateTimeOffset(2026, 6, 8, 20, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.aggregate Weekly [ r1; r2 ]
   test <@ result[0].Count = 2 @>
 
 [<Fact>]
 let ``aggregate Weekly: single reading on a day yields Count=1`` () =
-  let r = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
+  let r = mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
   let result = ReadingStats.aggregate Weekly [ r ]
   test <@ result[0].Count = 1 @>
 
 [<Fact>]
 let ``aggregate Monthly: two readings in same ISO week yields Count=2`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 140 90 80 (DateTimeOffset(2026, 6, 9, 9, 0, 0, TimeSpan.Zero))
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 140 90 80 (DateTimeOffset(2026, 6, 9, 9, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.aggregate Monthly [ r1; r2 ]
   test <@ result[0].Count = 2 @>
 
 [<Fact>]
 let ``aggregate Yearly: two readings in same calendar month yields Count=2`` () =
-  let r1 = mkReading 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
-  let r2 = mkReading 2 140 90 80 (DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.Zero))
+  let r1 =
+    mkReading 1 1 120 80 60 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
+
+  let r2 =
+    mkReading 2 1 140 90 80 (DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.Zero))
+
   let result = ReadingStats.aggregate Yearly [ r1; r2 ]
   test <@ result[0].Count = 2 @>
 
@@ -232,9 +277,9 @@ let ``aggregate Yearly: two readings in same calendar month yields Count=2`` () 
 [<Fact>]
 let ``aggregate Weekly: multi-reading period carries correct MinSystolic and MaxSystolic`` () =
   let day = DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero)
-  let r1 = mkReading 1 110 75 60 (day.AddHours(8.0))
-  let r2 = mkReading 2 130 85 70 (day.AddHours(12.0))
-  let r3 = mkReading 3 150 95 80 (day.AddHours(20.0))
+  let r1 = mkReading 1 1 110 75 60 (day.AddHours(8.0))
+  let r2 = mkReading 2 1 130 85 70 (day.AddHours(12.0))
+  let r3 = mkReading 3 1 150 95 80 (day.AddHours(20.0))
   let a = ReadingStats.aggregate Weekly [ r1; r2; r3 ] |> List.exactlyOne
   test <@ a.MinSystolic = 110 @>
   test <@ a.MaxSystolic = 150 @>
@@ -242,23 +287,23 @@ let ``aggregate Weekly: multi-reading period carries correct MinSystolic and Max
 [<Fact>]
 let ``aggregate Weekly: multi-reading period carries correct MinDiastolic and MaxDiastolic`` () =
   let day = DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero)
-  let r1 = mkReading 1 110 75 60 (day.AddHours(8.0))
-  let r2 = mkReading 2 130 85 70 (day.AddHours(12.0))
-  let r3 = mkReading 3 150 95 80 (day.AddHours(20.0))
+  let r1 = mkReading 1 1 110 75 60 (day.AddHours(8.0))
+  let r2 = mkReading 2 1 130 85 70 (day.AddHours(12.0))
+  let r3 = mkReading 3 1 150 95 80 (day.AddHours(20.0))
   let a = ReadingStats.aggregate Weekly [ r1; r2; r3 ] |> List.exactlyOne
   test <@ a.MinDiastolic = 75 @>
   test <@ a.MaxDiastolic = 95 @>
 
 [<Fact>]
 let ``aggregate Weekly: single-reading period has MinSystolic = MaxSystolic = Reading.Systolic`` () =
-  let r = mkReading 1 130 85 70 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
+  let r = mkReading 1 1 130 85 70 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
   let a = ReadingStats.aggregate Weekly [ r ] |> List.exactlyOne
   test <@ a.MinSystolic = a.Reading.Systolic @>
   test <@ a.MaxSystolic = a.Reading.Systolic @>
 
 [<Fact>]
 let ``aggregate Weekly: single-reading period has MinDiastolic = MaxDiastolic = Reading.Diastolic`` () =
-  let r = mkReading 1 130 85 70 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
+  let r = mkReading 1 1 130 85 70 (DateTimeOffset(2026, 6, 8, 9, 0, 0, TimeSpan.Zero))
   let a = ReadingStats.aggregate Weekly [ r ] |> List.exactlyOne
   test <@ a.MinDiastolic = a.Reading.Diastolic @>
   test <@ a.MaxDiastolic = a.Reading.Diastolic @>
@@ -282,7 +327,7 @@ let ``summarizeRange: period metadata is stamped on the result`` () =
 
 [<Fact>]
 let ``summarizeRange: single reading yields correct averages`` () =
-  let r = mkReading 1 130 85 68 (now.AddDays(-1.0))
+  let r = mkReading 1 1 130 85 68 (now.AddDays(-1.0))
   let s = ReadingStats.summarizeRange currentWeeklyPeriod [ r ]
   test <@ s.Count = 1 @>
   test <@ s.AvgSystolic = 130 @>
@@ -291,8 +336,8 @@ let ``summarizeRange: single reading yields correct averages`` () =
 
 [<Fact>]
 let ``summarizeRange: averages are truncated to int`` () =
-  let r1 = mkReading 1 120 80 70 (now.AddDays(-1.0))
-  let r2 = mkReading 2 121 81 71 (now.AddDays(-2.0))
+  let r1 = mkReading 1 1 120 80 70 (now.AddDays(-1.0))
+  let r2 = mkReading 2 1 121 81 71 (now.AddDays(-2.0))
   let s = ReadingStats.summarizeRange currentWeeklyPeriod [ r1; r2 ]
   test <@ s.Count = 2 @>
   test <@ s.AvgSystolic = 120 @>
@@ -301,9 +346,9 @@ let ``summarizeRange: averages are truncated to int`` () =
 
 [<Fact>]
 let ``summarizeRange: min and max are correct for multiple readings`` () =
-  let r1 = mkReading 1 110 75 60 (now.AddDays(-1.0))
-  let r2 = mkReading 2 130 85 70 (now.AddDays(-2.0))
-  let r3 = mkReading 3 150 95 80 (now.AddDays(-3.0))
+  let r1 = mkReading 1 1 110 75 60 (now.AddDays(-1.0))
+  let r2 = mkReading 2 1 130 85 70 (now.AddDays(-2.0))
+  let r3 = mkReading 3 1 150 95 80 (now.AddDays(-3.0))
   let s = ReadingStats.summarizeRange currentWeeklyPeriod [ r1; r2; r3 ]
   test <@ s.MinSystolic = 110 @>
   test <@ s.MaxSystolic = 150 @>
@@ -314,7 +359,7 @@ let ``summarizeRange: min and max are correct for multiple readings`` () =
 
 [<Fact>]
 let ``summarizeRange: min and max equal avg for a single reading`` () =
-  let r = mkReading 1 130 85 68 (now.AddDays(-1.0))
+  let r = mkReading 1 1 130 85 68 (now.AddDays(-1.0))
   let s = ReadingStats.summarizeRange currentWeeklyPeriod [ r ]
   test <@ s.MinSystolic = 130 && s.MaxSystolic = 130 @>
   test <@ s.MinDiastolic = 85 && s.MaxDiastolic = 85 @>

--- a/code/BpMonitor.Core.Tests/TestBuilders.fs
+++ b/code/BpMonitor.Core.Tests/TestBuilders.fs
@@ -1,0 +1,25 @@
+module TestBuilders
+
+open System
+open BpMonitor.Core
+
+let mkReading id memberId sys dia hr (ts: DateTimeOffset) : BloodPressureReading =
+  { Id = id
+    MemberId = memberId
+    Systolic = sys
+    Diastolic = dia
+    HeartRate = hr
+    Timestamp = ts
+    Comments = None
+    CreatedAt = DateTimeOffset.MinValue
+    ModifiedAt = DateTimeOffset.MinValue }
+
+let mkMember id name isAdmin isActive : FamilyMember =
+  { Id = id
+    Name = name
+    IsAdmin = isAdmin
+    IsActive = isActive
+    PasswordHash = None
+    Goal = GoalRange.defaults
+    CreatedAt = DateTimeOffset.MinValue
+    ModifiedAt = DateTimeOffset.MinValue }


### PR DESCRIPTION
## Summary

- Extract shared `mkReading` and `mkMember` builders to `TestBuilders.fs` — centralizes test object creation across 4 test files
- Consolidate generator definitions into `Generators.fs` — move `clusteredSeriesGen` from inline to shared module
- Reduce duplication: replace verbose record literals with builder calls
- All 164 Core.Tests pass; full build succeeds