### PR TITLE
🐛 fix: surface real startup errors in E2E web app fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Maintenance
+
+- E2E test fixture now captures the `BpMonitor.Web` child process's stdout/stderr and fails fast with that output when the process exits early (e.g. a missing Release build), instead of always waiting out a 30s timeout with a generic error
+
 ## [1.7.8] - 2026-07-05
 
 ### Maintenance

--- a/code/BpMonitor.Web.E2E.Tests/BpMonitor.Web.E2E.Tests.fsproj
+++ b/code/BpMonitor.Web.E2E.Tests/BpMonitor.Web.E2E.Tests.fsproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="ProcessReadiness.fs" />
+    <Compile Include="ProcessReadinessTests.fs" />
     <Compile Include="WebAppFixture.fs" />
     <Compile Include="SmokeTests.fs" />
   </ItemGroup>

--- a/code/BpMonitor.Web.E2E.Tests/ProcessReadiness.fs
+++ b/code/BpMonitor.Web.E2E.Tests/ProcessReadiness.fs
@@ -1,0 +1,34 @@
+namespace BpMonitor.Web.E2E
+
+open System
+open System.Threading.Tasks
+
+/// Polls `isReady` until it succeeds, but fails fast (rather than waiting out
+/// the full timeout) if the process has already exited, and always includes
+/// captured process output in the failure so a startup crash is diagnosable
+/// instead of showing up as a generic "did not become ready" timeout.
+module ProcessReadiness =
+  let waitUntilReadyAsync
+    (isReady: unit -> Task<bool>)
+    (hasExited: unit -> bool)
+    (capturedOutput: unit -> string)
+    (timeout: TimeSpan)
+    (port: int)
+    : Task =
+    task {
+      let deadline = DateTime.UtcNow.Add(timeout)
+      let mutable ready = false
+
+      while not ready do
+        if hasExited () then
+          failwith $"process exited before becoming ready on port {port}. Captured output:\n{capturedOutput ()}"
+
+        if DateTime.UtcNow > deadline then
+          failwith $"did not become ready on {port} within {timeout}. Captured output:\n{capturedOutput ()}"
+
+        let! r = isReady ()
+        ready <- r
+
+        if not ready then
+          do! Task.Delay(250)
+    }

--- a/code/BpMonitor.Web.E2E.Tests/ProcessReadinessTests.fs
+++ b/code/BpMonitor.Web.E2E.Tests/ProcessReadinessTests.fs
@@ -1,0 +1,53 @@
+module BpMonitor.Web.E2E.ProcessReadinessTests
+
+open System
+open System.Diagnostics
+open System.Threading.Tasks
+open BpMonitor.Web.E2E
+open Xunit
+
+type ProcessReadinessTests() =
+
+  [<Fact>]
+  member _.``throws immediately with captured output when the process has already exited``() : Task =
+    task {
+      let stopwatch = Stopwatch.StartNew()
+
+      let! ex =
+        Assert.ThrowsAsync<Exception>(fun () ->
+          ProcessReadiness.waitUntilReadyAsync
+            (fun () -> Task.FromResult false)
+            (fun () -> true)
+            (fun () -> "boom: address already in use")
+            (TimeSpan.FromSeconds 30.0)
+            1234)
+
+      stopwatch.Stop()
+
+      Assert.Contains("boom: address already in use", ex.Message)
+      Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds 5.0)
+    }
+
+  [<Fact>]
+  member _.``throws with captured output when the timeout elapses without becoming ready``() : Task =
+    task {
+      let! ex =
+        Assert.ThrowsAsync<Exception>(fun () ->
+          ProcessReadiness.waitUntilReadyAsync
+            (fun () -> Task.FromResult false)
+            (fun () -> false)
+            (fun () -> "still starting up...")
+            (TimeSpan.FromMilliseconds 100.0)
+            5678)
+
+      Assert.Contains("still starting up...", ex.Message)
+    }
+
+  [<Fact>]
+  member _.``completes without throwing once isReady reports true``() : Task =
+    ProcessReadiness.waitUntilReadyAsync
+      (fun () -> Task.FromResult true)
+      (fun () -> false)
+      (fun () -> "")
+      (TimeSpan.FromSeconds 30.0)
+      9999

