### PR TITLE
💄 style(web): style page h1 titles with primary color and tighter spacing

### DIFF
--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -477,6 +477,13 @@ td.col-center {
   margin-right: 0.4rem;
 }
 
+main h1 {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--pico-primary);
+  margin: 1.25rem 0 1rem;
+}
+
 footer.container {
   max-width: 700px;
   margin-top: 2rem;


### PR DESCRIPTION
## Summary

- Reduce h1 font-size from 2rem to 1.35rem for better visual proportion on all screen sizes
- Apply primary color to h1 titles for brand identity and visual consistency with nav active states
- Use shorthand margin property to tighten spacing (1.25rem top, 1rem bottom) — prevents excessive gaps on mobile
- CSS-only change, no markup modification