### PR TITLE
🔧 chore(web-tests): theory-ize VersionTests; dedup ExportHandlerTests

### DIFF
--- a/code/BpMonitor.Web.Tests/ExportHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/ExportHandlerTests.fs
@@ -1,25 +1,22 @@
 module ExportHandlerTests
 
+open System.Threading.Tasks
+open Microsoft.AspNetCore.Http
 open Xunit
 open Swensen.Unquote
 open BpMonitor.Web
 open HandlerTestHelpers
 
-[<Fact>]
-let ``exportJson returns 200 with application/json content type`` () =
+let private assertExportResponse (handler: HttpContext -> Task) (contentType: string) (filename: string) =
   let ctx = TestHost.context (repoWith [ sample ])
-  TestHost.run ReadingHandlers.exportJson ctx
-
+  TestHost.run handler ctx
   test <@ ctx.Response.StatusCode = 200 @>
-  test <@ ctx.Response.ContentType = "application/json; charset=utf-8" @>
+  test <@ ctx.Response.ContentType = contentType @>
+  test <@ ctx.Response.Headers["Content-Disposition"].ToString() = $"attachment; filename=\"{filename}\"" @>
 
 [<Fact>]
-let ``exportJson sets Content-Disposition to attachment with correct filename`` () =
-  let ctx = TestHost.context (repoWith [ sample ])
-  TestHost.run ReadingHandlers.exportJson ctx
-
-  let disposition = ctx.Response.Headers["Content-Disposition"].ToString()
-  test <@ disposition = "attachment; filename=\"bpmonitor-export.json\"" @>
+let ``exportJson returns 200, json content type, and attachment header`` () =
+  assertExportResponse ReadingHandlers.exportJson "application/json; charset=utf-8" "bpmonitor-export.json"
 
 [<Fact>]
 let ``exportJson body contains the seeded reading's fields`` () =
@@ -44,20 +41,8 @@ let ``exportJson returns only the active member's readings`` () =
   test <@ body.StartsWith "[{" && body.EndsWith "}]" @>
 
 [<Fact>]
-let ``exportCsv returns 200 with text/csv content type`` () =
-  let ctx = TestHost.context (repoWith [ sample ])
-  TestHost.run ReadingHandlers.exportCsv ctx
-
-  test <@ ctx.Response.StatusCode = 200 @>
-  test <@ ctx.Response.ContentType = "text/csv; charset=utf-8" @>
-
-[<Fact>]
-let ``exportCsv sets Content-Disposition to attachment with correct filename`` () =
-  let ctx = TestHost.context (repoWith [ sample ])
-  TestHost.run ReadingHandlers.exportCsv ctx
-
-  let disposition = ctx.Response.Headers["Content-Disposition"].ToString()
-  test <@ disposition = "attachment; filename=\"bpmonitor-export.csv\"" @>
+let ``exportCsv returns 200, csv content type, and attachment header`` () =
+  assertExportResponse ReadingHandlers.exportCsv "text/csv; charset=utf-8" "bpmonitor-export.csv"
 
 [<Fact>]
 let ``exportCsv body contains header row and seeded reading's fields`` () =

--- a/code/BpMonitor.Web.Tests/VersionTests.fs
+++ b/code/BpMonitor.Web.Tests/VersionTests.fs
@@ -4,32 +4,19 @@ open Xunit
 open Swensen.Unquote
 open BpMonitor.Web
 
-[<Fact>]
-let ``parse None returns dev`` () = test <@ Version.parse None = "dev" @>
+[<Theory>]
+[<InlineData(null)>]
+[<InlineData("")>]
+[<InlineData("   ")>]
+[<InlineData("1.0.0+abc123")>]
+let ``parse returns dev for None and sentinel values`` (raw: string) =
+  test <@ Version.parse (Option.ofObj raw) = "dev" @>
 
-[<Fact>]
-let ``parse empty string returns dev`` () =
-  test <@ Version.parse (Some "") = "dev" @>
-
-[<Fact>]
-let ``parse whitespace returns dev`` () =
-  test <@ Version.parse (Some "   ") = "dev" @>
-
-[<Fact>]
-let ``parse 1.0.0 returns 1.0.0`` () =
-  test <@ Version.parse (Some "1.0.0") = "1.0.0" @>
-
-[<Fact>]
-let ``parse real version returns it unchanged`` () =
-  test <@ Version.parse (Some "0.1.14") = "0.1.14" @>
-
-[<Fact>]
-let ``parse preserves build metadata after plus`` () =
-  test <@ Version.parse (Some "0.1.14+abc123") = "0.1.14+abc123" @>
-
-[<Fact>]
-let ``parse 1.0.0 with sha returns dev`` () =
-  test <@ Version.parse (Some "1.0.0+abc123") = "dev" @>
+[<Theory>]
+[<InlineData("1.0.0")>]
+[<InlineData("0.1.14")>]
+[<InlineData("0.1.14+abc123")>]
+let ``parse returns the version unchanged`` (v: string) = test <@ Version.parse (Some v) = v @>
 
 [<Fact>]
 let ``releaseUrl returns None for dev`` () =


### PR DESCRIPTION
## Summary

- **VersionTests**: collapse 7 near-duplicate `[<Fact>]`s into two `[<Theory>]` cases — one for dev-sentinel inputs (`null`, `""`, `"   "`, `"1.0.0+abc123"`) and one for pass-through inputs (`"1.0.0"`, `"0.1.14"`, `"0.1.14+abc123"`); the two `releaseUrl` facts are unchanged (distinct behaviors)
- **ExportHandlerTests**: extract private `assertExportResponse` helper (status + content-type + Content-Disposition); merge the 4 duplicated response-header facts into 2 (one per format), reducing 8 → 6 tests