### PR TITLE
💄 style(web): add role=button to sidebar Add link and simplify CSS

### DIFF
--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -19,6 +19,7 @@ module ViewLayout =
       [ yield Attr.href href
         if isAction then
           yield Attr.class' "nav-action"
+          yield Attr.role "button"
         if href = active then
           yield Attr.create "aria-current" "page" ]
 

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -141,20 +141,13 @@ nav.sidebar ul.sidebar-bottom {
   margin-top: auto;
 }
 
+/* Pico's [role="button"] handles bg, color, border, and hover. We only
+   need layout overrides: full-width block, centered text, no underline. */
 nav.sidebar a.nav-action {
   display: block;
-  background: var(--pico-primary);
-  color: var(--pico-primary-inverse);
-  border-radius: var(--pico-border-radius);
-  padding: 0.35rem 0.75rem;
   text-align: center;
-  font-weight: 600;
   text-decoration: none;
-}
-
-nav.sidebar a.nav-action:hover {
-  background: var(--pico-primary-hover, var(--pico-primary));
-  color: var(--pico-primary-inverse);
+  margin-bottom: 0;
 }
 
 nav.sidebar a.nav-action[aria-current="page"] {


### PR DESCRIPTION
## Summary

- Added `role="button"` to the sidebar Add link in ViewLayout.fs so Pico applies native button styling
- Simplified `.nav-action` CSS by removing duplicate button styling (background, color, padding, hover states) that Pico now provides via `[role="button"]`
- Kept only layout overrides: full-width block display, centered text, no underline, and active-state outline

This makes the Add entry visually distinct from the reporting links by giving it proper button appearance with border, padding, and interactive states.