### PR TITLE
♻️ refactor(web): centralise form field names and trend granularity slugs

### DIFF
--- a/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
@@ -30,7 +30,7 @@ let ``loginWithCredentials redirects to / for correct credentials`` () =
 
   let repo = repoWith []
   let ctx = TestHost.contextWithMembers repo [ claimed ]
-  TestHost.setForm ctx [ "Username", "Me"; "Password", "correct" ]
+  TestHost.setForm ctx [ FormFields.username, "Me"; FormFields.password, "correct" ]
   TestHost.run AuthHandlers.loginWithCredentials ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
@@ -44,7 +44,7 @@ let ``loginWithCredentials returns 401 for wrong password`` () =
 
   let repo = repoWith []
   let ctx = TestHost.contextWithMembers repo [ claimed ]
-  TestHost.setForm ctx [ "Username", "Me"; "Password", "wrong" ]
+  TestHost.setForm ctx [ FormFields.username, "Me"; FormFields.password, "wrong" ]
   TestHost.run AuthHandlers.loginWithCredentials ctx
 
   test <@ ctx.Response.StatusCode = 401 @>
@@ -53,7 +53,7 @@ let ``loginWithCredentials returns 401 for wrong password`` () =
 let ``loginWithCredentials returns 401 for unknown user`` () =
   let repo = repoWith []
   let ctx = TestHost.context repo
-  TestHost.setForm ctx [ "Username", "Nobody"; "Password", "anything" ]
+  TestHost.setForm ctx [ FormFields.username, "Nobody"; FormFields.password, "anything" ]
   TestHost.run AuthHandlers.loginWithCredentials ctx
 
   test <@ ctx.Response.StatusCode = 401 @>
@@ -62,7 +62,7 @@ let ``loginWithCredentials returns 401 for unknown user`` () =
 let ``loginWithCredentials redirects to claim page for unclaimed member`` () =
   let repo = repoWith []
   let ctx = TestHost.contextWithMembers repo [ unclaimedMember ]
-  TestHost.setForm ctx [ "Username", "Me"; "Password", "" ]
+  TestHost.setForm ctx [ FormFields.username, "Me"; FormFields.password, "" ]
   TestHost.run AuthHandlers.loginWithCredentials ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
@@ -104,7 +104,12 @@ let ``loginSubmit claims unclaimed member and sets password hash`` () =
   let repo = repoWith []
   let ctx = TestHost.contextWithMembers repo [ unclaimedMember ]
   TestHost.setRouteId ctx 1
-  TestHost.setForm ctx [ "Password", "correct-horse"; "PasswordConfirm", "correct-horse" ]
+
+  TestHost.setForm
+    ctx
+    [ FormFields.password, "correct-horse"
+      FormFields.passwordConfirm, "correct-horse" ]
+
   TestHost.run AuthHandlers.loginSubmit ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
@@ -118,7 +123,7 @@ let ``loginSubmit rejects empty password for unclaimed member`` () =
   let repo = repoWith []
   let ctx = TestHost.contextWithMembers repo [ unclaimedMember ]
   TestHost.setRouteId ctx 1
-  TestHost.setForm ctx [ "Password", ""; "PasswordConfirm", "" ]
+  TestHost.setForm ctx [ FormFields.password, ""; FormFields.passwordConfirm, "" ]
   TestHost.run AuthHandlers.loginSubmit ctx
 
   test <@ ctx.Response.StatusCode = 422 @>
@@ -129,7 +134,7 @@ let ``loginSubmit rejects mismatched confirm for unclaimed member`` () =
   let repo = repoWith []
   let ctx = TestHost.contextWithMembers repo [ unclaimedMember ]
   TestHost.setRouteId ctx 1
-  TestHost.setForm ctx [ "Password", "abc"; "PasswordConfirm", "xyz" ]
+  TestHost.setForm ctx [ FormFields.password, "abc"; FormFields.passwordConfirm, "xyz" ]
   TestHost.run AuthHandlers.loginSubmit ctx
 
   test <@ ctx.Response.StatusCode = 422 @>
@@ -141,7 +146,7 @@ let ``loginSubmit accepts correct password for claimed member and redirects`` ()
   let repo = repoWith []
   let ctx = TestHost.contextWithMembers repo [ claimedMember hash ]
   TestHost.setRouteId ctx 1
