### PR TITLE
♻️ refactor(tests): replace hardcoded route strings with Routes module

### DIFF
--- a/code/BpMonitor.Web.Tests/HistoryViewTests.fs
+++ b/code/BpMonitor.Web.Tests/HistoryViewTests.fs
@@ -13,18 +13,20 @@ let ``history renders reading values, chart div and nav links`` () =
   test <@ html.Contains "123" @>
   test <@ html.Contains "after walk" @>
   test <@ html.Contains "class=\"chart\"" @>
-  test <@ html.Contains "href=\"/add\"" @>
-  test <@ html.Contains "/readings/7/edit" @>
+  test <@ html.Contains $"href=\"{Routes.add}\"" @>
+  test <@ html.Contains(Routes.readingEdit 7) @>
   // the History nav link is marked active on the history page
-  test <@ html.Contains "href=\"/history\" aria-current=\"page\"" @>
+  test <@ html.Contains $"href=\"{Routes.history}\" aria-current=\"page\"" @>
 
 [<Fact>]
 let ``edit form is prefilled from the reading`` () =
   let html =
-    renderHtml (ReadingViews.readingForm "" "Me" true "Edit reading" "/readings/7" [] (Binding.ofReading sample))
+    renderHtml (
+      ReadingViews.readingForm "" "Me" true "Edit reading" (Routes.readingUpdate 7) [] (Binding.ofReading sample)
+    )
 
   test <@ html.Contains "name=\"Systolic\" value=\"123\"" @>
-  test <@ html.Contains "action=\"/readings/7\"" @>
+  test <@ html.Contains $"action=\"{Routes.readingUpdate 7}\"" @>
   test <@ html.Contains "after walk" @>
 
 [<Fact>]
@@ -32,7 +34,7 @@ let ``form renders the validation errors it is given`` () =
   let errors = [ "Systolic 999 is out of range (1–300)" ]
 
   let html =
-    renderHtml (ReadingViews.readingForm "/add" "Me" true "Add reading" "/readings" errors Binding.empty)
+    renderHtml (ReadingViews.readingForm Routes.add "Me" true "Add reading" Routes.readings errors Binding.empty)
 
   test <@ html.Contains "errors" @>
   test <@ html.Contains "out of range" @>

--- a/code/BpMonitor.Web.Tests/LandingViewTests.fs
+++ b/code/BpMonitor.Web.Tests/LandingViewTests.fs
@@ -24,20 +24,20 @@ let private occurrences (needle: string) (haystack: string) : int =
 let ``landing renders links to add and history`` () =
   let html = renderHtml (ReadingViews.landing defaultMember)
 
-  test <@ html.Contains "href=\"/add\"" @>
-  test <@ html.Contains "href=\"/history\"" @>
+  test <@ html.Contains $"href=\"{Routes.add}\"" @>
+  test <@ html.Contains $"href=\"{Routes.history}\"" @>
   // the topbar title links to the landing page (replaces the removed Home sidebar entry)
-  test <@ html.Contains "class=\"topbar-title\" href=\"/\"" @>
+  test <@ html.Contains $"class=\"topbar-title\" href=\"{Routes.home}\"" @>
 
 [<Fact>]
 let ``landing renders action buttons for trends, recent, settings and both exports`` () =
   let html = renderHtml (ReadingViews.landing defaultMember)
 
-  test <@ occurrences "href=\"/trends\"" html = 2 @>
-  test <@ occurrences "href=\"/recent\"" html = 2 @>
-  test <@ occurrences "href=\"/settings\"" html = 2 @>
-  test <@ occurrences "href=\"/export\"" html = 2 @>
-  test <@ occurrences "href=\"/export.csv\"" html = 2 @>
+  test <@ occurrences $"href=\"{Routes.trends}\"" html = 2 @>
+  test <@ occurrences $"href=\"{Routes.recent}\"" html = 2 @>
+  test <@ occurrences $"href=\"{Routes.settings}\"" html = 2 @>
+  test <@ occurrences $"href=\"{Routes.exportJson}\"" html = 2 @>
+  test <@ occurrences $"href=\"{Routes.exportCsv}\"" html = 2 @>
 
 [<Fact>]
 let ``landing export action buttons do not get hx-boosted`` () =
