### PR TITLE
📝 docs: add changelog entry for MemberId index schema migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Database schema migration adds an index on `MemberId` in the `Readings` table on first startup — improves query performance for all reading lookups
+
 ## [1.7.4] - 2026-06-27
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Add `[Unreleased]` changelog entry for the `MemberId` index added to the `Readings` table in PR #357