### PR TITLE
🐛 fix(web): render 422 validation errors in htmx-boosted forms

### DIFF
--- a/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
+++ b/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
@@ -37,6 +37,31 @@ type LoginAddHistoryTests(fixture: WebAppFixture) =
       Assert.Contains("62", tableText)
     }
 
+/// Verifies that submitting invalid reading values re-renders the form with
+/// visible error messages (not silently discarded by htmx's 422 handling).
+type ReadingValidationTests(fixture: WebAppFixture) =
+  interface IClassFixture<WebAppFixture>
+
+  [<Fact>]
+  member _.``submitting an out-of-range reading shows error messages on the form``() : Task =
+    task {
+      let! page = fixture.Browser.NewPageAsync()
+
+      do! TestAccount.claimAndLogin fixture.BaseUrl page
+
+      let! _ = page.GotoAsync($"{fixture.BaseUrl}/add")
+      do! page.FillAsync("#Timestamp", "2026-06-19 08:30")
+      do! page.FillAsync("#Systolic", "999")
+      do! page.FillAsync("#Diastolic", "80")
+      do! page.FillAsync("#HeartRate", "66")
+      do! page.ClickAsync("form[action='/readings'] button[type=submit]")
+
+      let! _ = page.WaitForSelectorAsync(".errors")
+
+      let! errorText = page.Locator(".errors").TextContentAsync()
+      Assert.Contains("out of range", errorText)
+    }
+
 /// Verifies HTTP security properties of the running server via raw HttpClient
 /// (no browser required — just inspects response headers).
 type CookieSecurityTests(fixture: WebAppFixture) =

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -85,7 +85,13 @@ module ViewLayout =
   let layout (active: string) (memberName: string) (isAdmin: bool) (title: string) (content: XmlNode list) : XmlNode =
     Elem.html
       [ Attr.lang "en" ]
-      [ htmlHead title [ Elem.script [ Attr.src "/htmx.min.js" ] [] ]
+      [ htmlHead
+          title
+          [ Elem.script [ Attr.src "/htmx.min.js" ] []
+            Elem.script
+              []
+              [ Text.raw
+                  "htmx.config.responseHandling=[{code:'204',swap:false},{code:'[23]..',swap:true},{code:'422',swap:true,error:false},{code:'[45]..',swap:false,error:true}];" ] ]
         Elem.body
           [ Attr.create "hx-boost" "true" ]
           [ // Checkbox drives the mobile off-canvas drawer via pure CSS sibling selectors.


### PR DESCRIPTION
## Summary

- Configure `htmx.config.responseHandling` globally so htmx swaps 422 responses into the page instead of silently discarding them — fixes validation error messages never appearing after a failed reading form submit
- Add E2E test that submits an out-of-range systolic value and asserts the `.errors` element is rendered in the browser