### PR TITLE
🔧 chore(js): extract inline chart script to wwwroot and add zero-build TypeScript checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run Biome
         run: mise run lint:js
 
+      - name: Run TypeScript checkJs
+        run: mise run lint:ts
+
   lint-shell:
     name: Lint Shell
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,8 +131,9 @@ dotnet test --configuration Release --max-parallel-test-modules 2
 
 All non-dotnet linter versions are pinned in `mise.toml` (repo root); it also hosts one-time dev setup tasks like the Playwright Chromium install. Run `mise install` once after cloning.
 
-- `biome.json` — Biome JS linter config (scoped to `wwwroot/theme.js`, `wwwroot/theme-label.js`, `wwwroot/recent-scrubber.js`, `wwwroot/trends-scroll.js`, `wwwroot/recent-zoom.js`)
+- `biome.json` — Biome JS linter config (scoped to the hand-written `wwwroot/` files: `theme.js`, `theme-label.js`, `plot-ready.js`, `chart-hover.js`, `recent-scrubber.js`, `trends-scroll.js`, `recent-zoom.js`)
+- `tsconfig.json` + `typings/globals.d.ts` — zero-build TypeScript checking of the same `wwwroot/` JS via JSDoc (`tsc --checkJs`); the JS ships as-is, no bundler
 - `.markdownlint-cli2.yaml` — markdownlint config
