### PR TITLE
🔧 chore(web): apply cleanup pass over post-v1.7.6 changes — dedup active-pill CSS via Pico outline, defer behavior scripts, htmx meta config, scrubber efficiency fixes

### DIFF
--- a/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/ReadingHandlerTests.fs
@@ -1,5 +1,6 @@
 module ReadingHandlerTests
 
+open System.Text.RegularExpressions
 open Xunit
 open Swensen.Unquote
 open Microsoft.Extensions.Time.Testing
@@ -138,8 +139,8 @@ let ``recent marks only the Last 30 days button as active`` () =
   let body = TestHost.readBody ctx
 
   let zoomButtons =
-    System.Text.RegularExpressions.Regex.Matches(body, "<button[^>]*recent-zoom-button[^>]*>([^<]*)</button>")
-    |> Seq.cast<System.Text.RegularExpressions.Match>
+    Regex.Matches(body, "<button[^>]*recent-zoom-button[^>]*>([^<]*)</button>")
+    |> Seq.cast<Match>
     |> Seq.map (fun m -> m.Value.Contains "aria-pressed=\"true\"", m.Groups[1].Value)
     |> Seq.toList
 

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -123,16 +123,16 @@ module ReadingViews =
     // The button whose range starts at `windowStart` matches the chart's initial focus
     // (both `recent` and `recentFull` render `windowStart = now.AddDays(-30)`), so it's
     // rendered as the active pill on load; recent-zoom.js re-toggles `aria-pressed` on click.
-    let activeLo = Formats.formatLocal windowStart
-
+    // Pico's `outline` class gives the resting (inactive) look — app.css only styles the
+    // active filled state.
     let zoomButton (label: string) (days: float) =
-      let lo = Formats.formatLocal (now.AddDays(-days))
+      let lo = now.AddDays(-days)
 
       Elem.button
         [ Attr.type' "button"
-          Attr.class' "recent-zoom-button"
-          Attr.create "aria-pressed" (if lo = activeLo then "true" else "false")
-          Attr.create "data-lo" lo
+          Attr.class' "recent-zoom-button outline"
+          Attr.create "aria-pressed" (if lo = windowStart then "true" else "false")
+          Attr.create "data-lo" (Formats.formatLocal lo)
           Attr.create "data-hi" hiFormatted ]
         [ Text.raw label ]
 

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -61,14 +61,15 @@ module ViewLayout =
          // No defer/async — render-blocking prevents flash of the wrong theme (FOUC).
          Elem.script [ Attr.src "/theme.js" ] []
          // Behavior-only (no FOUC concern); each self-guards on the page elements it
-         // needs and re-runs on htmx:afterSettle to survive hx-boost swaps.
-         // plot-ready.js must come first — it defines the whenPlotReady helper the
-         // chart scripts below call at parse time registration.
-         Elem.script [ Attr.src "/plot-ready.js" ] []
-         Elem.script [ Attr.src "/chart-hover.js" ] []
-         Elem.script [ Attr.src "/recent-scrubber.js" ] []
-         Elem.script [ Attr.src "/recent-zoom.js" ] []
-         Elem.script [ Attr.src "/trends-scroll.js" ] []
+         // needs and re-runs on htmx:afterSettle to survive hx-boost swaps. Deferred so
+         // they don't block HTML parsing — they only register DOMContentLoaded/htmx
+         // listeners, and defer preserves document order, so plot-ready.js still
+         // defines the whenPlotReady helper before the chart scripts below run.
+         Elem.script [ Attr.src "/plot-ready.js"; Attr.create "defer" "" ] []
+         Elem.script [ Attr.src "/chart-hover.js"; Attr.create "defer" "" ] []
+         Elem.script [ Attr.src "/recent-scrubber.js"; Attr.create "defer" "" ] []
+         Elem.script [ Attr.src "/recent-zoom.js"; Attr.create "defer" "" ] []
+         Elem.script [ Attr.src "/trends-scroll.js"; Attr.create "defer" "" ] []
          Elem.link [ Attr.rel "stylesheet"; Attr.href "/pico.min.css" ]
          Elem.link [ Attr.rel "stylesheet"; Attr.href "/app.css" ]
          // Vendored from Plotly.NET's embedded resource (see scripts/extract-plotly-js.fsx) —
