### PR TITLE
🐛 fix(web): HTML-encode page title to prevent stored XSS

### DIFF
--- a/code/BpMonitor.Web.Tests/LayoutViewTests.fs
+++ b/code/BpMonitor.Web.Tests/LayoutViewTests.fs
@@ -55,3 +55,16 @@ let ``every authenticated page shows the logout button`` () =
 let ``every authenticated page shows the member name`` () =
   let html = renderHtml (ReadingViews.landing defaultMember)
   test <@ html.Contains "Me" @>
+
+[<Fact>]
+let ``page title HTML-encodes member name to prevent title injection`` () =
+  let hostile =
+    { defaultMember with
+        Name = "</title><script>alert(1)</script>" }
+
+  let html = renderHtml (LoginViews.loginMember hostile [])
+
+  // The raw injection string must not appear (it would break out of the <title> element)
+  test <@ not (html.Contains "</title><script>") @>
+  // The HTML-encoded form must appear instead
+  test <@ html.Contains "&lt;/title&gt;" @>

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -55,7 +55,7 @@ module ViewLayout =
       []
       ([ Elem.meta [ Attr.charset "utf-8" ]
          Elem.meta [ Attr.name "viewport"; Attr.content "width=device-width, initial-scale=1" ]
-         Elem.title [] [ Text.raw title ]
+         Elem.title [] [ Text.enc title ]
          Elem.link [ Attr.rel "icon"; Attr.href "/favicon.svg"; Attr.type' "image/svg+xml" ]
          // Runs once on initial load; survives hx-boost navigations because it lives in <head>.
          // No defer/async — render-blocking prevents flash of the wrong theme (FOUC).


### PR DESCRIPTION
## Summary

- `htmlHead` in `ViewLayout.fs` was rendering the `<title>` content with `Text.raw`, leaving caller-supplied strings unescaped
- A member name containing `</title><script>…</script>` would inject into `<head>` via the login page (the only path that embeds a user-controlled value in the title)
- Switch to `Text.enc` — a one-character change that closes the sink at the layout boundary for all current and future callers
- Add a regression test in `LayoutViewTests` that renders `LoginViews.loginMember` with a hostile name and asserts the raw injection string is absent and the encoded form is present