### PR TITLE
🔧 chore: add 5-day grace period and daily 5am schedule to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["every weekend"],
+  "schedule": ["* 5 * * *"],
+  "minimumReleaseAge": "5 days",
   "commitMessagePrefix": "⬆️ chore:",
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: "5 days"` so Renovate holds back new releases for 5 days before recommending them, reducing churn from hot-fixed/broken releases
- Change `schedule` from `every weekend` to `* 5 * * *` (daily at 5am) for more predictable, frequent updates