### PR TITLE
🐛 fix(recent): only active zoom button appears selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Recent page: "Last 7 days" and "Last 30 days" buttons no longer both appear selected — only the active range is highlighted
+
 ## [1.7.6] - 2026-06-28
 
 ### Fixed

--- a/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
@@ -129,6 +129,29 @@ let ``createReading rejects a non-numeric field with 422`` () =
   test <@ repo.GetAll(defaultMemberId) |> List.isEmpty @>
 
 [<Fact>]
+let ``recent marks only the Last 30 days button as active`` () =
+  let repo = repoWith [ sample ]
+  let ctx = TestHost.context repo
+  TestHost.run ReadingHandlers.recent ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  let body = TestHost.readBody ctx
+
+  let zoomButtons =
+    System.Text.RegularExpressions.Regex.Matches(body, "<button[^>]*recent-zoom-button[^>]*>([^<]*)</button>")
+    |> Seq.cast<System.Text.RegularExpressions.Match>
+    |> Seq.map (fun m -> m.Value.Contains "aria-pressed=\"true\"", m.Groups[1].Value)
+    |> Seq.toList
+
+  test <@ zoomButtons |> List.filter fst |> List.length = 1 @>
+
+  test
+    <@
+      zoomButtons
+      |> List.exists (fun (pressed, label) -> pressed && label = "Last 30 days")
+    @>
+
+[<Fact>]
 let ``editReading prefills the form for an existing reading`` () =
   let repo = repoWith [ sample ]
   let ctx = TestHost.context repo

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -120,11 +120,19 @@ module ReadingViews =
     // out-of-range cells automatically when relayout fires.
     let hiFormatted = Formats.formatLocal now
 
+    // The button whose range starts at `windowStart` matches the chart's initial focus
+    // (both `recent` and `recentFull` render `windowStart = now.AddDays(-30)`), so it's
+    // rendered as the active pill on load; recent-zoom.js re-toggles `aria-pressed` on click.
+    let activeLo = Formats.formatLocal windowStart
+
     let zoomButton (label: string) (days: float) =
+      let lo = Formats.formatLocal (now.AddDays(-days))
+
       Elem.button
         [ Attr.type' "button"
           Attr.class' "recent-zoom-button"
-          Attr.create "data-lo" (Formats.formatLocal (now.AddDays(-days)))
+          Attr.create "aria-pressed" (if lo = activeLo then "true" else "false")
+          Attr.create "data-lo" lo
           Attr.create "data-hi" hiFormatted ]
         [ Text.raw label ]
 

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -682,8 +682,10 @@ form.inline button {
 
 /* Granularity selector row (Weekly / Monthly / Yearly). Shared with the Recent
    page's zoom-shortcut row (ReadingViews.fs `zoomButtons`,
-   wwwroot/recent-zoom.js) — same pill layout, just an <a role="button"> here
-   vs a <button> there. */
+   wwwroot/recent-zoom.js) — same pill layout. The trends row is <a role="button">
+   (Pico's outline default) with a filled `aria-current="page"` pill below; the
+   recent row is <button> (Pico's filled default), so it gets its own outline
+   base + filled `aria-pressed="true"` pill instead. */
 .trends-window-buttons,
 .recent-zoom-buttons {
   display: flex;
@@ -702,9 +704,26 @@ form.inline button {
   text-align: center;
 }
 
+/* Outline base for the recent zoom-shortcut buttons: unlike the trends row's
+   <a role="button"> (Pico's outline default), a bare <button> defaults to
+   filled, so without this every recent-zoom-button would render as if active. */
+.recent-zoom-buttons button {
+  background: transparent;
+  color: var(--pico-primary);
+  border-color: var(--pico-primary);
+}
+
 /* Active granularity / sub-period pill — filled primary (matches nav active pill style) */
 .trends-window-buttons a[aria-current="page"],
 .trends-subperiod-buttons a[aria-current="page"] {
+  background: var(--pico-primary);
+  color: var(--pico-primary-inverse);
+  border-color: var(--pico-primary);
+}
+
+/* Active recent zoom-shortcut pill (ReadingViews.fs `zoomButton`, toggled by
+   wwwroot/recent-zoom.js on click) — same filled style as the pills above. */
+.recent-zoom-buttons button[aria-pressed="true"] {
   background: var(--pico-primary);
   color: var(--pico-primary-inverse);
   border-color: var(--pico-primary);

--- a/code/BpMonitor.Web/wwwroot/recent-zoom.js
+++ b/code/BpMonitor.Web/wwwroot/recent-zoom.js
@@ -3,7 +3,11 @@
 // Formats.formatLocal, anchored to the same `now` the chart's own initial range
 // uses), so clicking it just replays the chart's own range format through
 // Plotly.relayout — same call pattern as theme.js. The existing plotly_relayout
-// listener in recent-scrubber.js re-syncs the value strip automatically.
+// listener in recent-scrubber.js re-syncs the value strip automatically. The
+// server renders the initial active pill (aria-pressed="true" on whichever
+// button matches the chart's opening window, see ReadingViews.fs `zoomButton`);
+// clicking here re-toggles it client-side, since the chart itself never
+// round-trips to the server.
 function setupRecentZoomButtons() {
   const buttons = document.querySelectorAll(".recent-zoom-button");
   if (buttons.length === 0) return;
@@ -18,6 +22,9 @@ function setupRecentZoomButtons() {
     buttons.forEach((button) => {
       button.addEventListener("click", () => {
         Plotly.relayout(d, { "xaxis.range": [button.dataset.lo, button.dataset.hi] });
+        buttons.forEach((b) => {
+          b.setAttribute("aria-pressed", b === button ? "true" : "false");
+        });
       });
     });
   }


### PR DESCRIPTION
## Summary

- Recent page zoom-shortcut buttons ("Last 7 days" / "Last 30 days") were both rendered as filled pills due to Pico CSS's default button style, making them appear simultaneously selected even though only one range is active.
- Fixed by adding `aria-pressed` state management: server renders the initial active button (30-day window), CSS provides outline base + filled active-pill styling, and JS re-toggles `aria-pressed` on click.
- Added handler test confirming exactly one button is marked active on page load.
- All 420 tests pass; JS and markdown lints clean.