### PR TITLE
♻️ refactor(core,web): use active patterns for key parsing and route-id resolution

### DIFF
--- a/code/BpMonitor.Core/TrendPeriod.fs
+++ b/code/BpMonitor.Core/TrendPeriod.fs
@@ -40,11 +40,17 @@ module TrendPeriod =
 
   let private isoWeekKey (w: IsoWeek) = $"{w.Year}-W{w.Week:D2}"
 
+  /// Matches a string that parses as an int.
+  let private (|Int|_|) (s: string) : int option =
+    match Int32.TryParse s with
+    | true, v -> Some v
+    | _ -> None
+
   let private parseIsoWeekKey (key: string) : IsoWeek option =
     match key.Split('-') with
-    | [| y; w |] when w.Length >= 2 && w[0] = 'W' ->
-      match Int32.TryParse y, Int32.TryParse(w[1..]) with
-      | (true, year), (true, week) when week >= 1 && week <= 53 -> Some { Year = year; Week = week }
+    | [| Int year; w |] when w.Length >= 2 && w[0] = 'W' ->
+      match w[1..] with
+      | Int week when week >= 1 && week <= 53 -> Some { Year = year; Week = week }
       | _ -> None
     | _ -> None
 
@@ -52,15 +58,12 @@ module TrendPeriod =
 
   let private parseMonthKey (key: string) : YearMonth option =
     match key.Split('-') with
-    | [| y; m |] ->
-      match Int32.TryParse y, Int32.TryParse m with
-      | (true, year), (true, month) when month >= 1 && month <= 12 -> Some { Year = year; Month = month }
-      | _ -> None
+    | [| Int year; Int month |] when month >= 1 && month <= 12 -> Some { Year = year; Month = month }
     | _ -> None
 
   let private parseYearKey (key: string) : int option =
-    match Int32.TryParse key with
-    | true, year when year >= 1000 && year <= 9999 -> Some year
+    match key with
+    | Int year when year >= 1000 && year <= 9999 -> Some year
     | _ -> None
 
   let private previousIsoWeek (w: IsoWeek) : IsoWeek =

--- a/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
+++ b/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="MemberViewTests.fs" />
     <Compile Include="LoginViewTests.fs" />
     <Compile Include="ConfigTests.fs" />
+    <Compile Include="HandlerHelpersTests.fs" />
     <Compile Include="ReadingHandlerTests.fs" />
     <Compile Include="MemberHandlerTests.fs" />
     <Compile Include="LoginHandlerTests.fs" />