-  TestHost.setForm ctx [ "Password", "letmein" ]
+  TestHost.setForm ctx [ FormFields.password, "letmein" ]
   TestHost.run AuthHandlers.loginSubmit ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
@@ -153,7 +158,7 @@ let ``loginSubmit rejects wrong password for claimed member with 401`` () =
   let repo = repoWith []
   let ctx = TestHost.contextWithMembers repo [ claimedMember hash ]
   TestHost.setRouteId ctx 1
-  TestHost.setForm ctx [ "Password", "wrongpassword" ]
+  TestHost.setForm ctx [ FormFields.password, "wrongpassword" ]
   TestHost.run AuthHandlers.loginSubmit ctx
 
   test <@ ctx.Response.StatusCode = 401 @>
@@ -170,7 +175,7 @@ let ``loginSubmit returns 403 for inactive member`` () =
   let repo = repoWith []
   let ctx = TestHost.contextWithMembers repo [ inactive ]
   TestHost.setRouteId ctx 1
-  TestHost.setForm ctx [ "Password", "secret" ]
+  TestHost.setForm ctx [ FormFields.password, "secret" ]
   TestHost.run AuthHandlers.loginSubmit ctx
 
   test <@ ctx.Response.StatusCode = 403 @>

--- a/code/BpMonitor.Web.Tests/MemberHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/MemberHandlerTests.fs
@@ -23,7 +23,7 @@ let ``createMember with IsAdmin checkbox persists an admin member`` () =
   let repo = repoWith []
   let ctx = TestHost.context repo
 
-  TestHost.setForm ctx [ "Name", "Alice"; "IsAdmin", "on" ]
+  TestHost.setForm ctx [ FormFields.name, "Alice"; FormFields.isAdmin, "on" ]
   TestHost.run MemberHandlers.createMember ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
@@ -38,7 +38,7 @@ let ``createMember without IsAdmin checkbox persists a non-admin member`` () =
   let repo = repoWith []
   let ctx = TestHost.context repo
 
-  TestHost.setForm ctx [ "Name", "Bob" ]
+  TestHost.setForm ctx [ FormFields.name, "Bob" ]
   TestHost.run MemberHandlers.createMember ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
@@ -73,7 +73,12 @@ let ``updateMember saves changes and redirects to /members`` () =
   let ctx = TestHost.contextWithMembers repo [ adminMember 1 "Me" ]
   TestHost.setRouteId ctx 1
 
-  TestHost.setForm ctx [ "Name", "Myself"; "IsAdmin", "on"; "IsActive", "on" ]
+  TestHost.setForm
+    ctx
+    [ FormFields.name, "Myself"
+      FormFields.isAdmin, "on"
+      FormFields.isActive, "on" ]
+
   TestHost.run MemberHandlers.updateMember ctx
 
   test <@ ctx.Response.StatusCode = 302 @>
@@ -91,7 +96,7 @@ let ``updateMember rejects demoting the last active admin with 422`` () =
   TestHost.setRouteId ctx 1
 
   // Uncheck both IsAdmin and IsActive — would leave no active admin.
-  TestHost.setForm ctx [ "Name", "Me" ]
+  TestHost.setForm ctx [ FormFields.name, "Me" ]
   TestHost.run MemberHandlers.updateMember ctx
 
   test <@ ctx.Response.StatusCode = 422 @>
@@ -107,7 +112,7 @@ let ``updateMember allows demoting one admin when another active admin exists`` 
   TestHost.setRouteId ctx 1
 
   // Demote member 1 to non-admin; member 2 remains active admin → invariant holds.
-  TestHost.setForm ctx [ "Name", "Me"; "IsActive", "on" ]
+  TestHost.setForm ctx [ FormFields.name, "Me"; FormFields.isActive, "on" ]
   TestHost.run MemberHandlers.updateMember ctx
 
   test <@ ctx.Response.StatusCode = 302 @>

--- a/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
@@ -61,11 +61,11 @@ let ``createReading persists a valid reading and redirects`` () =
 
   TestHost.setForm
     ctx
