### PR TITLE
🗑️ chore(web): remove dead sidebar theme-toggle from markup and CSS

### DIFF
--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -112,7 +112,6 @@ module ViewLayout =
                 Elem.div
                   [ Attr.class' "sidebar-user" ]
                   [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ]
-                    themeToggleButton ""
                     Elem.form
                       [ Attr.method "post"; Attr.action Routes.logout; Attr.class' "inline" ]
                       [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Logout" ] ] ] ]

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -144,12 +144,6 @@ nav.sidebar ul li {
   align-items: flex-start;
 }
 
-/* The sidebar's own theme toggle is redundant — the topbar owns the single
-   theme toggle across all screen sizes. */
-.sidebar-user .theme-toggle {
-  display: none;
-}
-
 .content {
   margin-left: var(--sidebar-width);
   display: flex;


### PR DESCRIPTION
## Summary

- The sidebar's theme toggle button was permanently hidden by CSS after the persistent-header refactor (PR #328)
- Remove the button from the sidebar markup in `ViewLayout.fs` and delete the now-unnecessary `.sidebar-user .theme-toggle { display: none }` CSS rule
- Fixes the altitude issue: CSS should not compensate for stale markup; if an element is never shown, it should not be in the DOM