### PR TITLE
⚡️ perf(ci): cache NuGet packages and Playwright Chromium browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "10.0.x"
+          cache: true
+          cache-dependency-path: code/dotnet-tools.json
 
       - name: Restore tools
         run: dotnet tool restore
@@ -80,6 +82,10 @@ jobs:
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "10.0.x"
+          cache: true
+          cache-dependency-path: |
+            code/Directory.Packages.props
+            code/**/*.fsproj
 
       - name: Restore dependencies
         run: dotnet restore
@@ -89,8 +95,20 @@ jobs:
         run: dotnet build --no-restore --configuration Release
         working-directory: code
 
-      - name: Install Playwright browsers
-        run: pwsh bin/Release/net10.0/playwright.ps1 install --with-deps chromium
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('code/Directory.Packages.props') }}
+
+      - name: Install Playwright OS dependencies
+        run: pwsh bin/Release/net10.0/playwright.ps1 install-deps chromium
+        working-directory: code/BpMonitor.Web.E2E.Tests
+
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pwsh bin/Release/net10.0/playwright.ps1 install chromium
         working-directory: code/BpMonitor.Web.E2E.Tests
 
       - name: Test


### PR DESCRIPTION
## Summary
- Cache the Playwright Chromium browser binary (`~/.cache/ms-playwright`), keyed on the pinned `Microsoft.Playwright` version in `Directory.Packages.props`; OS-level deps still install every run (fast, apt-only), only the slow browser download is skipped on a cache hit.
- Cache restored NuGet packages via `setup-dotnet`'s built-in cache, keyed on `dotnet-tools.json` for the F# lint job and on `Directory.Packages.props` + all `*.fsproj` for the build-and-test job.