-- Run `mise run lint` to run all non-dotnet linters; `mise run lint:js` / `lint:md` / `lint:shell` individually
+- Run `mise run lint` to run all non-dotnet linters; `mise run lint:js` / `lint:ts` / `lint:md` / `lint:shell` individually
 - Run `mise run test:e2e-setup` once locally before the first `BpMonitor.Web.E2E.Tests` run (installs Playwright's Chromium)
 - Run `mise exec -- biome check --write` to auto-fix JS issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,15 +86,17 @@ cd code && dotnet tool restore   # only needed once after cloning
 | ---- | ------- | -------------- |
 | Fantomas | `cd code && dotnet fantomas --check .` | F# formatting |
 | Biome | `mise exec -- biome check` | JS linting |
+| TypeScript | `mise exec -- tsc -p tsconfig.json` | JSDoc type-checking of hand-written `wwwroot/` JS (no build step) |
 | markdownlint | `mise exec -- markdownlint-cli2 "**/*.md"` | Markdown style |
 | shellcheck | `mise exec -- shellcheck <file>.sh` | Shell scripts |
 
 Run all non-dotnet linters at once:
 
 ```bash
-mise run lint        # markdownlint + biome + shellcheck
+mise run lint        # markdownlint + biome + tsc + shellcheck
 mise run lint:md     # markdownlint only
 mise run lint:js     # biome only
+mise run lint:ts     # tsc checkJs only
 mise run lint:shell  # shellcheck only
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -3,6 +3,8 @@
   "files": {
     "includes": [
       "code/BpMonitor.Web/wwwroot/theme.js",
+      "code/BpMonitor.Web/wwwroot/plot-ready.js",
+      "code/BpMonitor.Web/wwwroot/chart-hover.js",
       "code/BpMonitor.Web/wwwroot/theme-label.js",
       "code/BpMonitor.Web/wwwroot/recent-scrubber.js",
       "code/BpMonitor.Web/wwwroot/recent-zoom.js",

--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -561,6 +561,14 @@ let ``toHtmlDashed Yearly: x-axis labels use month-name format`` () =
   test <@ html.Contains("Jan") @>
 
 [<Fact>]
+let ``toHtml does not embed chart behavior scripts — they live in wwwroot/chart-hover.js`` () =
+  let html = BpChart.toHtml GoalRange.defaults readings
+  // "g.errorbars" only ever appeared in the inline error-bar hover script;
+  // the chart HTML must carry data + Plotly.newPlot only.
+  test <@ not (html.Contains "g.errorbars") @>
+  test <@ not (html.Contains "Plotly.Plots.resize") @>
+
+[<Fact>]
 let ``toHtml escapes </script> in comment text to prevent inline script injection`` () =
   let hostile = reading 1 120 80 70 1 9 (Some "</script><img src=x onerror=alert(1)>")
   let html = BpChart.toHtml GoalRange.defaults [ hostile ]

--- a/code/BpMonitor.Charts.Tests/VerifiedSnapshots/ChartsTests.toHtml matches snapshot.verified.html
+++ b/code/BpMonitor.Charts.Tests/VerifiedSnapshots/ChartsTests.toHtml matches snapshot.verified.html
@@ -5,4 +5,4 @@
     Plotly.newPlot('Guid_1', data, layout, config);
 };
 renderPlotly_GUID();
-</script></div><script>(function(){function setup(){var d=document.querySelector('.js-plotly-plot');if(!d||!d.on){setTimeout(setup,50);return;}Plotly.Plots.resize(d);d.on('plotly_hover',function(e){var p=e.points[0];var gs=d.querySelectorAll('g.errorbars')[p.curveNumber];if(!gs)return;var bar=gs.querySelectorAll('g.errorbar')[p.pointIndex];if(!bar)return;var path=bar.querySelector('path.yerror');if(path)path.style.setProperty('stroke-opacity','1','important');});d.on('plotly_unhover',function(){d.querySelectorAll('g.errorbars path.yerror').forEach(function(p){p.style.removeProperty('stroke-opacity');});});}setTimeout(setup,0);})()</script>
+</script></div>

--- a/code/BpMonitor.Charts.Tests/VerifiedSnapshots/ChartsTests.toHtmlDashed matches snapshot.verified.html
+++ b/code/BpMonitor.Charts.Tests/VerifiedSnapshots/ChartsTests.toHtmlDashed matches snapshot.verified.html
@@ -5,4 +5,4 @@
     Plotly.newPlot('Guid_1', data, layout, config);
 };
 renderPlotly_GUID();
-</script></div><script>(function(){function setup(){var d=document.querySelector('.js-plotly-plot');if(!d||!d.on){setTimeout(setup,50);return;}Plotly.Plots.resize(d);d.on('plotly_hover',function(e){var p=e.points[0];var gs=d.querySelectorAll('g.errorbars')[p.curveNumber];if(!gs)return;var bar=gs.querySelectorAll('g.errorbar')[p.pointIndex];if(!bar)return;var path=bar.querySelector('path.yerror');if(path)path.style.setProperty('stroke-opacity','1','important');});d.on('plotly_unhover',function(){d.querySelectorAll('g.errorbars path.yerror').forEach(function(p){p.style.removeProperty('stroke-opacity');});});}setTimeout(setup,0);})()</script>
+</script></div>

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -147,35 +147,6 @@ module BpChart =
   // !important that takes precedence; removeProperty on unhover falls back to the CSS rule.
   // g.errorbar (singular, per point) lives inside g.errorbars (plural, per trace).
   //
-  // Plotly's initial render ignores the `.chart` container's CSS height (it lays out at its own
-  // content-driven default, ~450px) and only correctly fits the actual container on a later
-  // resize event. Since `.chart` has `overflow:hidden`, that mismatch clips the bottom of the
-  // chart — on narrow mobile heights, severely enough to cut off the x-axis tick labels
-  // entirely. Forcing one `Plotly.Plots.resize` right after mount makes it re-measure the real
-  // (CSS-constrained) container immediately, instead of waiting for a resize event that may
-  // never fire.
-  let private errorBarScript =
-    "<script>(function(){"
-    + "function setup(){"
-    + "var d=document.querySelector('.js-plotly-plot');"
-    + "if(!d||!d.on){setTimeout(setup,50);return;}"
-    + "Plotly.Plots.resize(d);"
-    + "d.on('plotly_hover',function(e){"
-    + "var p=e.points[0];"
-    + "var gs=d.querySelectorAll('g.errorbars')[p.curveNumber];"
-    + "if(!gs)return;"
-    + "var bar=gs.querySelectorAll('g.errorbar')[p.pointIndex];"
-    + "if(!bar)return;"
-    + "var path=bar.querySelector('path.yerror');"
-    + "if(path)path.style.setProperty('stroke-opacity','1','important');"
-    + "});"
-    + "d.on('plotly_unhover',function(){"
-    + "d.querySelectorAll('g.errorbars path.yerror').forEach(function(p){p.style.removeProperty('stroke-opacity');});"
-    + "});"
-    + "}"
-    + "setTimeout(setup,0);"
-    + "})()</script>"
-
   // /history and /recent are interactive (unlike /trends, which disables the modebar
   // outright): lasso, autoscale and box-select are removed because they let a reader
   // visually distort the blood-pressure scale (Wegier et al. 2021's goal-range bands
@@ -217,7 +188,7 @@ module BpChart =
       else
         html
 
-    escaped + errorBarScript
+    escaped
 
   let private finish (chart: GenericChart) =
     chart

--- a/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/TrendHandlerTests.fs
@@ -45,7 +45,7 @@ let ``trends renders 200 with granularity buttons and current Weekly panel`` () 
   // Weekly is active
   test <@ body.Contains "aria-current=\"page\"" @>
   // Inline chart rendered
-  test <@ body.Contains "js-plotly-plot" @>
+  test <@ body.Contains "Plotly.newPlot" @>
 
 [<Fact>]
 let ``trends renders the chart with the authenticated member's goal range`` () =
@@ -119,7 +119,7 @@ let ``trendsPanel with gran=weekly returns fragment with sub-period buttons and 
   test <@ body.Contains "This Week" @>
   test <@ body.Contains "Last Week" @>
   // Inline chart rendered
-  test <@ body.Contains "js-plotly-plot" @>
+  test <@ body.Contains "Plotly.newPlot" @>
 
 [<Fact>]
 let ``trendsPanel with gran=monthly returns monthly sub-period buttons`` () =
@@ -155,7 +155,7 @@ let ``trendsPanel with gran + key uses that specific sub-period`` () =
   test <@ body.Contains "118" @>
   test <@ body.Contains "77" @>
   // Inline chart rendered
-  test <@ body.Contains "js-plotly-plot" @>
+  test <@ body.Contains "Plotly.newPlot" @>
 
 [<Fact>]
 let ``trendsPanel includes readings table with in-period readings`` () =
@@ -216,7 +216,7 @@ let ``trendsPanel shows empty state when no readings in period`` () =
   let body = TestHost.readBody ctx
   test <@ body.Contains "No readings in" @>
   // No chart rendered when there are no readings in the period
-  test <@ body.Contains "js-plotly-plot" |> not @>
+  test <@ body.Contains "Plotly.newPlot" |> not @>
 
 [<Fact>]
 let ``trendsPanel returns 400 for unrecognised gran`` () =

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -62,6 +62,10 @@ module ViewLayout =
          Elem.script [ Attr.src "/theme.js" ] []
          // Behavior-only (no FOUC concern); each self-guards on the page elements it
          // needs and re-runs on htmx:afterSettle to survive hx-boost swaps.
+         // plot-ready.js must come first — it defines the whenPlotReady helper the
+         // chart scripts below call at parse time registration.
+         Elem.script [ Attr.src "/plot-ready.js" ] []
+         Elem.script [ Attr.src "/chart-hover.js" ] []
          Elem.script [ Attr.src "/recent-scrubber.js" ] []
          Elem.script [ Attr.src "/recent-zoom.js" ] []
          Elem.script [ Attr.src "/trends-scroll.js" ] []

--- a/code/BpMonitor.Web/wwwroot/chart-hover.js
+++ b/code/BpMonitor.Web/wwwroot/chart-hover.js
@@ -1,0 +1,43 @@
+// Chart mount fix + error-bar hover highlight, shared by every chart page
+// (/history, /recent, /trends). Extracted from the inline script Charts.fs
+// used to append to each chart's HTML, so it is Biome-lintable and served as
+// a normal static asset. Self-guards on the server-rendered `.chart` container
+// (whenPlotReady polls forever, so it must not start on chartless pages) and
+// re-runs on htmx:afterSettle to survive hx-boost navigations and the
+// trends-panel fragment swaps — same pattern as the other wwwroot scripts.
+function setupChartHover() {
+  if (!document.querySelector(".chart")) return;
+
+  whenPlotReady((d) => {
+    // Plotly's initial render ignores the `.chart` container's CSS height (it
+    // lays out at its own content-driven default, ~450px) and only correctly
+    // fits the actual container on a later resize event. Since `.chart` has
+    // `overflow:hidden`, that mismatch clips the bottom of the chart — on
+    // narrow mobile heights, severely enough to cut off the x-axis tick labels
+    // entirely. Forcing one resize right after mount makes Plotly re-measure
+    // the real (CSS-constrained) container immediately, instead of waiting for
+    // a resize event that may never fire.
+    Plotly.Plots.resize(d);
+
+    d.on("plotly_hover", (e) => {
+      const p = e.points[0];
+      const gs = d.querySelectorAll("g.errorbars")[p.curveNumber];
+      if (!gs) return;
+      const bar = gs.querySelectorAll("g.errorbar")[p.pointIndex];
+      if (!bar) return;
+      const path = /** @type {SVGPathElement | null} */ (
+        bar.querySelector("path.yerror")
+      );
+      if (path) path.style.setProperty("stroke-opacity", "1", "important");
+    });
+
+    d.on("plotly_unhover", () => {
+      d.querySelectorAll("g.errorbars path.yerror").forEach((p) => {
+        /** @type {SVGPathElement} */ (p).style.removeProperty("stroke-opacity");
+      });
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", setupChartHover);
+document.addEventListener("htmx:afterSettle", setupChartHover);

--- a/code/BpMonitor.Web/wwwroot/plot-ready.js
+++ b/code/BpMonitor.Web/wwwroot/plot-ready.js
@@ -1,0 +1,29 @@
+// Shared "wait for Plotly" helper — the single copy of the poll-until-ready
+// pattern previously duplicated by recent-scrubber.js, recent-zoom.js, and the
+// (since-extracted) inline error-bar script in Charts.fs.
+//
+// The chart's own render script (Plotly.NET's Plotly.newPlot call, inlined in
+// the chart HTML fragment) runs synchronously when parsed, but Plotly attaches
+// its event API (`.on`) to the plot div asynchronously — so callers must poll
+// until the div exists AND has `.on`. Callers are responsible for only invoking
+// this on pages that actually render a chart; otherwise the poll never resolves.
+//
+// Must load before any script that calls it (see ViewLayout.fs htmlHead order).
+
+/** @param {(d: PlotlyChartElement) => void} fn */
+// biome-ignore lint/correctness/noUnusedVariables: shared global, called by the other wwwroot chart scripts
+function whenPlotReady(fn) {
+  function poll() {
+    const d = /** @type {PlotlyChartElement | null} */ (
+      document.querySelector(".js-plotly-plot")
+    );
+    if (!d?.on) {
+      setTimeout(poll, 50);
+      return;
+    }
+    fn(d);
+  }
+  // Deferred a tick so the chart fragment's own inline render script (parsed
+  // later in the body) gets a chance to run first.
+  setTimeout(poll, 0);
+}

--- a/code/BpMonitor.Web/wwwroot/recent-scrubber.js
+++ b/code/BpMonitor.Web/wwwroot/recent-scrubber.js
@@ -1,7 +1,7 @@
 // Fig. 5's scrubber bar (Wegier et al. 2021): the chart's x-axis spike (Charts.fs
 // `recentXAxis`) already draws the moving vertical line; this links it to the value
-// strip by boxing the hovered column. Follows the same poll-until-ready pattern as
-// the chart's own errorBarScript (BpMonitor.Charts/Charts.fs).
+// strip by boxing the hovered column. Waits for the chart via whenPlotReady
+// (plot-ready.js), like the other chart scripts.
 //
 // The strip lists every loaded reading (the chart's load window — bounded but wider
 // than the visible focus). Each cell is tagged with the same x-label the chart uses
@@ -25,6 +25,7 @@ function setupRecentScrubber() {
   // comment-tooltip mousemove handler and the strip → chart mouseover handler below,
   // both of which need to convert a data x-value to a viewport pixel position. Queried
   // fresh on each call (not cached) since the drag-layer rect can shift on scroll/resize.
+  /** @param {PlotlyChartElement} d */
   function chartGeometry(d) {
     const xaxis = d._fullLayout?.xaxis;
     const yaxis = d._fullLayout?.yaxis;
@@ -34,13 +35,7 @@ function setupRecentScrubber() {
     return { xaxis, yaxis, dragRect, br: dragRect.getBoundingClientRect() };
   }
 
-  function setup() {
-    const d = document.querySelector(".js-plotly-plot");
-    if (!d?.on) {
-      setTimeout(setup, 50);
-      return;
-    }
-
+  whenPlotReady((d) => {
     // chart → strip: box the value-strip column matching the hovered chart point.
     d.on("plotly_hover", (e) => {
       const x = e.points[0].x;
@@ -69,10 +64,11 @@ function setupRecentScrubber() {
     //
     // Matched by trace name — keep this in sync with the `Name = "Comments"` trace built
     // in Charts.fs `commentTraces`.
-    const commentTraceIndex = d.data?.findIndex((t) => t.name === "Comments") ?? -1;
+    const traces = d.data ?? [];
+    const commentTraceIndex = traces.findIndex((t) => t.name === "Comments");
     if (commentTraceIndex !== -1) {
-      const commentXs = d.data[commentTraceIndex].x;
-      const commentTexts = d.data[commentTraceIndex].text;
+      const commentXs = traces[commentTraceIndex].x;
+      const commentTexts = traces[commentTraceIndex].text;
 
       const tooltip = document.createElement("div");
       tooltip.className = "comment-tooltip";
@@ -130,15 +126,18 @@ function setupRecentScrubber() {
     // correct x pixel without any timezone conversion (Plotly's own d2l parses the
     // same date strings it stored in the trace data). The plotly_hover event fires
     // naturally, so the existing chart→strip listener adds .scrubbed for free.
+    /** @type {string | null} */
     let lastX = null;
     strip.addEventListener("mouseover", (e) => {
-      const cell = e.target.closest("td[data-x]");
-      if (!cell || cell.dataset.x === lastX) return;
-      lastX = cell.dataset.x;
+      if (!(e.target instanceof Element)) return;
+      const cell = /** @type {HTMLElement | null} */ (e.target.closest("td[data-x]"));
+      const x = cell?.dataset.x;
+      if (!x || x === lastX) return;
+      lastX = x;
       const geo = chartGeometry(d);
       if (!geo) return;
       const { xaxis, dragRect, br } = geo;
-      const xPx = xaxis.l2p(xaxis.d2l(cell.dataset.x));
+      const xPx = xaxis.l2p(xaxis.d2l(x));
       const yPx = geo.yaxis?.l2p?.(120) ?? br.height / 2;
       dragRect.dispatchEvent(
         new MouseEvent("mousemove", {
@@ -162,7 +161,9 @@ function setupRecentScrubber() {
     });
 
     d.on("plotly_relayout", (e) => {
-      const cells = document.querySelectorAll(".value-strip td[data-x]");
+      const cells = /** @type {NodeListOf<HTMLElement>} */ (
+        document.querySelectorAll(".value-strip td[data-x]")
+      );
       let lo = e["xaxis.range[0]"];
       let hi = e["xaxis.range[1]"];
 
@@ -192,14 +193,14 @@ function setupRecentScrubber() {
       if (Number.isNaN(loT) || Number.isNaN(hiT)) return;
 
       cells.forEach((c) => {
-        const t = new Date(c.dataset.x.replace(" ", "T")).getTime();
+        const cellX = c.dataset.x;
+        if (!cellX) return;
+        const t = new Date(cellX.replace(" ", "T")).getTime();
         if (Number.isNaN(t)) return;
         c.classList.toggle("out-of-range", t < loT || t > hiT);
       });
     });
-  }
-
-  setTimeout(setup, 0);
+  });
 }
 
 document.addEventListener("DOMContentLoaded", setupRecentScrubber);

--- a/code/BpMonitor.Web/wwwroot/recent-zoom.js
+++ b/code/BpMonitor.Web/wwwroot/recent-zoom.js
@@ -9,16 +9,12 @@
 // clicking here re-toggles it client-side, since the chart itself never
 // round-trips to the server.
 function setupRecentZoomButtons() {
-  const buttons = document.querySelectorAll(".recent-zoom-button");
+  const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+    document.querySelectorAll(".recent-zoom-button")
+  );
   if (buttons.length === 0) return;
 
-  function setup() {
-    const d = document.querySelector(".js-plotly-plot");
-    if (!d?.on) {
-      setTimeout(setup, 50);
-      return;
-    }
-
+  whenPlotReady((d) => {
     buttons.forEach((button) => {
       button.addEventListener("click", () => {
         Plotly.relayout(d, { "xaxis.range": [button.dataset.lo, button.dataset.hi] });
@@ -27,9 +23,7 @@ function setupRecentZoomButtons() {
         });
       });
     });
-  }
-
-  setup();
+  });
 }
 
 document.addEventListener("DOMContentLoaded", setupRecentZoomButtons);

--- a/code/BpMonitor.Web/wwwroot/theme.js
+++ b/code/BpMonitor.Web/wwwroot/theme.js
@@ -4,6 +4,7 @@
   document.documentElement.setAttribute('data-theme',t);
 })();
 
+/** @param {string} theme */
 function applyChartTheme(theme) {
   if (typeof Plotly === 'undefined') return;
   const isDark = theme === 'dark';

--- a/code/BpMonitor.Web/wwwroot/trends-scroll.js
+++ b/code/BpMonitor.Web/wwwroot/trends-scroll.js
@@ -42,7 +42,10 @@ window.addEventListener("resize", updateSubPeriodFades);
 document.addEventListener(
   "scroll",
   (event) => {
-    if (event.target?.classList?.contains("trends-subperiod-buttons")) {
+    if (
+      event.target instanceof Element &&
+      event.target.classList.contains("trends-subperiod-buttons")
+    ) {
       updateSubPeriodFades();
     }
   },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,6 +180,7 @@ graph TD
 | --- | --- | --- |
 | node | `mise.toml` | Runtime for npm-based tools (markdownlint-cli2) |
 | Biome | `mise.toml` | JS linter (`biome check`) for files in `wwwroot/` |
+| TypeScript | `mise.toml` (npm backend) | Type-checks the hand-written `wwwroot/` JS via JSDoc (`tsc --checkJs`, config in `tsconfig.json` + `typings/globals.d.ts`) — no build step, the JS ships as-is |
 | markdownlint-cli2 | `mise.toml` | Markdown style linter |
 | shellcheck | `mise.toml` | Shell script linter |
 
@@ -190,11 +191,12 @@ mise install          # install all pinned tools
 mise run lint         # run all non-dotnet linters
 mise run lint:md      # markdownlint only
 mise run lint:js      # biome only
+mise run lint:ts      # tsc checkJs only
 mise run lint:shell   # shellcheck only
 mise exec -- biome check --write  # auto-fix safe JS issues
 ```
 
-**CI:** the `lint-markdown`, `lint-js`, and `lint-shell` jobs in `.github/workflows/ci.yml` each install tools via `jdx/mise-action` and invoke the corresponding `mise run lint:*` task — the same command as local dev.
+**CI:** the `lint-markdown`, `lint-js` (Biome + `tsc` checkJs), and `lint-shell` jobs in `.github/workflows/ci.yml` each install tools via `jdx/mise-action` and invoke the corresponding `mise run lint:*` task — the same command as local dev.
 
 ## Architecture Decision Records
 

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ node = "26.4.0"
 biome = "2.4.16"
 markdownlint-cli2 = "0.23.0"
 shellcheck = "0.11.0"
+"npm:typescript" = "5.9.3"
 
 [tasks."lint:md"]
 run = 'markdownlint-cli2 "**/*.md"'
@@ -10,12 +11,16 @@ run = 'markdownlint-cli2 "**/*.md"'
 [tasks."lint:js"]
 run = "biome check"
 
+[tasks."lint:ts"]
+# Type-checks the hand-written wwwroot JS via JSDoc (tsconfig.json, checkJs) — no build step
+run = "tsc -p tsconfig.json"
+
 [tasks."lint:shell"]
 # mirror the CI/hook exclusion of Husky's generated wrapper scripts
 run = 'find . -name "*.sh" -not -path "./.husky/_/*" | xargs -r shellcheck'
 
 [tasks.lint]
-depends = ["lint:md", "lint:js", "lint:shell"]
+depends = ["lint:md", "lint:js", "lint:ts", "lint:shell"]
 
 [tasks."test:e2e-setup"]
 description = "One-time local setup: installs the Playwright Chromium browser used by BpMonitor.Web.E2E.Tests"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "target": "es2022",
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "types": []
+  },
+  "include": ["typings/globals.d.ts", "code/BpMonitor.Web/wwwroot/*.js"],
+  "exclude": [
+    "code/BpMonitor.Web/wwwroot/htmx.min.js",
+    "code/BpMonitor.Web/wwwroot/plotly-2.27.1.min.js"
+  ]
+}

