### PR TITLE
🐛 fix(web): return 404 when updateReading targets a non-existent or non-owned reading

### DIFF
--- a/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
@@ -167,3 +167,21 @@ let ``updateReading saves changes and redirects`` () =
   test <@ ctx.Response.Headers.Location.ToString() = Routes.history @>
   let updated = repo.GetAll(defaultMemberId) |> List.exactlyOne
   test <@ updated.Systolic = 111 && updated.Comments = Some "updated" @>
+
+[<Fact>]
+let ``updateReading returns 404 for an unknown id`` () =
+  let repo = repoWith [ sample ]
+  let ctx = TestHost.context repo
+  TestHost.setRouteId ctx 999
+
+  TestHost.setForm
+    ctx
+    [ FormFields.timestamp, "2026-05-01 09:00"
+      FormFields.systolic, "111"
+      FormFields.diastolic, "70"
+      FormFields.heartRate, "60"
+      FormFields.comments, "" ]
+
+  TestHost.run ReadingHandlers.updateReading ctx
+
+  test <@ ctx.Response.StatusCode = 404 @>

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -285,8 +285,14 @@ module ReadingHandlers =
 
   let updateReading: HttpContext -> Task =
     withMemberAndRouteId "updateReading" (fun m id ctx ->
-      submit ctx "" m.Name m.IsAdmin "Edit reading" (Routes.readingUpdate id) Routes.history (fun r ->
-        (repo ctx).Update { r with Id = id; MemberId = m.Id }))
+      match (repo ctx).GetAll(m.Id) |> List.tryFind (fun r -> r.Id = id) with
+      | None ->
+        let log = logger ctx
+        log.LogWarning("updateReading: reading {Id} not found for member {MemberId}", id, m.Id)
+        notFound ctx
+      | Some _ ->
+        submit ctx "" m.Name m.IsAdmin "Edit reading" (Routes.readingUpdate id) Routes.history (fun r ->
+          (repo ctx).Update { r with Id = id; MemberId = m.Id }))
 
   // ---------------------------------------------------------------------------
   // Export


### PR DESCRIPTION
## Summary

- `updateReading` previously relied on the repo's silent no-op, returning 302 → `/history` even for unknown or cross-member ids — inconsistent with `editReading` which returns 404
- Added ownership lookup (mirrors `editReading`) + 404 + warning log for missing/non-owned ids
- Added regression test `updateReading returns 404 for an unknown id`