### PR TITLE
⚡ perf(data): translate EF member/reading filters to SQL WHERE clauses

### DIFF
--- a/code/BpMonitor.Data.Tests/EfFamilyMemberRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/EfFamilyMemberRepositoryTests.fs
@@ -20,6 +20,20 @@ let private createContext () =
   ctx.Database.EnsureCreated() |> ignore
   ctx
 
+let private createContextWithLog (log: ResizeArray<string>) =
+  let connection = new SqliteConnection("DataSource=:memory:")
+  connection.Open()
+
+  let options =
+    DbContextOptionsBuilder<BpMonitorDbContext>()
+      .UseSqlite(connection)
+      .LogTo(System.Action<string>(fun s -> log.Add(s)))
+      .Options
+
+  let ctx = new BpMonitorDbContext(options)
+  ctx.Database.EnsureCreated() |> ignore
+  ctx
+
 let private createRepo (ctx: BpMonitorDbContext) : IFamilyMemberRepository =
   EfFamilyMemberRepository(ctx, TimeProvider.System) :> IFamilyMemberRepository
 
@@ -167,3 +181,17 @@ let ``Add persists a custom goal range and Update round-trips changes to it`` ()
 
   repo.Update { added with Goal = newGoal }
   test <@ (repo.GetById added.Id).Value.Goal = newGoal @>
+
+[<Fact>]
+let ``GetById translates Id filter to SQL WHERE clause`` () =
+  let log = ResizeArray<string>()
+  use ctx = createContextWithLog log
+  let repo = createRepo ctx
+  let added = repo.Add(newMember "Alice" true)
+  log.Clear()
+  repo.GetById(added.Id) |> ignore
+
+  let selectSql =
+    log |> Seq.filter (fun s -> s.Contains("SELECT")) |> String.concat " "
+
+  Assert.Contains("WHERE", selectSql)

--- a/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
@@ -33,6 +33,20 @@ let private createContext () =
   ctx.Database.EnsureCreated() |> ignore
   ctx
 
+let private createContextWithLog (log: ResizeArray<string>) =
+  let connection = new SqliteConnection("DataSource=:memory:")
+  connection.Open()
+
+  let options =
+    DbContextOptionsBuilder<BpMonitorDbContext>()
+      .UseSqlite(connection)
+      .LogTo(System.Action<string>(fun s -> log.Add(s)))
+      .Options
+
+  let ctx = new BpMonitorDbContext(options)
+  ctx.Database.EnsureCreated() |> ignore
+  ctx
+
 let private createRepo (ctx: BpMonitorDbContext) : IReadingRepository =
   EfReadingRepository(ctx, TimeProvider.System) :> IReadingRepository
 
@@ -184,3 +198,17 @@ let ``Update does not affect a reading belonging to a different member`` () =
   // Reading should remain unchanged for member 1
   // ReSharper disable once FSharpRedundantDotInIndexer
   test <@ (repo.GetAll 1).[0].Systolic = 120 @>
+
+[<Fact>]
+let ``GetAll translates MemberId filter to SQL WHERE clause`` () =
+  let log = ResizeArray<string>()
+  use ctx = createContextWithLog log
+  let repo = createRepo ctx
+  repo.Add defaultMemberId sample
+  log.Clear()
+  repo.GetAll(defaultMemberId) |> ignore
+
+  let selectSql =
+    log |> Seq.filter (fun s -> s.Contains("SELECT")) |> String.concat " "
+
+  Assert.Contains("WHERE", selectSql)

--- a/code/BpMonitor.Data/EfFamilyMemberRepository.fs
+++ b/code/BpMonitor.Data/EfFamilyMemberRepository.fs
@@ -41,8 +41,12 @@ type EfFamilyMemberRepository(ctx: BpMonitorDbContext, timeProvider: System.Time
       ctx.Members.AsNoTracking() |> Seq.map MemberMapping.toDomain |> Seq.toList
 
     member _.GetById(id) =
-      ctx.Members.AsNoTracking()
-      |> Seq.tryFind (fun m -> m.Id = id)
+      query {
+        for m in ctx.Members.AsNoTracking() do
+          where (m.Id = id)
+          select m
+      }
+      |> Seq.tryHead
       |> Option.map MemberMapping.toDomain
 
     member _.Add(m) =
@@ -54,7 +58,14 @@ type EfFamilyMemberRepository(ctx: BpMonitorDbContext, timeProvider: System.Time
 
     member _.Update(m) =
       // Guard: only update if the member exists (prevents DbUpdateConcurrencyException on missing rows).
-      let exists = ctx.Members.AsNoTracking() |> Seq.exists (fun r -> r.Id = m.Id)
+      let exists =
+        query {
+          for r in ctx.Members.AsNoTracking() do
+            where (r.Id = m.Id)
+            select r
+        }
+        |> Seq.isEmpty
+        |> not
 
       if exists then
         let now = timeProvider.GetUtcNow()

--- a/code/BpMonitor.Data/EfReadingRepository.fs
+++ b/code/BpMonitor.Data/EfReadingRepository.fs
@@ -36,8 +36,11 @@ module private Mapping =
 type EfReadingRepository(ctx: BpMonitorDbContext, timeProvider: System.TimeProvider) =
   interface IReadingRepository with
     member _.GetAll(memberId) =
-      ctx.Readings.AsNoTracking()
-      |> Seq.filter (fun r -> r.MemberId = memberId)
+      query {
+        for r in ctx.Readings.AsNoTracking() do
+          where (r.MemberId = memberId)
+          select r
+      }
       |> Seq.map Mapping.toDomain
       |> Seq.toList
 
@@ -74,8 +77,13 @@ type EfReadingRepository(ctx: BpMonitorDbContext, timeProvider: System.TimeProvi
 
       // Guard: only update if reading belongs to the expected member (prevents cross-member writes)
       let existsForMember =
-        ctx.Readings.AsNoTracking()
-        |> Seq.exists (fun r -> r.Id = reading.Id && r.MemberId = reading.MemberId)
+        query {
+          for r in ctx.Readings.AsNoTracking() do
+            where (r.Id = reading.Id && r.MemberId = reading.MemberId)
+            select r
+        }
+        |> Seq.isEmpty
+        |> not
 
       if existsForMember then
         ctx.ChangeTracker.Entries<ReadingRecord>()

--- a/code/BpMonitor.Data/SchemaMigrations.fs
+++ b/code/BpMonitor.Data/SchemaMigrations.fs
@@ -133,3 +133,7 @@ module SchemaMigrations =
 
     // Promote the lowest-Id member to admin+active when no active admin exists yet.
     ensureActiveAdmin ctx
+
+    // Index for member-scoped reading queries (every GetAll/Update filters by MemberId).
+    ctx.Database.ExecuteSqlRaw("CREATE INDEX IF NOT EXISTS \"idx_readings_memberid\" ON \"Readings\" (\"MemberId\")")
+    |> ignore


### PR DESCRIPTION
## Summary

- Replace `Seq.filter`/`Seq.exists`/`Seq.tryFind` in `EfReadingRepository` and `EfFamilyMemberRepository` with F# query expressions so EF Core emits parameterised SQL `WHERE` clauses instead of loading entire tables into memory
- Add `CREATE INDEX IF NOT EXISTS idx_readings_memberid` in `SchemaMigrations.apply` to back the per-member filter on every `GetAll`/`Update` call
- Add two red→green SQL-translation tests (using `DbContextOptionsBuilder.LogTo`) that assert the emitted `SELECT` contains `WHERE`