-    [ "Timestamp", "2026-05-01 09:00"
-      "Systolic", "120"
-      "Diastolic", "80"
-      "HeartRate", "66"
-      "Comments", "x" ]
+    [ FormFields.timestamp, "2026-05-01 09:00"
+      FormFields.systolic, "120"
+      FormFields.diastolic, "80"
+      FormFields.heartRate, "66"
+      FormFields.comments, "x" ]
 
   TestHost.run ReadingHandlers.createReading ctx
 
@@ -80,11 +80,11 @@ let ``createReading stamps reading with active member Id`` () =
 
   TestHost.setForm
     ctx
-    [ "Timestamp", "2026-05-01 09:00"
-      "Systolic", "120"
-      "Diastolic", "80"
-      "HeartRate", "66"
-      "Comments", "" ]
+    [ FormFields.timestamp, "2026-05-01 09:00"
+      FormFields.systolic, "120"
+      FormFields.diastolic, "80"
+      FormFields.heartRate, "66"
+      FormFields.comments, "" ]
 
   TestHost.run ReadingHandlers.createReading ctx
 
@@ -97,11 +97,11 @@ let ``createReading rejects an out-of-range reading with 422 and does not persis
 
   TestHost.setForm
     ctx
-    [ "Timestamp", "2026-05-01 09:00"
-      "Systolic", "999"
-      "Diastolic", "80"
-      "HeartRate", "66"
-      "Comments", "" ]
+    [ FormFields.timestamp, "2026-05-01 09:00"
+      FormFields.systolic, "999"
+      FormFields.diastolic, "80"
+      FormFields.heartRate, "66"
+      FormFields.comments, "" ]
 
   TestHost.run ReadingHandlers.createReading ctx
 
@@ -116,11 +116,11 @@ let ``createReading rejects a non-numeric field with 422`` () =
 
   TestHost.setForm
     ctx
-    [ "Timestamp", "2026-05-01 09:00"
-      "Systolic", "abc"
-      "Diastolic", "80"
-      "HeartRate", "66"
-      "Comments", "" ]
+    [ FormFields.timestamp, "2026-05-01 09:00"
+      FormFields.systolic, "abc"
+      FormFields.diastolic, "80"
+      FormFields.heartRate, "66"
+      FormFields.comments, "" ]
 
   TestHost.run ReadingHandlers.createReading ctx
 
@@ -155,11 +155,11 @@ let ``updateReading saves changes and redirects`` () =
 
   TestHost.setForm
     ctx
-    [ "Timestamp", "2026-05-01 09:00"
-      "Systolic", "111"
-      "Diastolic", "70"
-      "HeartRate", "60"
-      "Comments", "updated" ]
+    [ FormFields.timestamp, "2026-05-01 09:00"
+      FormFields.systolic, "111"
+      FormFields.diastolic, "70"
+      FormFields.heartRate, "60"
+      FormFields.comments, "updated" ]
 
   TestHost.run ReadingHandlers.updateReading ctx
 

--- a/code/BpMonitor.Web.Tests/SettingsHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/SettingsHandlerTests.fs
@@ -26,10 +26,10 @@ let ``updateSettings persists a valid goal range and redirects to history`` () =
 
   TestHost.setForm
     ctx
-    [ "SystolicGoalMin", "100"
-      "SystolicGoalMax", "130"
-      "DiastolicGoalMin", "65"
-      "DiastolicGoalMax", "85" ]
+    [ FormFields.systolicGoalMin, "100"
+      FormFields.systolicGoalMax, "130"
+      FormFields.diastolicGoalMin, "65"
+      FormFields.diastolicGoalMax, "85" ]
 
   TestHost.run ReadingHandlers.updateSettings ctx
 
@@ -70,10 +70,10 @@ let ``updateSettings rejects a systolic min greater than or equal to max with 42
 
   TestHost.setForm
     ctx
-    [ "SystolicGoalMin", "140"
-      "SystolicGoalMax", "100"
-      "DiastolicGoalMin", "65"
-      "DiastolicGoalMax", "85" ]
+    [ FormFields.systolicGoalMin, "140"
+      FormFields.systolicGoalMax, "100"
+      FormFields.diastolicGoalMin, "65"
+      FormFields.diastolicGoalMax, "85" ]
 
   TestHost.run ReadingHandlers.updateSettings ctx
 
@@ -91,10 +91,10 @@ let ``updateSettings redisplays the submitted values, not the stale persisted go
 
   TestHost.setForm
     ctx