@@ -50,10 +50,10 @@ let ``landing export action buttons do not get hx-boosted`` () =
 let ``admin sees a Members action button on landing`` () =
   let admin = { defaultMember with IsAdmin = true }
   let html = renderHtml (ReadingViews.landing admin)
-  test <@ occurrences "href=\"/members\"" html = 2 @>
+  test <@ occurrences $"href=\"{Routes.members}\"" html = 2 @>
 
 [<Fact>]
 let ``non-admin does not see a Members action button on landing`` () =
   let nonAdmin = { defaultMember with IsAdmin = false }
   let html = renderHtml (ReadingViews.landing nonAdmin)
-  test <@ occurrences "href=\"/members\"" html = 0 @>
+  test <@ occurrences $"href=\"{Routes.members}\"" html = 0 @>

--- a/code/BpMonitor.Web.Tests/LayoutViewTests.fs
+++ b/code/BpMonitor.Web.Tests/LayoutViewTests.fs
@@ -21,20 +21,20 @@ let ``layout renders a topbar with menu button, title and theme toggle`` () =
 let ``admin sees Members nav link`` () =
   let admin = { defaultMember with IsAdmin = true }
   let html = renderHtml (ReadingViews.landing admin)
-  test <@ html.Contains "href=\"/members\"" @>
+  test <@ html.Contains $"href=\"{Routes.members}\"" @>
 
 [<Fact>]
 let ``non-admin does not see Members nav link`` () =
   let nonAdmin = { defaultMember with IsAdmin = false }
   let html = renderHtml (ReadingViews.landing nonAdmin)
-  test <@ not (html.Contains "href=\"/members\"") @>
+  test <@ not (html.Contains $"href=\"{Routes.members}\"") @>
 
 [<Fact>]
 let ``every page has a BpMonitor footer`` () =
   let pages =
     [ renderHtml (ReadingViews.landing defaultMember)
       renderHtml (ReadingViews.history defaultMember "" [ sample ])
-      renderHtml (ReadingViews.readingForm "/add" "Me" true "Add reading" "/readings" [] Binding.empty) ]
+      renderHtml (ReadingViews.readingForm Routes.add "Me" true "Add reading" Routes.readings [] Binding.empty) ]
 
   for html in pages do
     test <@ html.Contains "<footer" @>
@@ -45,10 +45,10 @@ let ``every authenticated page shows the logout button`` () =
   let pages =
     [ renderHtml (ReadingViews.landing defaultMember)
       renderHtml (ReadingViews.history defaultMember "" [ sample ])
-      renderHtml (ReadingViews.readingForm "/add" "Me" true "Add reading" "/readings" [] Binding.empty) ]
+      renderHtml (ReadingViews.readingForm Routes.add "Me" true "Add reading" Routes.readings [] Binding.empty) ]
 
   for html in pages do
-    test <@ html.Contains "action=\"/logout\"" @>
+    test <@ html.Contains $"action=\"{Routes.logout}\"" @>
     test <@ html.Contains "Logout" @>
 
 [<Fact>]

--- a/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
@@ -34,7 +34,7 @@ let ``loginWithCredentials redirects to / for correct credentials`` () =
   TestHost.run AuthHandlers.loginWithCredentials ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
-  test <@ ctx.Response.Headers.Location.ToString() = "/" @>
+  test <@ ctx.Response.Headers.Location.ToString() = Routes.home @>
 
 [<Fact>]
 let ``loginWithCredentials returns 401 for wrong password`` () =
@@ -66,7 +66,7 @@ let ``loginWithCredentials redirects to claim page for unclaimed member`` () =
   TestHost.run AuthHandlers.loginWithCredentials ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
-  test <@ ctx.Response.Headers.Location.ToString() = "/login/1" @>
+  test <@ ctx.Response.Headers.Location.ToString() = Routes.loginMember 1 @>
 
 [<Fact>]
 let ``loginMember returns 200 for an existing active member`` () =
@@ -145,7 +145,7 @@ let ``loginSubmit accepts correct password for claimed member and redirects`` ()
   TestHost.run AuthHandlers.loginSubmit ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
