### PR TITLE
⬆️ chore: Automerge minor/patch/digest Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,16 @@
       ],
       "enabled": false,
       "description": "Pinned: these share a Microsoft.Testing.Platform transitive dep that must version-match; update manually and together"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Automerge Renovate PRs for minor/patch/pin/digest updates via native GitHub PR automerge
- Major updates still require manual review and merge
- Existing 5-day `minimumReleaseAge` grace period still applies to all updates before they're even opened/merged