### PR TITLE
🔒 fix(web): set CookieSecurePolicy=Always and wire UseForwardedHeaders

### DIFF
--- a/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
+++ b/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
@@ -1,5 +1,8 @@
 module BpMonitor.Web.E2E.SmokeTests
 
+open System
+open System.Collections.Generic
+open System.Net.Http
 open System.Threading.Tasks
 open BpMonitor.Web.E2E
 open Xunit
@@ -32,4 +35,39 @@ type LoginAddHistoryTests(fixture: WebAppFixture) =
       Assert.Contains("118", tableText)
       Assert.Contains("76", tableText)
       Assert.Contains("62", tableText)
+    }
+
+/// Verifies HTTP security properties of the running server via raw HttpClient
+/// (no browser required — just inspects response headers).
+type CookieSecurityTests(fixture: WebAppFixture) =
+  interface IClassFixture<WebAppFixture>
+
+  [<Fact>]
+  member _.``auth Set-Cookie always includes Secure attribute``() : Task =
+    task {
+      use handler = new HttpClientHandler(AllowAutoRedirect = false)
+      use client = new HttpClient(handler)
+
+      // POST /login with just a username — the "Me" account starts unclaimed,
+      // so the server redirects to the per-member claim page without checking
+      // the password field.
+      use step1Body =
+        new FormUrlEncodedContent([ KeyValuePair("Username", TestAccount.username); KeyValuePair("Password", "") ])
+
+      let! redirectResp = client.PostAsync($"{fixture.BaseUrl}/login", step1Body)
+      let claimUrl = Uri(Uri(fixture.BaseUrl), redirectResp.Headers.Location).ToString()
+
+      // Claim the account — SignInAsync fires here and emits the Set-Cookie header.
+      use step2Body =
+        new FormUrlEncodedContent(
+          [ KeyValuePair("Password", TestAccount.password)
+            KeyValuePair("PasswordConfirm", TestAccount.password) ]
+        )
+
+      let! signInResp = client.PostAsync(claimUrl, step2Body)
+
+      let setCookieHeader =
+        signInResp.Headers.GetValues("Set-Cookie") |> String.concat " "
+
+      Assert.Contains("secure", setCookieHeader.ToLower())
     }

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -6,6 +6,7 @@ open Falco.Routing
 open Microsoft.AspNetCore.Authentication.Cookies
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Http
+open Microsoft.AspNetCore.HttpOverrides
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.EntityFrameworkCore
@@ -79,8 +80,12 @@ let main args =
         o.LoginPath <- PathString("/login")
         o.Cookie.HttpOnly <- true
         o.Cookie.SameSite <- SameSiteMode.Strict
-        o.Cookie.SecurePolicy <- CookieSecurePolicy.SameAsRequest
+        o.Cookie.SecurePolicy <- CookieSecurePolicy.Always
         o.SlidingExpiration <- true)
+    |> ignore
+
+    builder.Services.Configure<ForwardedHeadersOptions>(fun (opts: ForwardedHeadersOptions) ->
+      opts.ForwardedHeaders <- ForwardedHeaders.XForwardedFor ||| ForwardedHeaders.XForwardedProto)
     |> ignore
 
     builder.Services.AddAuthorization() |> ignore
@@ -109,6 +114,8 @@ let main args =
 
     // One structured log line per request (method, path, status, elapsed ms).
     app.UseSerilogRequestLogging() |> ignore
+
+    app.UseForwardedHeaders() |> ignore
 
     app.UseStaticFiles().UseRouting().UseAuthentication().UseAuthorization().UseFalco(endpoints)
     |> ignore


### PR DESCRIPTION
## Summary

- Auth cookie now always carries the `Secure` flag regardless of whether the incoming request is HTTP or HTTPS — required when TLS is terminated by a reverse proxy upstream of the app
- `ForwardedHeaders` middleware (`X-Forwarded-For` + `X-Forwarded-Proto`) registered so the app sees the real client IP and scheme behind a proxy
- E2E regression test (`CookieSecurityTests`) asserts the `Set-Cookie` header contains the `secure` attribute after a successful sign-in