### PR TITLE
💄 style(web): make topbar title link to home; reorganize sidebar

### DIFF
--- a/code/BpMonitor.Web.Tests/LandingViewTests.fs
+++ b/code/BpMonitor.Web.Tests/LandingViewTests.fs
@@ -26,8 +26,8 @@ let ``landing renders links to add and history`` () =
 
   test <@ html.Contains "href=\"/add\"" @>
   test <@ html.Contains "href=\"/history\"" @>
-  // the Home nav link is marked active on the landing page
-  test <@ html.Contains "href=\"/\" aria-current=\"page\"" @>
+  // the topbar title links to the landing page (replaces the removed Home sidebar entry)
+  test <@ html.Contains "class=\"topbar-title\" href=\"/\"" @>
 
 [<Fact>]
 let ``landing renders action buttons for trends, recent, settings and both exports`` () =

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -88,7 +88,7 @@ module ViewLayout =
                     Attr.class' "nav-burger"
                     Attr.create "aria-label" "Menu" ]
                   [ Text.raw "☰" ]
-                Elem.span [ Attr.class' "topbar-title" ] [ Text.raw "BpMonitor" ]
+                Elem.a [ Attr.class' "topbar-title"; Attr.href Routes.home ] [ Text.raw "BpMonitor" ]
                 Elem.div
                   [ Attr.class' "topbar-right" ]
                   [ Elem.span [ Attr.class' "nav-member-name" ] [ Text.enc memberName ]
@@ -101,11 +101,12 @@ module ViewLayout =
               [ Attr.class' "sidebar" ]
               [ Elem.ul
                   []
-                  [ navLink active Routes.home "Home"
-                    navLink active Routes.add "Add"
+                  [ navLink active Routes.add "Add"
                     navLink active Routes.history "History"
                     navLink active Routes.recent "Recent"
                     navLink active Routes.trends "Trends"
+                    if isAdmin then
+                      navLink active Routes.members "Members"
                     navLink active Routes.settings "Settings"
                     // hx-boost="false" prevents htmx from AJAX-swapping the download response.
                     Elem.li
@@ -116,9 +117,7 @@ module ViewLayout =
                     // hx-boost="false" prevents htmx from AJAX-swapping the download response.
                     Elem.li
                       []
-                      [ Elem.a [ Attr.href Routes.exportCsv; Attr.create "hx-boost" "false" ] [ Text.raw "Export CSV" ] ]
-                    if isAdmin then
-                      navLink active Routes.members "Members" ] ]
+                      [ Elem.a [ Attr.href Routes.exportCsv; Attr.create "hx-boost" "false" ] [ Text.raw "Export CSV" ] ] ] ]
             Elem.div
               [ Attr.class' "content" ]
               [ Elem.main [ Attr.class' "container" ] content

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -69,6 +69,8 @@ label.nav-backdrop {
 
 .topbar-title {
   font-weight: 600;
+  color: inherit;
+  text-decoration: none;
 }
 
 .topbar-right {


### PR DESCRIPTION
## Summary
- Topbar "BpMonitor" title is now an anchor linking to the landing page (`/`)
- Removed redundant "Home" sidebar entry
- Reorganized sidebar: primary nav (Add, History, Recent, Trends) → admin Members link → secondary actions (Settings, Export JSON, Export CSV)
- Updated test to verify topbar title link instead of removed sidebar Home entry
- Styled topbar title anchor to appear as plain text (no underline, inherit color)

All 407 tests pass; E2E verification confirmed in real Chromium browser.