### PR TITLE
💄 style(web): add sidebar icons and style Add entry as button

### DIFF
--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -14,14 +14,23 @@ module ViewLayout =
     | Some url -> [ Text.raw "BpMonitor "; Elem.a [ Attr.href url ] [ Text.raw $"v{v}" ] ]
     | None -> [ Text.raw $"BpMonitor {v}" ]
 
-  let private navLink (active: string) (href: string) (label: string) : XmlNode =
-    let attrs =
-      if href = active then
-        [ Attr.href href; Attr.create "aria-current" "page" ]
-      else
-        [ Attr.href href ]
+  let private navLink (active: string) (href: string) (glyph: string) (label: string) (isAction: bool) : XmlNode =
+    let aAttrs =
+      [ yield Attr.href href
+        if isAction then
+          yield Attr.class' "nav-action"
+        if href = active then
+          yield Attr.create "aria-current" "page" ]
 
-    Elem.li [] [ Elem.a attrs [ Text.raw label ] ]
+    let liAttrs = if isAction then [ Attr.class' "nav-action-item" ] else []
+    Elem.li liAttrs [ Elem.a aAttrs [ Elem.span [ Attr.class' "icon" ] [ Text.raw glyph ]; Text.raw label ] ]
+
+  let private navDownloadLink (href: string) (glyph: string) (label: string) : XmlNode =
+    Elem.li
+      []
+      [ Elem.a
+          [ Attr.href href; Attr.create "hx-boost" "false" ]
+          [ Elem.span [ Attr.class' "icon" ] [ Text.raw glyph ]; Text.raw label ] ]
 
   /// The dark/light mode toggle (icon set by theme.js/theme-label.js). `extraClass`
   /// lets the login page add `theme-toggle--standalone` since it has no topbar/sidebar
@@ -101,23 +110,18 @@ module ViewLayout =
               [ Attr.class' "sidebar" ]
               [ Elem.ul
                   []
-                  [ navLink active Routes.add "Add"
-                    navLink active Routes.history "History"
-                    navLink active Routes.recent "Recent"
-                    navLink active Routes.trends "Trends"
+                  [ navLink active Routes.add "➕" "Add" true
+                    navLink active Routes.history "📜" "History" false
+                    navLink active Routes.recent "🕒" "Recent" false
+                    navLink active Routes.trends "📈" "Trends" false
                     if isAdmin then
-                      navLink active Routes.members "Members"
-                    navLink active Routes.settings "Settings"
+                      navLink active Routes.members "👥" "Members" false ]
+                Elem.ul
+                  [ Attr.class' "sidebar-bottom" ]
+                  [ navLink active Routes.settings "⚙️" "Settings" false
                     // hx-boost="false" prevents htmx from AJAX-swapping the download response.
-                    Elem.li
-                      []
-                      [ Elem.a
-                          [ Attr.href Routes.exportJson; Attr.create "hx-boost" "false" ]
-                          [ Text.raw "Export JSON" ] ]
-                    // hx-boost="false" prevents htmx from AJAX-swapping the download response.
-                    Elem.li
-                      []
-                      [ Elem.a [ Attr.href Routes.exportCsv; Attr.create "hx-boost" "false" ] [ Text.raw "Export CSV" ] ] ] ]
+                    navDownloadLink Routes.exportJson "⬇️" "Export JSON"
+                    navDownloadLink Routes.exportCsv "⬇️" "Export CSV" ] ]
             Elem.div
               [ Attr.class' "content" ]
               [ Elem.main [ Attr.class' "container" ] content

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -5,7 +5,7 @@
      the mobile backdrop's offset, and .content's margin-left, so they can't
      drift out of sync. Same value on mobile and desktop (desktop used to be
      14rem, which felt oversized for a nav-only column). */
-  --sidebar-width: 10rem;
+  --sidebar-width: 12rem;
   /* Topbar height — referenced by nav.sidebar's top offset, .content's
      padding-top, and the mobile backdrop, so they stay in sync. */
   --topbar-height: 3rem;
@@ -135,6 +135,36 @@ nav.sidebar ul {
 nav.sidebar ul li {
   padding: 0;
   margin: 0;
+}
+
+nav.sidebar ul.sidebar-bottom {
+  margin-top: auto;
+}
+
+nav.sidebar a.nav-action {
+  display: block;
+  background: var(--pico-primary);
+  color: var(--pico-primary-inverse);
+  border-radius: var(--pico-border-radius);
+  padding: 0.35rem 0.75rem;
+  text-align: center;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+nav.sidebar a.nav-action:hover {
+  background: var(--pico-primary-hover, var(--pico-primary));
+  color: var(--pico-primary-inverse);
+}
+
+nav.sidebar a.nav-action[aria-current="page"] {
+  text-decoration: none;
+  outline: 2px solid var(--pico-primary-inverse);
+  outline-offset: -3px;
+}
+
+nav.sidebar li.nav-action-item {
+  margin-bottom: 1rem;
 }
 
 
@@ -450,7 +480,7 @@ td.col-center {
   margin-bottom: 0;
 }
 
-.home-actions .icon {
+.icon {
   margin-right: 0.4rem;
 }
 


### PR DESCRIPTION
## Summary

- Added glyph icons (➕ 📜 🕒 📈 👥 ⚙️ ⬇️) to all sidebar navigation links, matching the landing page visual language
- Styled the "Add" entry as a filled primary button (nav-action) to visually distinguish it as the primary action from the reporting/settings entries below
- Reorganized sidebar: moved Settings and Export entries to a bottom section with 1rem gap separator
- Widened sidebar from 10rem → 12rem to accommodate icon + text + button padding
- Simplified F# helpers: merged `navActionLink` into `navLink` with `isAction: bool` parameter, eliminating duplicate active-check logic
- Extracted `navDownloadLink` helper to eliminate inline export-link duplication (centralized `hx-boost="false"` handling)
- Consolidated duplicate `.icon` CSS rule to single top-level selector (margin-right: 0.4rem)