### PR TITLE
♻️ refactor(web): extract formActions helper; unify member errors to string list; inline CSS to class

### DIFF
--- a/code/BpMonitor.Web.Tests/MemberViewTests.fs
+++ b/code/BpMonitor.Web.Tests/MemberViewTests.fs
@@ -21,7 +21,7 @@ let ``members page renders Admin and Active columns and Edit link`` () =
       ModifiedAt = DateTimeOffset.MinValue }
 
   let html =
-    renderHtml (MemberViews.members [ defaultMember; otherMember ] defaultMember None)
+    renderHtml (MemberViews.members [ defaultMember; otherMember ] defaultMember [])
 
   test <@ html.Contains "Admin" @>
   test <@ html.Contains "Active" @>
@@ -44,19 +44,19 @@ let ``members page shows claimed/unclaimed badge`` () =
       CreatedAt = DateTimeOffset.MinValue
       ModifiedAt = DateTimeOffset.MinValue }
 
-  let html = renderHtml (MemberViews.members [ claimed; unclaimed ] claimed None)
+  let html = renderHtml (MemberViews.members [ claimed; unclaimed ] claimed [])
 
   test <@ html.Contains "Claimed" @>
   test <@ html.Contains "Unclaimed" @>
 
 [<Fact>]
 let ``members page shows reset-password button`` () =
-  let html = renderHtml (MemberViews.members [ defaultMember ] defaultMember None)
+  let html = renderHtml (MemberViews.members [ defaultMember ] defaultMember [])
   test <@ html.Contains "reset-password" @>
 
 [<Fact>]
 let ``members page does NOT show Switch button`` () =
-  let html = renderHtml (MemberViews.members [ defaultMember ] defaultMember None)
+  let html = renderHtml (MemberViews.members [ defaultMember ] defaultMember [])
   test <@ not (html.Contains "/members/switch") @>
 
 [<Fact>]

