### PR TITLE
♻️ refactor(web): add withMemberAndRouteId combinator; rewrite newReading with withMember

### DIFF
--- a/code/BpMonitor.Web/AuthHandlers.fs
+++ b/code/BpMonitor.Web/AuthHandlers.fs
@@ -83,6 +83,15 @@ module AuthHandlers =
         Task.CompletedTask
       | Some m -> handler m ctx
 
+  /// Resolves both the authenticated member and the "id" route segment, passing both to
+  /// `handler`. Redirects to /login if the member cannot be resolved; returns 400 for a
+  /// non-integer id.
+  let withMemberAndRouteId
+    (handlerName: string)
+    (handler: FamilyMember -> int -> HttpContext -> Task)
+    : HttpContext -> Task =
+    withMember (fun m ctx -> (withRouteId handlerName (fun id ctx -> handler m id ctx)) ctx)
+
   // ---------------------------------------------------------------------------
   // Login / logout
   // ---------------------------------------------------------------------------

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -250,48 +250,33 @@ module ReadingHandlers =
   // ---------------------------------------------------------------------------
 
   let newReading: HttpContext -> Task =
-    fun ctx ->
-      let m = authenticatedMember ctx
-
+    withMember (fun m ctx ->
       let prefill =
         { Binding.empty with
             Binding.Timestamp = (timeProvider ctx).GetLocalNow().ToString(Formats.timestamp) }
 
-      htmlResponse
-        (ReadingViews.readingForm
-          Routes.add
-          (m |> Option.map _.Name |> Option.defaultValue "")
-          (m |> Option.exists _.IsAdmin)
-          "Add reading"
-          Routes.readings
-          []
-          prefill)
-        ctx
+      htmlResponse (ReadingViews.readingForm Routes.add m.Name m.IsAdmin "Add reading" Routes.readings [] prefill) ctx)
 
   let createReading: HttpContext -> Task =
     withMember (fun m ctx ->
       submit ctx Routes.add m.Name m.IsAdmin "Add reading" Routes.readings Routes.recent ((repo ctx).Add m.Id))
 
   let editReading: HttpContext -> Task =
-    withMember (fun m ctx ->
-      (withRouteId "editReading" (fun id ctx ->
-        match (repo ctx).GetAll(m.Id) |> List.tryFind (fun r -> r.Id = id) with
-        | Some r ->
-          htmlResponse
-            (ReadingViews.readingForm "" m.Name m.IsAdmin "Edit reading" $"/readings/{id}" [] (Binding.ofReading r))
-            ctx
-        | None ->
-          let log = logger ctx
-          log.LogWarning("editReading: reading {Id} not found for member {MemberId}", id, m.Id)
-          notFound ctx))
-        ctx)
+    withMemberAndRouteId "editReading" (fun m id ctx ->
+      match (repo ctx).GetAll(m.Id) |> List.tryFind (fun r -> r.Id = id) with
+      | Some r ->
+        htmlResponse
+          (ReadingViews.readingForm "" m.Name m.IsAdmin "Edit reading" $"/readings/{id}" [] (Binding.ofReading r))
+          ctx
+      | None ->
+        let log = logger ctx
+        log.LogWarning("editReading: reading {Id} not found for member {MemberId}", id, m.Id)
+        notFound ctx)
 
   let updateReading: HttpContext -> Task =
-    withMember (fun m ctx ->
-      (withRouteId "updateReading" (fun id ctx ->
-        submit ctx "" m.Name m.IsAdmin "Edit reading" $"/readings/{id}" Routes.history (fun r ->
-          (repo ctx).Update { r with Id = id; MemberId = m.Id })))
-        ctx)
+    withMemberAndRouteId "updateReading" (fun m id ctx ->
+      submit ctx "" m.Name m.IsAdmin "Edit reading" $"/readings/{id}" Routes.history (fun r ->
+        (repo ctx).Update { r with Id = id; MemberId = m.Id }))
 
   // ---------------------------------------------------------------------------
   // Export


### PR DESCRIPTION
## Summary

- Added `withMemberAndRouteId` combinator to `AuthHandlers` — composes `withMember` + `withRouteId` so `editReading`/`updateReading` no longer need to nest the two combinators manually
- Rewrote `newReading` to use `withMember` instead of calling `authenticatedMember` directly and branching on `Option`; member name and admin flag now come straight from the resolved `FamilyMember`
- `editReading` and `updateReading` simplified from double-nested lambda to a flat `withMemberAndRouteId` call