--- a/code/BpMonitor.Web.Tests/HandlerHelpersTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerHelpersTests.fs
@@ -1,0 +1,68 @@
+module HandlerHelpersTests
+
+open System.Threading.Tasks
+open Microsoft.AspNetCore.Http
+open Xunit
+open Swensen.Unquote
+open BpMonitor.Core
+open BpMonitor.Web
+open HandlerTestHelpers
+
+let private echoId: int -> Microsoft.AspNetCore.Http.HttpContext -> Task =
+  fun id ctx ->
+    ctx.Response.StatusCode <- 200
+    ctx.Response.WriteAsync(string id)
+
+let private echoMember: FamilyMember -> Microsoft.AspNetCore.Http.HttpContext -> Task =
+  fun m ctx ->
+    ctx.Response.StatusCode <- 200
+    ctx.Response.WriteAsync(m.Name)
+
+[<Fact>]
+let ``withRouteId invokes the handler with the parsed id`` () =
+  let ctx = TestHost.context (repoWith [])
+  TestHost.setRouteId ctx 42
+  TestHost.run (HandlerHelpers.withRouteId "test" echoId) ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  test <@ TestHost.readBody ctx = "42" @>
+
+[<Fact>]
+let ``withRouteId returns 400 for a non-integer id`` () =
+  let ctx = TestHost.context (repoWith [])
+  ctx.Request.RouteValues["id"] <- box "not-a-number"
+  TestHost.run (HandlerHelpers.withRouteId "test" echoId) ctx
+
+  test <@ ctx.Response.StatusCode = 400 @>
+
+[<Fact>]
+let ``withRouteId returns 400 for a missing id`` () =
+  let ctx = TestHost.context (repoWith [])
+  TestHost.run (HandlerHelpers.withRouteId "test" echoId) ctx
+
+  test <@ ctx.Response.StatusCode = 400 @>
+
+[<Fact>]
+let ``withRouteMember invokes the handler with the resolved member`` () =
+  let ctx = TestHost.contextWithMembers (repoWith []) [ sampleMember ]
+  TestHost.setRouteId ctx sampleMember.Id
+  TestHost.run (HandlerHelpers.withRouteMember "test" echoMember) ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  test <@ TestHost.readBody ctx = sampleMember.Name @>
+
+[<Fact>]
+let ``withRouteMember returns 400 for a non-integer id`` () =
+  let ctx = TestHost.contextWithMembers (repoWith []) [ sampleMember ]
+  ctx.Request.RouteValues["id"] <- box "not-a-number"
+  TestHost.run (HandlerHelpers.withRouteMember "test" echoMember) ctx
+
+  test <@ ctx.Response.StatusCode = 400 @>
+
+[<Fact>]
+let ``withRouteMember returns 404 for an unknown member id`` () =
+  let ctx = TestHost.contextWithMembers (repoWith []) [ sampleMember ]
+  TestHost.setRouteId ctx 999
+  TestHost.run (HandlerHelpers.withRouteMember "test" echoMember) ctx
+
+  test <@ ctx.Response.StatusCode = 404 @>

--- a/code/BpMonitor.Web/HandlerHelpers.fs
+++ b/code/BpMonitor.Web/HandlerHelpers.fs
@@ -99,26 +99,29 @@ module HandlerHelpers =
         routeStr ctx "id" |> Option.defaultValue "<missing>"
       )
 
+  /// Matches an HttpContext whose "id" route segment parses as an int.
+  let private (|RouteId|_|) (ctx: HttpContext) : int option = routeInt ctx "id"
+
   /// Resolves the "id" route segment to an int, logging and returning 400 for a noninteger id.
   let withRouteId (handlerName: string) (handler: int -> HttpContext -> Task) : HttpContext -> Task =
     fun ctx ->
-      match routeInt ctx "id" with
-      | None ->
+      match ctx with
+      | RouteId id -> handler id ctx
+      | _ ->
         logBadRouteId handlerName ctx
         badRequest ctx
-      | Some id -> handler id ctx
 
   /// Resolves the "id" route segment to a FamilyMember, logging and returning
   /// 400 for a noninteger id or 404 when no member with that id exists.
   let withRouteMember (handlerName: string) (handler: FamilyMember -> HttpContext -> Task) : HttpContext -> Task =
     fun ctx ->
-      match routeInt ctx "id" with
-      | None ->
-        logBadRouteId handlerName ctx
-        badRequest ctx
-      | Some id ->
+      match ctx with
+      | RouteId id ->
         match (memberRepo ctx).GetById(id) with
         | None ->
           (logger ctx).LogWarning("{Handler}: member {Id} not found", handlerName, id)
           notFound ctx
         | Some m -> handler m ctx
+      | _ ->
+        logBadRouteId handlerName ctx
+        badRequest ctx


### PR DESCRIPTION
## Summary

- Replace nested `Int32.TryParse` matches in `TrendPeriod`'s ISO-week/month/year key parsers with a private `(|Int|_|)` active pattern
- Collapse the duplicated "parse route id, 400 on failure" branch in `withRouteId`/`withRouteMember` into a private `(|RouteId|_|)` active pattern
- Add direct tests for `withRouteId`/`withRouteMember`, which previously only had indirect coverage via handler-level tests