### PR TITLE
📝 docs: remove landing and history page screenshots from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A blood pressure monitoring application for families and households, built with 
 
 | | |
 | --- | --- |
-| ![Landing page](docs/screenshots/landing-light.png) | ![History](docs/screenshots/history-light.png) |
 | ![Recent readings with scrubber](docs/screenshots/recent-scrubber-light.png) | ![Trends](docs/screenshots/trends-light.png) |
 
 ## Docs


### PR DESCRIPTION
## Summary
- Remove the landing page and history page screenshot entries from the README screenshots table, keeping only recent-scrubber and trends