-    [ "SystolicGoalMin", "140"
-      "SystolicGoalMax", "100"
-      "DiastolicGoalMin", "65"
-      "DiastolicGoalMax", "85" ]
+    [ FormFields.systolicGoalMin, "140"
+      FormFields.systolicGoalMax, "100"
+      FormFields.diastolicGoalMin, "65"
+      FormFields.diastolicGoalMax, "85" ]
 
   TestHost.run ReadingHandlers.updateSettings ctx
 
@@ -109,10 +109,10 @@ let ``updateSettings rejects non-numeric input with 422 and does not persist`` (
 
   TestHost.setForm
     ctx
-    [ "SystolicGoalMin", "abc"
-      "SystolicGoalMax", "130"
-      "DiastolicGoalMin", "65"
-      "DiastolicGoalMax", "85" ]
+    [ FormFields.systolicGoalMin, "abc"
+      FormFields.systolicGoalMax, "130"
+      FormFields.diastolicGoalMin, "65"
+      FormFields.diastolicGoalMax, "85" ]
 
   TestHost.run ReadingHandlers.updateSettings ctx
 
@@ -130,10 +130,10 @@ let ``updateSettings accumulates an error for every invalid field, not just the 
 
   TestHost.setForm
     ctx
-    [ "SystolicGoalMin", "abc"
-      "SystolicGoalMax", "130"
-      "DiastolicGoalMin", "xyz"
-      "DiastolicGoalMax", "85" ]
+    [ FormFields.systolicGoalMin, "abc"
+      FormFields.systolicGoalMax, "130"
+      FormFields.diastolicGoalMin, "xyz"
+      FormFields.diastolicGoalMax, "85" ]
 
   TestHost.run ReadingHandlers.updateSettings ctx
 

--- a/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
@@ -36,9 +36,9 @@ let ``trends renders 200 with granularity buttons and current Weekly panel`` () 
   test <@ ctx.Response.StatusCode = 200 @>
   let body = TestHost.readBody ctx
   // Granularity buttons
-  let weeklyGran = Routes.trendsGran "weekly"
-  let monthlyGran = Routes.trendsGran "monthly"
-  let yearlyGran = Routes.trendsGran "yearly"
+  let weeklyGran = Routes.trendsGran (TrendPeriod.slug Weekly)
+  let monthlyGran = Routes.trendsGran (TrendPeriod.slug Monthly)
+  let yearlyGran = Routes.trendsGran (TrendPeriod.slug Yearly)
   test <@ body.Contains $"href=\"{weeklyGran}\"" @>
   test <@ body.Contains $"href=\"{monthlyGran}\"" @>
   test <@ body.Contains $"href=\"{yearlyGran}\"" @>
@@ -90,7 +90,7 @@ let ``trendsPanel renders the chart with the authenticated member's goal range``
   let ctx =
     TestHost.contextWithMembersAndProvider (repoWith [ r ]) [ memberWithGoal goal ] tp
 
-  setRouteGran ctx "weekly"
+  setRouteGran ctx (TrendPeriod.slug Weekly)
   TestHost.run ReadingHandlers.trendsPanel ctx
   assertGoalBands goal (TestHost.readBody ctx)
 
@@ -106,7 +106,7 @@ let ``trendsPanel with gran=weekly returns fragment with sub-period buttons and 
         HeartRate = 70 }
 
   let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
-  setRouteGran ctx "weekly"
+  setRouteGran ctx (TrendPeriod.slug Weekly)
   TestHost.run ReadingHandlers.trendsPanel ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
@@ -125,7 +125,7 @@ let ``trendsPanel with gran=weekly returns fragment with sub-period buttons and 
 let ``trendsPanel with gran=monthly returns monthly sub-period buttons`` () =
   let tp = FakeTimeProvider(trendsNow)
   let ctx = TestHost.contextWithProvider (repoWith []) tp
-  setRouteGran ctx "monthly"
+  setRouteGran ctx (TrendPeriod.slug Monthly)
   TestHost.run ReadingHandlers.trendsPanel ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
@@ -146,7 +146,7 @@ let ``trendsPanel with gran + key uses that specific sub-period`` () =
         HeartRate = 65 }
 
   let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
-  setRouteGranKey ctx "weekly" "2026-W23"
+  setRouteGranKey ctx (TrendPeriod.slug Weekly) "2026-W23"
   TestHost.run ReadingHandlers.trendsPanel ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