-  test <@ ctx.Response.Headers.Location.ToString() = "/" @>
+  test <@ ctx.Response.Headers.Location.ToString() = Routes.home @>
 
 [<Fact>]
 let ``loginSubmit rejects wrong password for claimed member with 401`` () =

--- a/code/BpMonitor.Web.Tests/MemberHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/MemberHandlerTests.fs
@@ -77,7 +77,7 @@ let ``updateMember saves changes and redirects to /members`` () =
   TestHost.run MemberHandlers.updateMember ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
-  test <@ ctx.Response.Headers.Location.ToString() = "/members" @>
+  test <@ ctx.Response.Headers.Location.ToString() = Routes.members @>
 
   let memberRepo = ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
 

--- a/code/BpMonitor.Web.Tests/MemberViewTests.fs
+++ b/code/BpMonitor.Web.Tests/MemberViewTests.fs
@@ -25,8 +25,8 @@ let ``members page renders Admin and Active columns and Edit link`` () =
 
   test <@ html.Contains "Admin" @>
   test <@ html.Contains "Active" @>
-  test <@ html.Contains "href=\"/members/1/edit\"" @>
-  test <@ html.Contains "href=\"/members/2/edit\"" @>
+  test <@ html.Contains $"href=\"{Routes.memberEdit 1}\"" @>
+  test <@ html.Contains $"href=\"{Routes.memberEdit 2}\"" @>
 
 [<Fact>]
 let ``members page shows claimed/unclaimed badge`` () =
@@ -72,10 +72,10 @@ let ``memberForm prefills name and reflects IsAdmin and IsActive`` () =
       ModifiedAt = DateTimeOffset.MinValue }
 
   let html =
-    renderHtml (MemberViews.memberForm "/members" "Me" true "Edit member" "/members/3" [] m)
+    renderHtml (MemberViews.memberForm Routes.members "Me" true "Edit member" (Routes.memberUpdate 3) [] m)
 
   test <@ html.Contains "value=\"Bob\"" @>
-  test <@ html.Contains "action=\"/members/3\"" @>
+  test <@ html.Contains $"action=\"{Routes.memberUpdate 3}\"" @>
   // IsAdmin checked → checked attribute present
   test <@ html.Contains "checked" @>
 
@@ -84,11 +84,11 @@ let ``memberForm renders errors`` () =
   let html =
     renderHtml (
       MemberViews.memberForm
-        "/members"
+        Routes.members
         "Me"
         true
         "Edit member"
-        "/members/3"
+        (Routes.memberUpdate 3)
         [ "At least one member must be an active admin" ]
         defaultMember
     )

--- a/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
@@ -15,7 +15,12 @@ let ``landing renders links to add and history`` () =
 
   test <@ ctx.Response.StatusCode = 200 @>
   let body = TestHost.readBody ctx
-  test <@ body.Contains "href=\"/add\"" && body.Contains "href=\"/history\"" @>
+
+  test
+    <@
+      body.Contains $"href=\"{Routes.add}\""
+      && body.Contains $"href=\"{Routes.history}\""
+    @>
 
 [<Fact>]
 let ``history renders a row per reading`` () =
@@ -24,7 +29,7 @@ let ``history renders a row per reading`` () =
   TestHost.run ReadingHandlers.history ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
-  test <@ (TestHost.readBody ctx).Contains "/readings/1/edit" @>
+  test <@ (TestHost.readBody ctx).Contains(Routes.readingEdit 1) @>
 
 [<Fact>]
 let ``history renders the chart with the authenticated member's goal range`` () =
@@ -65,7 +70,7 @@ let ``createReading persists a valid reading and redirects`` () =
   TestHost.run ReadingHandlers.createReading ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
-  test <@ ctx.Response.Headers.Location.ToString() = "/recent" @>
+  test <@ ctx.Response.Headers.Location.ToString() = Routes.recent @>
   test <@ repo.GetAll(defaultMemberId) |> List.length = 1 @>
 
 [<Fact>]
@@ -159,6 +164,6 @@ let ``updateReading saves changes and redirects`` () =
   TestHost.run ReadingHandlers.updateReading ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
-  test <@ ctx.Response.Headers.Location.ToString() = "/history" @>
+  test <@ ctx.Response.Headers.Location.ToString() = Routes.history @>
   let updated = repo.GetAll(defaultMemberId) |> List.exactlyOne
   test <@ updated.Systolic = 111 && updated.Comments = Some "updated" @>