--- a/code/BpMonitor.Web/MemberHandlers.fs
+++ b/code/BpMonitor.Web/MemberHandlers.fs
@@ -12,7 +12,7 @@ module MemberHandlers =
   let members: HttpContext -> Task =
     withMember (fun active ctx ->
       let allMembers = (memberRepo ctx).GetAll()
-      htmlResponse (MemberViews.members allMembers active None) ctx)
+      htmlResponse (MemberViews.members allMembers active []) ctx)
 
   let createMember: HttpContext -> Task =
     withMember (fun active ctx ->
@@ -25,7 +25,7 @@ module MemberHandlers =
         | Error NameIsEmpty ->
           let allMembers = (memberRepo ctx).GetAll()
           ctx.Response.StatusCode <- 422
-          do! htmlResponse (MemberViews.members allMembers active (Some "Name cannot be empty")) ctx
+          do! htmlResponse (MemberViews.members allMembers active [ "Name cannot be empty" ]) ctx
         | Ok m ->
           (memberRepo ctx).Add(m) |> ignore
           ctx.Response.Redirect Routes.members

--- a/code/BpMonitor.Web/MemberViews.fs
+++ b/code/BpMonitor.Web/MemberViews.fs
@@ -5,11 +5,7 @@ open BpMonitor.Core
 
 /// Server-rendered HTML views for family-member management pages.
 module MemberViews =
-  let private membersList
-    (allMembers: FamilyMember list)
-    (active: FamilyMember)
-    (errorMsg: string option)
-    : XmlNode list =
+  let private membersList (allMembers: FamilyMember list) (active: FamilyMember) (errors: string list) : XmlNode list =
     let badge (text: string) (cls: string) =
       Elem.span [ Attr.class' cls ] [ Text.raw text ]
 
@@ -28,7 +24,7 @@ module MemberViews =
               else
                 badge "Unclaimed" "badge badge-unclaimed" ]
           Elem.td
-            [ Attr.style "display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap" ]
+            [ Attr.class' "member-actions" ]
             [ if isCurrent then
                 Elem.span [ Attr.class' "current-member" ] [ Text.raw "You" ]
               Elem.a [ Attr.href (Routes.memberEdit m.Id); Attr.class' "outline" ] [ Text.raw "Edit" ]
@@ -38,9 +34,7 @@ module MemberViews =
                   Attr.class' "inline" ]
                 [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Reset password" ] ] ] ]
 
-    [ match errorMsg with
-      | Some msg -> yield ViewLayout.errorBox [ msg ]
-      | None -> ()
+    [ yield ViewLayout.errorBox errors
       yield
         Elem.table
           []
@@ -107,10 +101,7 @@ module MemberViews =
                   [ Attr.for' "IsActive" ]
                   [ Elem.input (checkedAttr m.IsActive @ [ Attr.id "IsActive"; Attr.name "IsActive" ])
                     Text.raw " Active" ] ]
-            Elem.div
-              [ Attr.class' "actions" ]
-              [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Save" ]
-                Elem.a [ Attr.href Routes.members; Attr.role "button"; Attr.class' "secondary" ] [ Text.raw "Cancel" ] ] ] ]
+            ViewLayout.formActions Routes.members ] ]
 
   /// Self-service goal-range settings page: lets the logged-in member edit their own
   /// systolic/diastolic goal range, rendered as color-coded bands on their charts.
@@ -139,17 +130,14 @@ module MemberViews =
             ViewLayout.field "Systolic max" "SystolicGoalMax" sysMax "number"
             ViewLayout.field "Diastolic min" "DiastolicGoalMin" diaMin "number"
             ViewLayout.field "Diastolic max" "DiastolicGoalMax" diaMax "number"
-            Elem.div
-              [ Attr.class' "actions" ]
-              [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Save" ]
-                Elem.a [ Attr.href Routes.history; Attr.role "button"; Attr.class' "secondary" ] [ Text.raw "Cancel" ] ] ] ]
+            ViewLayout.formActions Routes.history ] ]
 
   /// Members page: list of family members with Edit/Reset-password buttons and an add form.
-  /// Pass `error = Some "msg"` to show a validation error above the add form.
-  let members (allMembers: FamilyMember list) (active: FamilyMember) (error: string option) : XmlNode =
+  /// Pass non-empty `errors` to show validation errors above the add form.
+  let members (allMembers: FamilyMember list) (active: FamilyMember) (errors: string list) : XmlNode =
     ViewLayout.layout
       Routes.members
       active.Name
       active.IsAdmin
       "Family Members"
-      (Elem.h1 [] [ Text.raw "Family Members" ] :: membersList allMembers active error)
+      (Elem.h1 [] [ Text.raw "Family Members" ] :: membersList allMembers active errors)

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -212,7 +212,4 @@ module ReadingViews =
             fieldWithHint "Diastolic" "mmHg" "Diastolic" m.Diastolic "number"
             fieldWithHint "Heart Rate" "bpm" "HeartRate" m.HeartRate "number"
             ViewLayout.field "Comment" "Comments" m.Comments "text"
-            Elem.div
-              [ Attr.class' "actions" ]
-              [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Save" ]
-                Elem.a [ Attr.href Routes.history; Attr.role "button"; Attr.class' "secondary" ] [ Text.raw "Cancel" ] ] ] ]
+            ViewLayout.formActions Routes.history ] ]

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -156,6 +156,13 @@ module ViewLayout =
         [ Attr.class' "errors"; Attr.role "alert" ]
         [ Elem.ul [] (errors |> List.map (fun e -> Elem.li [] [ Text.enc e ])) ]
 
+  /// The shared form save/cancel row. `cancelHref` is the Cancel link destination.
+  let formActions (cancelHref: string) : XmlNode =
+    Elem.div
+      [ Attr.class' "actions" ]
+      [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Save" ]
+        Elem.a [ Attr.href cancelHref; Attr.role "button"; Attr.class' "secondary" ] [ Text.raw "Cancel" ] ]
+
   /// A single labeled form field: `<div class="field"><label/><input/></div>`.
   /// Shared by readingForm, memberForm, and settingsForm.
   let field (labelText: string) (name: string) (value: string) (inputType: string) : XmlNode =

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -562,6 +562,14 @@ form.inline button {
   color: var(--pico-muted-color);
 }
 
+/* Actions cell in the members table */
+.member-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 /* ── Recent page ────────────────────────────────────────────────────────── */
 
 :root {


### PR DESCRIPTION
## Summary

- Added `ViewLayout.formActions (cancelHref: string)` helper — the shared Save/Cancel div that was copy-pasted across `readingForm`, `memberForm`, and `settingsForm` is now a single call
- Changed `MemberViews.members` / `membersList` error parameter from `string option` to `string list`, consistent with every other view in the codebase; updated `MemberHandlers` and `MemberViewTests` callers
- Replaced the stray inline `style="display:flex; gap:0.5rem; …"` on the members-table actions `<td>` with `class="member-actions"` and a matching rule in `app.css`