@@ -167,7 +167,7 @@ let ``trendsPanel includes readings table with in-period readings`` () =
         Systolic = 130 }
 
   let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
-  setRouteGran ctx "weekly"
+  setRouteGran ctx (TrendPeriod.slug Weekly)
   TestHost.run ReadingHandlers.trendsPanel ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
@@ -191,7 +191,7 @@ let ``trendsPanel excludes readings outside the period from the table`` () =
         Systolic = 999 }
 
   let ctx = TestHost.contextWithProvider (repoWith [ inside; outside ]) tp
-  setRouteGran ctx "weekly"
+  setRouteGran ctx (TrendPeriod.slug Weekly)
   TestHost.run ReadingHandlers.trendsPanel ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
@@ -209,7 +209,7 @@ let ``trendsPanel shows empty state when no readings in period`` () =
         Timestamp = trendsNow.AddDays(-100.0) }
 
   let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
-  setRouteGran ctx "weekly"
+  setRouteGran ctx (TrendPeriod.slug Weekly)
   TestHost.run ReadingHandlers.trendsPanel ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
@@ -247,13 +247,13 @@ let ``trendsPanel period pills without data are aria-disabled and have no href``
         Systolic = 130 }
 
   let ctx = TestHost.contextWithProvider (repoWith [ r ]) tp
-  setRouteGran ctx "weekly"
+  setRouteGran ctx (TrendPeriod.slug Weekly)
   TestHost.run ReadingHandlers.trendsPanel ctx
 
   test <@ ctx.Response.StatusCode = 200 @>
   let body = TestHost.readBody ctx
-  let w24Route = Routes.trendsGranKey "weekly" "2026-W24"
-  let w23Route = Routes.trendsGranKey "weekly" "2026-W23"
+  let w24Route = Routes.trendsGranKey (TrendPeriod.slug Weekly) "2026-W24"
+  let w23Route = Routes.trendsGranKey (TrendPeriod.slug Weekly) "2026-W23"
   // W24 (This Week) pill should be a normal link
   test <@ body.Contains $"href=\"{w24Route}\"" @>
   // W23 (Last Week) pill should be disabled — no href, has aria-disabled

--- a/code/BpMonitor.Web/AuthHandlers.fs
+++ b/code/BpMonitor.Web/AuthHandlers.fs
@@ -144,8 +144,8 @@ module AuthHandlers =
     fun ctx ->
       task {
         let! form = ctx.Request.ReadFormAsync()
-        let username = form["Username"].ToString().Trim()
-        let password = form["Password"].ToString()
+        let username = form[FormFields.username].ToString().Trim()
+        let password = form[FormFields.password].ToString()
 
         let found =
           (memberRepo ctx).GetAll()
@@ -180,11 +180,11 @@ module AuthHandlers =
           do! ctx.Response.WriteAsync("This account is inactive")
         else
           let! form = ctx.Request.ReadFormAsync()
-          let password = form["Password"].ToString()
+          let password = form[FormFields.password].ToString()
 
           match m.PasswordHash with
           | Some hash -> do! claimedLogin m password hash (LoginViews.loginMember m [ "Incorrect password" ]) ctx
-          | None -> do! unclaimedLogin m password (form["PasswordConfirm"].ToString()) ctx
+          | None -> do! unclaimedLogin m password (form[FormFields.passwordConfirm].ToString()) ctx
       }
       :> Task)
 

--- a/code/BpMonitor.Web/BpMonitor.Web.fsproj
+++ b/code/BpMonitor.Web/BpMonitor.Web.fsproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <Compile Include="Config.fs" />
+    <Compile Include="FormFields.fs" />
     <Compile Include="Binding.fs" />
     <Compile Include="Version.fs" />
     <Compile Include="Routes.fs" />

