### PR TITLE
🐛 fix(web): truncate member name on mobile topbar to prevent overflow

### DIFF
--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -505,6 +505,16 @@ footer.container {
 .nav-member-name {
   color: var(--pico-muted-color);
   font-size: 0.875rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: clamp(4rem, 20vw, 10rem);
+}
+
+/* Allow topbar-right to shrink on narrow viewports so the member name
+   truncates instead of overflowing the topbar. */
+.topbar-right {
+  min-width: 0;
 }
 
 /* Inline logout/action form — removes default form block display */


### PR DESCRIPTION
## Summary

- Add text truncation to `.nav-member-name` (overflow, text-overflow: ellipsis, max-width clamp)
- Set `.topbar-right` min-width: 0 to allow flex shrinking on narrow viewports
- Member name now clips gracefully instead of pushing logout/theme-toggle buttons off-screen