### PR TITLE
🐛 fix(web): prevent readings table from overflowing page on mobile

### DIFF
--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -421,6 +421,15 @@ input#DiastolicGoalMax {
   text-align: center;
 }
 
+/* Prevents the wide readings table (fixed-width timestamp + several columns) from
+   overflowing the page horizontally on narrow mobile viewports. Without this,
+   the page scrolls horizontally, which corrupts position:fixed elements (the topbar)
+   on some mobile browsers — right:0 resolves against the scrollable width instead of
+   the viewport, pushing the topbar off-screen. */
+#readings {
+  overflow-x: auto;
+}
+
 #readings,
 form {
   font-size: 0.875rem;


### PR DESCRIPTION
## Summary

- Add `overflow-x: auto` to `#readings` so the readings table scrolls horizontally within its own box rather than overflowing the page
- The timestamp column is fixed-width (`10.5rem`, `white-space: nowrap`), pushing the table past 375 px on narrow viewports
- Page-level horizontal overflow corrupts `position: fixed` on some mobile browsers: `right: 0` resolves against the scrollable width instead of the viewport, so the topbar is pushed off-screen
- `/recent` has no readings table and was unaffected; `/history` and `/trends` both render the table and showed the overflow