--- a/code/BpMonitor.Web/FormFields.fs
+++ b/code/BpMonitor.Web/FormFields.fs
@@ -1,0 +1,25 @@
+namespace BpMonitor.Web
+
+/// Single source of truth for HTML form field names — keeps name attributes in
+/// views, form-key lookups in handlers, and test form data aligned so a rename
+/// is a compile error rather than a silent mismatch.
+module FormFields =
+  // Reading form
+  let systolic = "Systolic"
+  let diastolic = "Diastolic"
+  let heartRate = "HeartRate"
+  let timestamp = "Timestamp"
+  let comments = "Comments"
+  // Member form
+  let name = "Name"
+  let isAdmin = "IsAdmin"
+  let isActive = "IsActive"
+  // Login / password form
+  let username = "Username"
+  let password = "Password"
+  let passwordConfirm = "PasswordConfirm"
+  // Settings / goal-range form
+  let systolicGoalMin = "SystolicGoalMin"
+  let systolicGoalMax = "SystolicGoalMax"
+  let diastolicGoalMin = "DiastolicGoalMin"
+  let diastolicGoalMax = "DiastolicGoalMax"

--- a/code/BpMonitor.Web/HandlerHelpers.fs
+++ b/code/BpMonitor.Web/HandlerHelpers.fs
@@ -68,11 +68,11 @@ module HandlerHelpers =
         | _ -> ""
 
       return
-        { Binding.Systolic = get "Systolic"
-          Binding.Diastolic = get "Diastolic"
-          Binding.HeartRate = get "HeartRate"
-          Binding.Timestamp = get "Timestamp"
-          Binding.Comments = get "Comments" }
+        { Binding.Systolic = get FormFields.systolic
+          Binding.Diastolic = get FormFields.diastolic
+          Binding.HeartRate = get FormFields.heartRate
+          Binding.Timestamp = get FormFields.timestamp
+          Binding.Comments = get FormFields.comments }
     }
 
   let sortedReadings (memberId: int) (ctx: HttpContext) =

