### PR TITLE
📋 docs: add SECURITY.md and exclude bin/ from markdown linting

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,6 @@
+ignores:
+  - "**/bin/**"
+
 config:
   MD013: false # line length
   MD024: false # duplicate heading content

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A blood pressure monitoring application for families and households, built with 
 - [Install](docs/install.md) — install, configure, and deploy
 - [Contributing](CONTRIBUTING.md) — build, test, and release the project
 - [Badges branch](docs/badges-branch.md) — how the coverage badge is generated and stored
+- [Security](SECURITY.md) — how to report a vulnerability
 
 ## About This Project
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not open a public issue** for security vulnerabilities.
+
+Report privately via GitHub's Security Advisory:
+**[Report a vulnerability](https://github.com/draptik/BpMonitor/security/advisories/new)**
+(Security tab → "Report a vulnerability")
+
+## What to Expect
+
+This is a personal/hobby project — there is no SLA. I will acknowledge the
+report when I can and aim to fix confirmed vulnerabilities in a future release.
+
+## Scope
+
+BpMonitor is a self-hosted, single-family app. Reports about vulnerabilities
+in the deployed web application are welcome.


### PR DESCRIPTION
## Summary

- Add SECURITY.md with vulnerability reporting policy (GitHub private advisory channel)
- Add Security link to README Docs section
- Exclude bin/ from markdown linting to silence pre-existing Playwright vendored-file errors

Note: For the GitHub advisory link to work, enable "Private vulnerability reporting" in repo Settings → Code security & analysis.