--- a/code/BpMonitor.Web.E2E.Tests/WebAppFixture.fs
+++ b/code/BpMonitor.Web.E2E.Tests/WebAppFixture.fs
@@ -54,6 +54,7 @@ type WebAppFixture() =
   let mutable playwright: IPlaywright = null
   let mutable browser: IBrowser = null
   let mutable dbPath = ""
+  let capturedOutput = Text.StringBuilder()
 
   let port =
     let listener = new TcpListener(System.Net.IPAddress.Loopback, 0)
@@ -68,18 +69,23 @@ type WebAppFixture() =
   member private _.WaitUntilReadyAsync() : Task =
     task {
       use client = new HttpClient(Timeout = TimeSpan.FromSeconds 2.0)
-      let deadline = DateTime.UtcNow.AddSeconds(30.0)
-      let mutable ready = false
 
-      while not ready do
-        if DateTime.UtcNow > deadline then
-          failwith $"BpMonitor.Web did not become ready on {port} within 30s"
+      let isReady () =
+        task {
+          try
+            let! resp = client.GetAsync($"http://127.0.0.1:{port}/login")
+            return resp.IsSuccessStatusCode
+          with _ ->
+            return false
+        }
 
-        try
-          let! resp = client.GetAsync($"http://127.0.0.1:{port}/login")
-          ready <- resp.IsSuccessStatusCode
-        with _ ->
-          do! Task.Delay(250)
+      do!
+        ProcessReadiness.waitUntilReadyAsync
+          isReady
+          (fun () -> webProcess.HasExited)
+          (fun () -> capturedOutput.ToString())
+          (TimeSpan.FromSeconds 30.0)
+          port
     }
 
   interface IAsyncLifetime with
@@ -95,13 +101,29 @@ type WebAppFixture() =
           ProcessStartInfo(
             FileName = "dotnet",
             Arguments = $"run --project \"%s{webProjectPath}\" -c Release --no-build -- --urls=%s{this.BaseUrl}",
-            UseShellExecute = false
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
           )
 
         psi.EnvironmentVariables["ConnectionStrings__DefaultConnection"] <- $"Data Source={dbPath}"
         psi.EnvironmentVariables["BpMonitor__SeedDemoData"] <- "false"
 
-        webProcess <- Process.Start(psi)
+        let proc = new Process(StartInfo = psi)
+
+        proc.OutputDataReceived.Add(fun e ->
+          if e.Data <> null then
+            capturedOutput.AppendLine(e.Data) |> ignore)
+
+        proc.ErrorDataReceived.Add(fun e ->
+          if e.Data <> null then
+            capturedOutput.AppendLine(e.Data) |> ignore)
+
+        proc.Start() |> ignore
+        proc.BeginOutputReadLine()
+        proc.BeginErrorReadLine()
+        webProcess <- proc
+
         do! this.WaitUntilReadyAsync()
 
         let! pw = Playwright.CreateAsync()


### PR DESCRIPTION
## Summary
- E2E fixture used to wait a fixed 30s for the web app to become ready, then fail with a generic timeout even when the child process crashed immediately (e.g. missing Release build) — happened after moving the repo folder in Rider, whose test runner didn't rebuild Release first.
- Now captures the child process's stdout/stderr and fails fast (within ~500ms) with the real error the moment the process exits, instead of masking it behind a 30s timeout.
- Extracted the wait/readiness logic into a standalone, unit-testable `ProcessReadiness` module (fake `isReady`/`hasExited`/`capturedOutput` functions, no real process needed).