### PR TITLE
💄 style(web): move logout button to topbar; extract inline POST button helper

### DIFF
--- a/code/BpMonitor.Web/MemberViews.fs
+++ b/code/BpMonitor.Web/MemberViews.fs
@@ -28,11 +28,7 @@ module MemberViews =
             [ if isCurrent then
                 Elem.span [ Attr.class' "current-member" ] [ Text.raw "You" ]
               Elem.a [ Attr.href (Routes.memberEdit m.Id); Attr.class' "outline" ] [ Text.raw "Edit" ]
-              Elem.form
-                [ Attr.method "post"
-                  Attr.action (Routes.memberResetPassword m.Id)
-                  Attr.class' "inline" ]
-                [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Reset password" ] ] ] ]
+              ViewLayout.inlinePostButton (Routes.memberResetPassword m.Id) "Reset password" ] ]
 
     [ yield ViewLayout.errorBox errors
       yield

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -57,6 +57,13 @@ module ViewLayout =
          Elem.script [ Attr.src "/plotly-2.27.1.min.js"; Attr.charset "utf-8" ] [] ]
        @ extras)
 
+  /// Inline POST form containing a single secondary outline submit button — used
+  /// wherever a destructive or secondary action needs no surrounding form.
+  let inlinePostButton (action: string) (label: string) : XmlNode =
+    Elem.form
+      [ Attr.method "post"; Attr.action action; Attr.class' "inline" ]
+      [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw label ] ]
+
   /// Page shell for authenticated pages: shared <head>, nav bar with logged-in member
   /// name + logout, and hx-boosted body.
   let layout (active: string) (memberName: string) (isAdmin: bool) (title: string) (content: XmlNode list) : XmlNode =
@@ -82,7 +89,11 @@ module ViewLayout =
                     Attr.create "aria-label" "Menu" ]
                   [ Text.raw "☰" ]
                 Elem.span [ Attr.class' "topbar-title" ] [ Text.raw "BpMonitor" ]
-                themeToggleButton "" ]
+                Elem.div
+                  [ Attr.class' "topbar-right" ]
+                  [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ]
+                    themeToggleButton ""
+                    inlinePostButton Routes.logout "Logout" ] ]
             // Second label for same checkbox: acts as the backdrop — clicking it unchecks
             // the checkbox and closes the drawer.
             Elem.label [ Attr.create "for" "nav-toggle"; Attr.class' "nav-backdrop" ] []
@@ -107,14 +118,7 @@ module ViewLayout =
                       []
                       [ Elem.a [ Attr.href Routes.exportCsv; Attr.create "hx-boost" "false" ] [ Text.raw "Export CSV" ] ]
                     if isAdmin then
-                      navLink active Routes.members "Members" ]
-                // Member name and logout pinned to the bottom of the sidebar.
-                Elem.div
-                  [ Attr.class' "sidebar-user" ]
-                  [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ]
-                    Elem.form
-                      [ Attr.method "post"; Attr.action Routes.logout; Attr.class' "inline" ]
-                      [ Elem.button [ Attr.type' "submit"; Attr.class' "outline secondary" ] [ Text.raw "Logout" ] ] ] ]
+                      navLink active Routes.members "Members" ] ]
             Elem.div
               [ Attr.class' "content" ]
               [ Elem.main [ Attr.class' "container" ] content

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -71,7 +71,10 @@ label.nav-backdrop {
   font-weight: 600;
 }
 
-.topbar .theme-toggle {
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   margin-left: auto;
 }
 
@@ -133,16 +136,6 @@ nav.sidebar ul li {
 }
 
 
-/* Member name / logout / theme toggle pinned to the sidebar bottom */
-.sidebar-user {
-  margin-top: auto;
-  padding-top: 1rem;
-  border-top: 1px solid var(--pico-muted-border-color);
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  align-items: flex-start;
-}
 
 .content {
   margin-left: var(--sidebar-width);


### PR DESCRIPTION
## Summary

- Move logout button and member name from sidebar bottom to topbar header, positioned at far-right
- Add `.topbar-right` flex wrapper for semantic, robust right-alignment (replaces fragile `margin-left: auto` on `.nav-member-name`)
- Extract `inlinePostButton(action, label)` helper to eliminate duplicated form pattern — now shared by logout and Reset password actions
- Remove unused `.sidebar-user` CSS block

The `.topbar-right` wrapper groups member name, theme toggle, and logout as a flex unit, making right-alignment semantic and safe to future refactoring. The `inlinePostButton` helper removes 4-line form boilerplate across ViewLayout and MemberViews.