--- a/code/BpMonitor.Web/LoginViews.fs
+++ b/code/BpMonitor.Web/LoginViews.fs
@@ -15,20 +15,20 @@ module LoginViews =
           [ Attr.method "post"; Attr.action Routes.login; Attr.class' "stacked" ]
           [ Elem.div
               [ Attr.class' "field" ]
-              [ Elem.label [ Attr.for' "Username" ] [ Text.raw "Name" ]
+              [ Elem.label [ Attr.for' FormFields.username ] [ Text.raw "Name" ]
                 Elem.input
                   [ Attr.type' "text"
-                    Attr.id "Username"
-                    Attr.name "Username"
+                    Attr.id FormFields.username
+                    Attr.name FormFields.username
                     Attr.create "autofocus" "autofocus"
                     Attr.create "autocomplete" "username" ] ]
             Elem.div
               [ Attr.class' "field" ]
-              [ Elem.label [ Attr.for' "Password" ] [ Text.raw "Password" ]
+              [ Elem.label [ Attr.for' FormFields.password ] [ Text.raw "Password" ]
                 Elem.input
                   [ Attr.type' "password"
-                    Attr.id "Password"
-                    Attr.name "Password"
+                    Attr.id FormFields.password
+                    Attr.name FormFields.password
                     Attr.create "autocomplete" "current-password" ] ]
             Elem.div [ Attr.class' "actions" ] [ Elem.button [ Attr.type' "submit" ] [ Text.raw "Sign in" ] ] ] ]
 
@@ -42,11 +42,11 @@ module LoginViews =
         // Claimed: single password field
         [ Elem.div
             [ Attr.class' "field" ]
-            [ Elem.label [ Attr.for' "Password" ] [ Text.raw "Password" ]
+            [ Elem.label [ Attr.for' FormFields.password ] [ Text.raw "Password" ]
               Elem.input
                 [ Attr.type' "password"
-                  Attr.id "Password"
-                  Attr.name "Password"
+                  Attr.id FormFields.password
+                  Attr.name FormFields.password
                   Attr.create "autofocus" "autofocus"
                   Attr.create "autocomplete" "current-password" ] ] ]
       else
@@ -56,20 +56,20 @@ module LoginViews =
             [ Text.raw "This account hasn't been claimed yet. Choose a password to activate it." ]
           Elem.div
             [ Attr.class' "field" ]
-            [ Elem.label [ Attr.for' "Password" ] [ Text.raw "New password" ]
+            [ Elem.label [ Attr.for' FormFields.password ] [ Text.raw "New password" ]
               Elem.input
                 [ Attr.type' "password"
-                  Attr.id "Password"
-                  Attr.name "Password"
+                  Attr.id FormFields.password
+                  Attr.name FormFields.password
                   Attr.create "autofocus" "autofocus"
                   Attr.create "autocomplete" "new-password" ] ]
           Elem.div
             [ Attr.class' "field" ]
-            [ Elem.label [ Attr.for' "PasswordConfirm" ] [ Text.raw "Confirm password" ]
+            [ Elem.label [ Attr.for' FormFields.passwordConfirm ] [ Text.raw "Confirm password" ]
               Elem.input
                 [ Attr.type' "password"
-                  Attr.id "PasswordConfirm"
-                  Attr.name "PasswordConfirm"
+                  Attr.id FormFields.passwordConfirm
+                  Attr.name FormFields.passwordConfirm
                   Attr.create "autocomplete" "new-password" ] ] ]
 
     ViewLayout.loginLayout

--- a/code/BpMonitor.Web/MemberHandlers.fs
+++ b/code/BpMonitor.Web/MemberHandlers.fs
@@ -18,8 +18,8 @@ module MemberHandlers =
     withMember (fun active ctx ->
       task {
         let! form = ctx.Request.ReadFormAsync()
-        let name = form["Name"].ToString()
-        let isAdmin = form.ContainsKey("IsAdmin")
+        let name = form[FormFields.name].ToString()
+        let isAdmin = form.ContainsKey(FormFields.isAdmin)
 
         match FamilyMember.create name isAdmin with
         | Error NameIsEmpty ->
@@ -106,9 +106,9 @@ module MemberHandlers =
             existing.Id
             (authenticatedMemberName ctx)
             existing
-            (form["Name"].ToString())
-            (form.ContainsKey("IsAdmin"))
-            (form.ContainsKey("IsActive"))
+            (form[FormFields.name].ToString())
+            (form.ContainsKey(FormFields.isAdmin))
+            (form.ContainsKey(FormFields.isActive))
             ctx
       }
       :> Task)

--- a/code/BpMonitor.Web/MemberViews.fs
+++ b/code/BpMonitor.Web/MemberViews.fs
@@ -50,11 +50,14 @@ module MemberViews =
           [ Attr.method "post"; Attr.action Routes.members; Attr.class' "stacked" ]
           [ Elem.div
               [ Attr.class' "field" ]
-              [ Elem.label [ Attr.for' "Name" ] [ Text.raw "Name" ]
-                Elem.input [ Attr.type' "text"; Attr.id "Name"; Attr.name "Name" ] ]
+              [ Elem.label [ Attr.for' FormFields.name ] [ Text.raw "Name" ]
+                Elem.input [ Attr.type' "text"; Attr.id FormFields.name; Attr.name FormFields.name ] ]
             Elem.label
-              [ Attr.for' "IsAdmin" ]
-              [ Elem.input [ Attr.type' "checkbox"; Attr.id "IsAdmin"; Attr.name "IsAdmin" ]
+              [ Attr.for' FormFields.isAdmin ]
+              [ Elem.input
+                  [ Attr.type' "checkbox"
+                    Attr.id FormFields.isAdmin
+                    Attr.name FormFields.isAdmin ]
                 Text.raw " Admin" ]
             Elem.button [ Attr.type' "submit" ] [ Text.raw "Add member" ] ] ]
 
@@ -84,18 +87,24 @@ module MemberViews =
         ViewLayout.errorBox errors
         Elem.form
           [ Attr.method "post"; Attr.action action ]
-          [ ViewLayout.field "Name" "Name" m.Name "text"
+          [ ViewLayout.field "Name" FormFields.name m.Name "text"
             Elem.div
               [ Attr.class' "field" ]
               [ Elem.label
-                  [ Attr.for' "IsAdmin" ]
-                  [ Elem.input (checkedAttr m.IsAdmin @ [ Attr.id "IsAdmin"; Attr.name "IsAdmin" ])
+                  [ Attr.for' FormFields.isAdmin ]
+                  [ Elem.input (
+                      checkedAttr m.IsAdmin
+                      @ [ Attr.id FormFields.isAdmin; Attr.name FormFields.isAdmin ]
+                    )
                     Text.raw " Admin" ] ]
             Elem.div
               [ Attr.class' "field" ]
               [ Elem.label
-                  [ Attr.for' "IsActive" ]
-                  [ Elem.input (checkedAttr m.IsActive @ [ Attr.id "IsActive"; Attr.name "IsActive" ])
+                  [ Attr.for' FormFields.isActive ]
+                  [ Elem.input (
+                      checkedAttr m.IsActive
+                      @ [ Attr.id FormFields.isActive; Attr.name FormFields.isActive ]
+                    )
                     Text.raw " Active" ] ]
             ViewLayout.formActions Routes.members ] ]
 
@@ -122,10 +131,10 @@ module MemberViews =
         ViewLayout.errorBox errors
         Elem.form
           [ Attr.method "post"; Attr.action Routes.settings ]
-          [ ViewLayout.field "Systolic min" "SystolicGoalMin" sysMin "number"
-            ViewLayout.field "Systolic max" "SystolicGoalMax" sysMax "number"
-            ViewLayout.field "Diastolic min" "DiastolicGoalMin" diaMin "number"
-            ViewLayout.field "Diastolic max" "DiastolicGoalMax" diaMax "number"
+          [ ViewLayout.field "Systolic min" FormFields.systolicGoalMin sysMin "number"
+            ViewLayout.field "Systolic max" FormFields.systolicGoalMax sysMax "number"
+            ViewLayout.field "Diastolic min" FormFields.diastolicGoalMin diaMin "number"
+            ViewLayout.field "Diastolic max" FormFields.diastolicGoalMax diaMax "number"
             ViewLayout.formActions Routes.history ] ]
 
   /// Members page: list of family members with Edit/Reset-password buttons and an add form.

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -216,7 +216,10 @@ module ReadingHandlers =
         let raw key = form[key].ToString()
 
         let sysMinRaw, sysMaxRaw, diaMinRaw, diaMaxRaw =
-          raw "SystolicGoalMin", raw "SystolicGoalMax", raw "DiastolicGoalMin", raw "DiastolicGoalMax"
+          raw FormFields.systolicGoalMin,
+          raw FormFields.systolicGoalMax,
+          raw FormFields.diastolicGoalMin,
+          raw FormFields.diastolicGoalMax
 
         let renderErrors errors =
           ctx.Response.StatusCode <- 422

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -207,9 +207,9 @@ module ReadingViews =
         ViewLayout.errorBox errors
         Elem.form
           [ Attr.method "post"; Attr.action action ]
-          [ fieldWithHint "Timestamp" "yyyy-MM-dd HH:mm" "Timestamp" m.Timestamp "text"
-            fieldWithHint "Systolic" "mmHg" "Systolic" m.Systolic "number"
-            fieldWithHint "Diastolic" "mmHg" "Diastolic" m.Diastolic "number"
-            fieldWithHint "Heart Rate" "bpm" "HeartRate" m.HeartRate "number"
-            ViewLayout.field "Comment" "Comments" m.Comments "text"
+          [ fieldWithHint "Timestamp" "yyyy-MM-dd HH:mm" FormFields.timestamp m.Timestamp "text"
+            fieldWithHint "Systolic" "mmHg" FormFields.systolic m.Systolic "number"
+            fieldWithHint "Diastolic" "mmHg" FormFields.diastolic m.Diastolic "number"
+            fieldWithHint "Heart Rate" "bpm" FormFields.heartRate m.HeartRate "number"
+            ViewLayout.field "Comment" FormFields.comments m.Comments "text"
             ViewLayout.formActions Routes.history ] ]


### PR DESCRIPTION
## Summary

- Add `FormFields` module as the single source of truth for all HTML form field name strings (`Systolic`, `HeartRate`, `Username`, `IsAdmin`, `SystolicGoalMin`, etc.)
- Update all views (`LoginViews`, `ReadingViews`, `MemberViews`) to use `FormFields.*` for `Attr.name`/`Attr.id`/`Attr.for'` attributes
- Update all handlers (`HandlerHelpers`, `AuthHandlers`, `MemberHandlers`, `ReadingHandlers`) to use `FormFields.*` for form key lookups
- Update all handler tests to use `FormFields.*` in `TestHost.setForm` calls — a field rename is now a compile error, not a silent test mismatch
- Replace raw `"weekly"`/`"monthly"`/`"yearly"` string literals in `TrendHandlerTests` with `TrendPeriod.slug Weekly/Monthly/Yearly` — a slug change in `TrendPeriod` is now caught at compile time