### PR TITLE
⬆️ chore(renovate): apply Renovate best practices

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["* 5 * * *"],
+  "schedule": ["before 6am"],
   "minimumReleaseAge": "5 days",
   "commitMessagePrefix": "⬆️ chore(renovate):",
+  "automergeStrategy": "squash",
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchPackageNames": ["Microsoft.Testing.Extensions.CodeCoverage"],


### PR DESCRIPTION
## Summary
- Fix cron schedule bug: `"* 5 * * *"` ran every minute during the 5am hour instead of once daily; switched to `"before 6am"`
- Pin `automergeStrategy` to `squash` to match the repo's squash-only merge policy
- Enable `osvVulnerabilityAlerts` so Renovate raises PRs for known-vulnerable dependencies