### PR TITLE
⬆️ chore: update Microsoft.NET.Test.Sdk to 18.8.1

### DIFF
--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="TngTech.ArchUnitNET.xUnit" Version="0.13.3" />
   </ItemGroup>
   <ItemGroup Label="Test - xunit">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,9 @@
   "commitMessagePrefix": "⬆️ chore:",
   "packageRules": [
     {
-      "matchPackageNames": [
-        "Microsoft.NET.Test.Sdk",
-        "Microsoft.Testing.Extensions.CodeCoverage"
-      ],
+      "matchPackageNames": ["Microsoft.Testing.Extensions.CodeCoverage"],
       "enabled": false,
-      "description": "Pinned: these share a Microsoft.Testing.Platform transitive dep that must version-match; update manually and together"
+      "description": "Pinned at 18.0.6: every later release requires Microsoft.Testing.Platform >= 2.0.0, but xunit.v3 3.2.2 (latest stable) pins Microsoft.Testing.Platform.MSBuild to 1.9.1, which only supports Microsoft.Testing.Platform 1.x — mixing them throws a TypeLoadException on IDataConsumer at test-host startup. Re-enable once xunit.v3 ships a stable release with an updated Microsoft.Testing.Platform.MSBuild dependency."
     },
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## Summary

- Updates `Microsoft.NET.Test.Sdk` from 18.6.0 to 18.8.1
- `Microsoft.Testing.Extensions.CodeCoverage` stays pinned at 18.0.6: every later release requires `Microsoft.Testing.Platform >= 2.0.0`, which conflicts with xunit.v3 3.2.2's pinned `Microsoft.Testing.Platform.MSBuild` 1.9.1 and throws a `TypeLoadException` on `IDataConsumer` at test-host startup. Verified this empirically against 2.1.0 and 2.3.0.
- Narrowed the renovate.json pin to just `CodeCoverage`, with an updated description explaining the actual blocker so it's easy to re-enable once xunit.v3 ships a stable release with a compatible `Microsoft.Testing.Platform.MSBuild` dependency