### PR TITLE
⬆️ chore(renovate): scope commit message prefix to renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "schedule": ["* 5 * * *"],
   "minimumReleaseAge": "5 days",
-  "commitMessagePrefix": "⬆️ chore:",
+  "commitMessagePrefix": "⬆️ chore(renovate):",
   "packageRules": [
     {
       "matchPackageNames": ["Microsoft.Testing.Extensions.CodeCoverage"],


### PR DESCRIPTION
## Summary

- Scopes the renovate.json `commitMessagePrefix` from `⬆️ chore:` to `⬆️ chore(renovate):` so Renovate-authored commits are distinguishable from manual dependency updates