--- a/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/RecentHandlerTests.fs
@@ -304,7 +304,7 @@ let ``recent renders a 'Load full history' button when a reading older than the 
 
   let body = TestHost.readBody ctx
   test <@ body.Contains "Load full history" @>
-  test <@ body.Contains "hx-get=\"/recent/full\"" @>
+  test <@ body.Contains $"hx-get=\"{Routes.recentFull}\"" @>
 
 [<Fact>]
 let ``recent omits the 'Load full history' button when all readings are within the load window`` () =

--- a/code/BpMonitor.Web.Tests/SettingsHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/SettingsHandlerTests.fs
@@ -34,7 +34,7 @@ let ``updateSettings persists a valid goal range and redirects to history`` () =
   TestHost.run ReadingHandlers.updateSettings ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
-  test <@ ctx.Response.Headers.Location.ToString() = "/history" @>
+  test <@ ctx.Response.Headers.Location.ToString() = Routes.history @>
 
   let memberRepo = ctx.RequestServices.GetRequiredService<IFamilyMemberRepository>()
   let updated = (memberRepo.GetById defaultMemberId).Value

--- a/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
@@ -36,9 +36,12 @@ let ``trends renders 200 with granularity buttons and current Weekly panel`` () 
   test <@ ctx.Response.StatusCode = 200 @>
   let body = TestHost.readBody ctx
   // Granularity buttons
-  test <@ body.Contains "href=\"/trends/weekly\"" @>
-  test <@ body.Contains "href=\"/trends/monthly\"" @>
-  test <@ body.Contains "href=\"/trends/yearly\"" @>
+  let weeklyGran = Routes.trendsGran "weekly"
+  let monthlyGran = Routes.trendsGran "monthly"
+  let yearlyGran = Routes.trendsGran "yearly"
+  test <@ body.Contains $"href=\"{weeklyGran}\"" @>
+  test <@ body.Contains $"href=\"{monthlyGran}\"" @>
+  test <@ body.Contains $"href=\"{yearlyGran}\"" @>
   // Weekly is active
   test <@ body.Contains "aria-current=\"page\"" @>
   // Inline chart rendered
@@ -249,8 +252,10 @@ let ``trendsPanel period pills without data are aria-disabled and have no href``
 
   test <@ ctx.Response.StatusCode = 200 @>
   let body = TestHost.readBody ctx
+  let w24Route = Routes.trendsGranKey "weekly" "2026-W24"
+  let w23Route = Routes.trendsGranKey "weekly" "2026-W23"
   // W24 (This Week) pill should be a normal link
-  test <@ body.Contains "href=\"/trends/weekly/2026-W24\"" @>
+  test <@ body.Contains $"href=\"{w24Route}\"" @>
   // W23 (Last Week) pill should be disabled — no href, has aria-disabled
-  test <@ body.Contains "href=\"/trends/weekly/2026-W23\"" |> not @>
+  test <@ body.Contains $"href=\"{w23Route}\"" |> not @>
   test <@ body.Contains "aria-disabled=\"true\"" @>

--- a/code/BpMonitor.Web/Routes.fs
+++ b/code/BpMonitor.Web/Routes.fs
@@ -23,3 +23,5 @@ module Routes =
   let memberUpdate (id: int) = $"/members/{id}"
   let memberResetPassword (id: int) = $"/members/{id}/reset-password"
   let loginMember (id: int) = $"{login}/{id}"
+  let trendsGran (gran: string) = $"{trends}/{gran}"
+  let trendsGranKey (gran: string) (key: string) = $"{trends}/{gran}/{key}"


### PR DESCRIPTION
## Summary

- Added `trendsGran` and `trendsGranKey` URL builders to `Routes.fs` to cover the two parametric trend routes that were missing from the module
- Replaced all hardcoded route string literals in `BpMonitor.Web.Tests` with `Routes.*` references — redirect assertions, link-contains checks, form action arguments, and `hx-get` values now derive from the single source of truth
- CSS class strings and the `/recent-scrubber.js` static asset path were intentionally left as literals (not routes)