--- a/typings/globals.d.ts
+++ b/typings/globals.d.ts
@@ -1,0 +1,26 @@
+// Ambient declarations for `tsc --checkJs` over the hand-written wwwroot JS
+// (see tsconfig.json at the repo root, run via `mise run lint:ts`). Dev-time
+// only — nothing here is served or shipped.
+
+// The plot div once Plotly.newPlot has run: Plotly grafts its event API and
+// state onto the element. Only the members our scripts touch are declared.
+interface PlotlyChartElement extends HTMLElement {
+  on(event: string, handler: (event: any) => void): void;
+  data?: any[];
+  layout?: any;
+  _fullLayout?: any;
+}
+
+// Vendored plotly-2.27.1.min.js global. `any` on purpose: typing the full
+// Plotly surface is not worth it for the handful of calls we make.
+declare const Plotly: any;
+
+// wwwroot/plot-ready.js — classic scripts share one global scope, but tsc
+// treats each file as its own module-less script, so cross-file functions
+// need an ambient declaration.
+declare function whenPlotReady(fn: (d: PlotlyChartElement) => void): void;
+
+// wwwroot/theme.js assigns this onto window for the inline onclick handler.
+interface Window {
+  toggleTheme: () => void;
+}


### PR DESCRIPTION
## Summary
- Extract the inline error-bar hover/resize script from `Charts.fs` into two lintable static assets: `wwwroot/plot-ready.js` (shared `whenPlotReady` poll-until-Plotly-ready helper) and `wwwroot/chart-hover.js` (mount resize + error-bar hover highlight), loaded from `ViewLayout.fs`; `recent-scrubber.js` and `recent-zoom.js` now reuse the shared helper instead of duplicating the poll
- Add zero-build TypeScript checking of the hand-written `wwwroot/` JS via JSDoc (`tsc --checkJs`, `tsconfig.json` + `typings/globals.d.ts`); the JS still ships as-is, no bundler
- Pin `typescript` in `mise.toml`, add `lint:ts` task, wire it into `mise run lint` and the CI lint-js job; scope Biome to the two new files as well
- Update Charts snapshot tests (chart HTML no longer embeds the script) and TrendHandler tests; docs (`AGENTS.md`, `CONTRIBUTING.md`, `docs/architecture.md`) updated to match