@@ -91,11 +92,19 @@ module ViewLayout =
       [ Attr.lang "en" ]
       [ htmlHead
           title
-          [ Elem.script [ Attr.src "/htmx.min.js" ] []
-            Elem.script
-              []
-              [ Text.raw
-                  "htmx.config.responseHandling=[{code:'204',swap:false},{code:'[23]..',swap:true},{code:'422',swap:true,error:false},{code:'[45]..',swap:false,error:true}];" ] ]
+          [ // htmx merges this into htmx.config on init (declarative equivalent of an
+            // inline `htmx.config.responseHandling = ...` script, with no
+            // script-ordering dependency): swap 422 validation re-renders without
+            // treating them as errors; never swap other 4xx/5xx. Falco.Markup renders
+            // attribute values verbatim, so the JSON's quotes must be entity-escaped
+            // by hand (the browser decodes them back before htmx JSON-parses).
+            Elem.meta
+              [ Attr.name "htmx-config"
+                Attr.content (
+                  """{"responseHandling":[{"code":"204","swap":false},{"code":"[23]..","swap":true},{"code":"422","swap":true,"error":false},{"code":"[45]..","swap":false,"error":true}]}"""
+                    .Replace("\"", "&quot;")
+                ) ]
+            Elem.script [ Attr.src "/htmx.min.js" ] [] ]
         Elem.body
           [ Attr.create "hx-boost" "true" ]
           [ // Checkbox drives the mobile off-canvas drawer via pure CSS sibling selectors.

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -735,25 +735,12 @@ form.inline button {
   text-align: center;
 }
 
-/* Outline base for the recent zoom-shortcut buttons: unlike the trends row's
-   <a role="button"> (Pico's outline default), a bare <button> defaults to
-   filled, so without this every recent-zoom-button would render as if active. */
-.recent-zoom-buttons button {
-  background: transparent;
-  color: var(--pico-primary);
-  border-color: var(--pico-primary);
-}
-
-/* Active granularity / sub-period pill — filled primary (matches nav active pill style) */
+/* Active pill — filled primary (matches nav active pill style). Covers the trends
+   granularity / sub-period links and the recent zoom-shortcut buttons (ReadingViews.fs
+   `zoomButton`, toggled by wwwroot/recent-zoom.js on click); the zoom buttons' resting
+   look comes from Pico's own `outline` button class set in `zoomButton`. */
 .trends-window-buttons a[aria-current="page"],
-.trends-subperiod-buttons a[aria-current="page"] {
-  background: var(--pico-primary);
-  color: var(--pico-primary-inverse);
-  border-color: var(--pico-primary);
-}
-
-/* Active recent zoom-shortcut pill (ReadingViews.fs `zoomButton`, toggled by
-   wwwroot/recent-zoom.js on click) — same filled style as the pills above. */
+.trends-subperiod-buttons a[aria-current="page"],
 .recent-zoom-buttons button[aria-pressed="true"] {
   background: var(--pico-primary);
   color: var(--pico-primary-inverse);

--- a/code/BpMonitor.Web/wwwroot/chart-hover.js
+++ b/code/BpMonitor.Web/wwwroot/chart-hover.js
@@ -9,6 +9,11 @@ function setupChartHover() {
   if (!document.querySelector(".chart")) return;
 
   whenPlotReady((d) => {
+    // Setup runs on every htmx:afterSettle; skip plots already wired so a settle
+    // that doesn't swap the chart can't stack duplicate handlers on the same div.
+    if (d.dataset.hoverBound) return;
+    d.dataset.hoverBound = "1";
+
     // Plotly's initial render ignores the `.chart` container's CSS height (it
     // lays out at its own content-driven default, ~450px) and only correctly
     // fits the actual container on a later resize event. Since `.chart` has

--- a/code/BpMonitor.Web/wwwroot/recent-scrubber.js
+++ b/code/BpMonitor.Web/wwwroot/recent-scrubber.js
@@ -36,6 +36,11 @@ function setupRecentScrubber() {
   }
 
   whenPlotReady((d) => {
+    // Setup runs on every htmx:afterSettle; skip plots already wired so a settle
+    // that doesn't swap the chart can't stack duplicate handlers on the same div.
+    if (d.dataset.scrubberBound) return;
+    d.dataset.scrubberBound = "1";
+
     // chart → strip: box the value-strip column matching the hovered chart point.
     d.on("plotly_hover", (e) => {
       const x = e.points[0].x;
@@ -70,6 +75,9 @@ function setupRecentScrubber() {
       const commentXs = traces[commentTraceIndex].x;
       const commentTexts = traces[commentTraceIndex].text;
 
+      // The tooltip lives on <body>, outside the htmx-swapped #recent-chart region,
+      // so drop the previous plot's tooltip before appending this one.
+      document.querySelector(".comment-tooltip")?.remove();
       const tooltip = document.createElement("div");
       tooltip.className = "comment-tooltip";
       const tooltipText = document.createElement("div");
@@ -80,17 +88,26 @@ function setupRecentScrubber() {
 
       const proximityPx = 8;
 
+      // xaxis.d2l is a pure date-string → linear-ms conversion that never changes
+      // for the plot's data (only l2p depends on zoom/pan), so convert each comment
+      // x once on the first mousemove instead of re-parsing every marker per event.
+      /** @type {number[] | null} */
+      let commentLs = null;
+
       d.addEventListener("mousemove", (e) => {
         const geo = chartGeometry(d);
         if (!geo?.yaxis?.l2p) return;
         const { xaxis, yaxis, br } = geo;
         const yPx = br.top + yaxis.l2p(0);
+        const ls =
+          commentLs ?? commentXs.map((/** @type {string} */ x) => xaxis.d2l(x));
+        commentLs = ls;
 
         let nearest = -1;
         let nearestXPx = 0;
         let nearestDist = Infinity;
-        for (let i = 0; i < commentXs.length; i++) {
-          const xPx = br.left + xaxis.l2p(xaxis.d2l(commentXs[i]));
+        for (let i = 0; i < ls.length; i++) {
+          const xPx = br.left + xaxis.l2p(ls[i]);
           const dist = Math.hypot(e.clientX - xPx, e.clientY - yPx);
           if (dist < nearestDist) {
             nearestDist = dist;
@@ -99,7 +116,7 @@ function setupRecentScrubber() {
           }
         }
 
-        if (nearest !== -1 && nearestDist <= proximityPx) {
+        if (nearestDist <= proximityPx) {
           tooltipText.textContent = commentTexts[nearest];
           tooltipTime.textContent = commentXs[nearest];
           tooltip.style.left = `${nearestXPx}px`;
@@ -152,7 +169,7 @@ function setupRecentScrubber() {
       lastX = null;
       // Dispatch mouseout on the drag layer to trigger Plotly's unhover path;
       // also clear .scrubbed directly so the box never lingers.
-      const dragRect = d.querySelector(".draglayer .xy > rect");
+      const dragRect = chartGeometry(d)?.dragRect;
       if (dragRect)
         dragRect.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
       document.querySelectorAll(".value-strip td.scrubbed").forEach((c) => {

--- a/code/BpMonitor.Web/wwwroot/recent-zoom.js
+++ b/code/BpMonitor.Web/wwwroot/recent-zoom.js
@@ -15,6 +15,12 @@ function setupRecentZoomButtons() {
   if (buttons.length === 0) return;
 
   whenPlotReady((d) => {
+    // Setup runs on every htmx:afterSettle; the buttons swap together with the
+    // chart (both live in #recent-chart), so a plot already wired means these
+    // buttons are wired too — skip instead of stacking duplicate click handlers.
+    if (d.dataset.zoomBound) return;
+    d.dataset.zoomBound = "1";
+
     buttons.forEach((button) => {
       button.addEventListener("click", () => {
         Plotly.relayout(d, { "xaxis.range": [button.dataset.lo, button.dataset.hi] });


### PR DESCRIPTION
## Summary
- Merge the duplicated recent-zoom active-pill CSS into the existing trends active-pill rule, and replace the hand-rolled outline-button block with Pico's own `outline` class on `zoomButton` (hover/focus/theme states now come from Pico)
- Determine the active zoom button by comparing `DateTimeOffset` values instead of formatted timestamp strings
- recent-scrubber.js: reuse `chartGeometry` in the strip `mouseleave` handler, drop the dead `nearest !== -1` guard, cache the pure `xaxis.d2l` conversions instead of re-parsing every comment marker per mousemove, and remove the previous comment-tooltip div before appending a new one (no more accumulation across htmx swaps)
- Stamp plot divs once wired (`data-*Bound`) in chart-hover.js / recent-scrubber.js / recent-zoom.js so an `htmx:afterSettle` that doesn't swap the chart can't stack duplicate handlers
- Defer the five behavior-only head scripts (they only register listeners; `defer` preserves order) so they no longer block parsing on every page
- Replace the inline `htmx.config.responseHandling` script with the declarative `<meta name="htmx-config">` (Falco renders attribute values verbatim, so the JSON quotes are entity-escaped explicitly)
- Simplify the zoom-button test's fully-qualified `Regex`/`Match` usage with an `open`

Verified via lint (biome/tsc/markdownlint/shellcheck), the full 422-test suite, and a throwaway Playwright test driving /recent in a real browser (outline pills, active-pill toggle, comment tooltip on direct marker hover, deferred-script chart wiring).