### PR TITLE
🔧 fix(web): make cookie SecurePolicy configurable, default to SameAsRequest

### DIFF
--- a/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
+++ b/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
@@ -43,7 +43,7 @@ type CookieSecurityTests(fixture: WebAppFixture) =
   interface IClassFixture<WebAppFixture>
 
   [<Fact>]
-  member _.``auth Set-Cookie always includes Secure attribute``() : Task =
+  member _.``auth Set-Cookie always includes HttpOnly attribute``() : Task =
     task {
       use handler = new HttpClientHandler(AllowAutoRedirect = false)
       use client = new HttpClient(handler)
@@ -69,5 +69,5 @@ type CookieSecurityTests(fixture: WebAppFixture) =
       let setCookieHeader =
         signInResp.Headers.GetValues("Set-Cookie") |> String.concat " "
 
-      Assert.Contains("secure", setCookieHeader.ToLower())
+      Assert.Contains("httponly", setCookieHeader.ToLower())
     }

--- a/code/BpMonitor.Web/Program.fs
+++ b/code/BpMonitor.Web/Program.fs
@@ -74,13 +74,21 @@ let main args =
       EfFamilyMemberRepository(sp.GetRequiredService<BpMonitorDbContext>(), TimeProvider.System))
     |> ignore
 
+    let secureCookies = builder.Configuration.GetValue<bool>("BpMonitor:SecureCookies")
+
     builder.Services
       .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
       .AddCookie(fun o ->
         o.LoginPath <- PathString("/login")
         o.Cookie.HttpOnly <- true
         o.Cookie.SameSite <- SameSiteMode.Strict
-        o.Cookie.SecurePolicy <- CookieSecurePolicy.Always
+
+        o.Cookie.SecurePolicy <-
+          if secureCookies then
+            CookieSecurePolicy.Always
+          else
+            CookieSecurePolicy.SameAsRequest
+
         o.SlidingExpiration <- true)
     |> ignore
 

--- a/code/BpMonitor.Web/appsettings.json
+++ b/code/BpMonitor.Web/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Urls": "http://0.0.0.0:5000",
   "BpMonitor": {
-    "SeedDemoData": false
+    "SeedDemoData": false,
+    "SecureCookies": false
   },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=bpmonitor.db"


### PR DESCRIPTION
## Summary

- `BpMonitor:SecureCookies` (bool, default `false`) controls the auth cookie secure policy
- `false` → `CookieSecurePolicy.SameAsRequest` (works over plain HTTP)
- `true` → `CookieSecurePolicy.Always` (required when behind an HTTPS reverse proxy)

Fixes login breakage on direct HTTP deployments introduced by v1.7.5.