### PR TITLE
🔒 fix(export): prevent CSV formula injection in comment fields

### DIFF
--- a/code/BpMonitor.Export.Tests/CsvExportTests.fs
+++ b/code/BpMonitor.Export.Tests/CsvExportTests.fs
@@ -80,3 +80,17 @@ let ``tryWriteToFile returns Error when path is invalid`` () =
   let result = tryWriteToFile "/invalid/path/that/does/not/exist/file.csv" []
 
   test <@ result <> Ok() @>
+
+[<Theory>]
+[<InlineData("=SUM(A1:A10)")>]
+[<InlineData("+1+1")>]
+[<InlineData("-1+2")>]
+[<InlineData("@SUM(A1)")>]
+let ``serialize prefixes formula-trigger comments to prevent spreadsheet injection`` (comment: string) =
+  let r = { reading with Comments = Some comment }
+  let csv = serialize [ r ]
+
+  // Raw trigger-starting field must not appear (would execute as a formula in Excel/Sheets)
+  test <@ not (csv.Contains $",{comment},") @>
+  // Apostrophe-prefixed field must appear instead
+  test <@ csv.Contains $",'{comment}," @>

--- a/code/BpMonitor.Export/CsvExport.fs
+++ b/code/BpMonitor.Export/CsvExport.fs
@@ -3,9 +3,20 @@ module BpMonitor.Export.CsvExport
 open System.Text
 open BpMonitor.Core
 
+// Characters that spreadsheet apps (Excel, Sheets) interpret as formula prefixes.
+// A field starting with one of these would execute as a formula when the CSV is
+// opened, so we prepend an apostrophe to force text interpretation.
+let private formulaTriggers = [| '='; '+'; '-'; '@' |]
+
 // RFC 4180: quote a field if it contains a comma, double-quote, CR, or LF;
 // double any embedded double-quotes.
 let private csvField (s: string) : string =
+  let s =
+    if s.Length > 0 && Array.contains s[0] formulaTriggers then
+      "'" + s
+    else
+      s
+
   if s.IndexOfAny [| ','; '"'; '\n'; '\r' |] >= 0 then
     "\"" + s.Replace("\"", "\"\"") + "\""
   else


### PR DESCRIPTION
## Summary

- Comments are the only user-controlled free-text field in the CSV export; a value starting with `=`, `+`, `-`, or `@` is treated as a formula by Excel/Sheets and executes on open
- Prefix such fields with an apostrophe in `csvField` so spreadsheet apps force text interpretation — applied before the existing RFC 4180 quoting so the apostrophe is included in any surrounding quotes
- Add a `[<Theory>]` test in `CsvExportTests` covering all four trigger characters, asserting the raw trigger-starting field is absent and the apostrophe-prefixed form is present