### PR TITLE
🔧 chore: fix git-workflow hook path to use absolute reference

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,13 +7,13 @@
           {
             "type": "command",
             "if": "Bash(git *)",
-            "command": "bash .claude/hooks/git-workflow-reminder.sh",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/git-workflow-reminder.sh\"",
             "statusMessage": "Checking git-workflow rules..."
           },
           {
             "type": "command",
             "if": "Bash(gh *)",
-            "command": "bash .claude/hooks/git-workflow-reminder.sh",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/git-workflow-reminder.sh\"",
             "statusMessage": "Checking git-workflow rules..."
           }
         ]


### PR DESCRIPTION
## Summary

- PreToolUse hook was using a relative path, failing when Claude's working directory wasn't the repo root
- Updated both git and gh hook commands to use `$CLAUDE_PROJECT_DIR` for absolute path resolution
- Fixes the recurring "No such file or directory" warning on git/gh operations