### PR TITLE
♻️ refactor(web): introduce parametric route-builders; eliminate inline string interpolation

### DIFF
--- a/code/BpMonitor.Web/AuthHandlers.fs
+++ b/code/BpMonitor.Web/AuthHandlers.fs
@@ -160,7 +160,7 @@ module AuthHandlers =
           | Some hash -> do! claimedLogin m password hash (LoginViews.loginPage [ "Invalid name or password" ]) ctx
           | None ->
             // Unclaimed: redirect to per-member claim page
-            ctx.Response.Redirect $"{Routes.login}/{m.Id}"
+            ctx.Response.Redirect(Routes.loginMember m.Id)
       }
       :> Task
 

--- a/code/BpMonitor.Web/MemberHandlers.fs
+++ b/code/BpMonitor.Web/MemberHandlers.fs
@@ -35,7 +35,14 @@ module MemberHandlers =
   let editMember: HttpContext -> Task =
     withRouteMember "editMember" (fun m ctx ->
       htmlResponse
-        (MemberViews.memberForm Routes.members (authenticatedMemberName ctx) true "Edit member" $"/members/{m.Id}" [] m)
+        (MemberViews.memberForm
+          Routes.members
+          (authenticatedMemberName ctx)
+          true
+          "Edit member"
+          (Routes.memberUpdate m.Id)
+          []
+          m)
         ctx)
 
   let private renderMemberEditError
@@ -46,7 +53,10 @@ module MemberHandlers =
     (ctx: HttpContext)
     : Task =
     ctx.Response.StatusCode <- 422
-    htmlResponse (MemberViews.memberForm Routes.members adminName true "Edit member" $"/members/{id}" errors m) ctx
+
+    htmlResponse
+      (MemberViews.memberForm Routes.members adminName true "Edit member" (Routes.memberUpdate id) errors m)
+      ctx
 
   let private applyMemberEdit
     (id: int)

--- a/code/BpMonitor.Web/MemberViews.fs
+++ b/code/BpMonitor.Web/MemberViews.fs
@@ -31,10 +31,10 @@ module MemberViews =
             [ Attr.style "display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap" ]
             [ if isCurrent then
                 Elem.span [ Attr.class' "current-member" ] [ Text.raw "You" ]
-              Elem.a [ Attr.href $"/members/{m.Id}/edit"; Attr.class' "outline" ] [ Text.raw "Edit" ]
+              Elem.a [ Attr.href (Routes.memberEdit m.Id); Attr.class' "outline" ] [ Text.raw "Edit" ]
               Elem.form
                 [ Attr.method "post"
-                  Attr.action $"/members/{m.Id}/reset-password"
+                  Attr.action (Routes.memberResetPassword m.Id)
                   Attr.class' "inline" ]
                 [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Reset password" ] ] ] ]
 

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -266,7 +266,14 @@ module ReadingHandlers =
       match (repo ctx).GetAll(m.Id) |> List.tryFind (fun r -> r.Id = id) with
       | Some r ->
         htmlResponse
-          (ReadingViews.readingForm "" m.Name m.IsAdmin "Edit reading" $"/readings/{id}" [] (Binding.ofReading r))
+          (ReadingViews.readingForm
+            ""
+            m.Name
+            m.IsAdmin
+            "Edit reading"
+            (Routes.readingUpdate id)
+            []
+            (Binding.ofReading r))
           ctx
       | None ->
         let log = logger ctx
@@ -275,7 +282,7 @@ module ReadingHandlers =
 
   let updateReading: HttpContext -> Task =
     withMemberAndRouteId "updateReading" (fun m id ctx ->
-      submit ctx "" m.Name m.IsAdmin "Edit reading" $"/readings/{id}" Routes.history (fun r ->
+      submit ctx "" m.Name m.IsAdmin "Edit reading" (Routes.readingUpdate id) Routes.history (fun r ->
         (repo ctx).Update { r with Id = id; MemberId = m.Id }))
 
   // ---------------------------------------------------------------------------

--- a/code/BpMonitor.Web/Routes.fs
+++ b/code/BpMonitor.Web/Routes.fs
@@ -15,3 +15,11 @@ module Routes =
   let exportJson = "/export"
   let exportCsv = "/export.csv"
   let settings = "/settings"
+
+  // Parametric URL builders for id-scoped resources.
+  let readingEdit (id: int) = $"/readings/{id}/edit"
+  let readingUpdate (id: int) = $"/readings/{id}"
+  let memberEdit (id: int) = $"/members/{id}/edit"
+  let memberUpdate (id: int) = $"/members/{id}"
+  let memberResetPassword (id: int) = $"/members/{id}/reset-password"
+  let loginMember (id: int) = $"{login}/{id}"

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -187,6 +187,6 @@ module ViewLayout =
           Elem.td [ Attr.class' "col-center" ] [ Text.enc (string r.Diastolic) ]
           Elem.td [ Attr.class' "col-center" ] [ Text.enc (string r.HeartRate) ]
           Elem.td [] [ Text.enc (r.Comments |> Option.defaultValue "") ]
-          Elem.td [] [ Elem.a [ Attr.href $"/readings/{r.Id}/edit" ] [ Text.raw "Edit" ] ] ]
+          Elem.td [] [ Elem.a [ Attr.href (Routes.readingEdit r.Id) ] [ Text.raw "Edit" ] ] ]
 
     Elem.div [ Attr.id "readings" ] [ Elem.table [] [ header; Elem.tbody [] (readings |> List.map row) ] ]


### PR DESCRIPTION
## Summary

- Added parametric URL builders to `Routes` module: `readingEdit`, `readingUpdate`, `memberEdit`, `memberUpdate`, `memberResetPassword`, `loginMember`
- Replaced all inline string interpolations (`$"/readings/{id}"`, `$"/members/{m.Id}/edit"`, etc.) across `ViewLayout`, `ReadingHandlers`, `MemberHandlers`, `MemberViews`, and `AuthHandlers` with calls to the new builders
- Route templates in `Program.fs` (which use ASP.NET constraint syntax like `{id:int}`) are unchanged — only URL construction sites are affected