### PR TITLE
♻️ refactor: use shorthand lambda syntax for single member-access chains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ Never start work on `main`. Creating the branch is the first step, not an aftert
 ## F# Style Conventions
 
 - Use shorthand lambda syntax where the argument is only used for a single member access chain: `_.Property` instead of `fun x -> x.Property`
+  - Covers property/method/indexer chains rooted at the parameter, e.g. `_.Timestamp.ToLocalTime().Date`, `_.Contains("x")`, `_.Groups[1].Value`
+  - Does not apply if the parameter is used more than once (e.g. `fun r -> r.Id = r.OtherId`) or if the chain result is piped into another function (e.g. `fun a -> a.GetValue() |> Option.ofObj` — `_.GetValue() |> Option.ofObj` type-checks against the wrong thing, since `|>` binds to the whole lambda, not its result)
 - Do not use `.[n]` indexer syntax outside of Unquote quotation expressions (`<@ ... @>`); use `[n]` instead
 - Inside Unquote quotation expressions, `[n]` only works on simple local variables — use `.[n]` when indexing the result of a method call (e.g. `repo.GetAll().[0]`)
 - `new` is required for any type implementing `IDisposable` — the compiler enforces this via FS0760

--- a/code/BpMonitor.Charts.Tests/ChartsTests.fs
+++ b/code/BpMonitor.Charts.Tests/ChartsTests.fs
@@ -298,7 +298,7 @@ let ``toHtmlRecent does not drop any reading, even when split across dash/solid 
 
   let coveredLabels (name: string) =
     Regex.Matches(html, $"\"name\":\"{name}\".*?\"x\":\\[([^\\]]*)\\]")
-    |> Seq.collect (fun m -> m.Groups[1].Value.Split(','))
+    |> Seq.collect _.Groups[1].Value.Split(',')
     |> Set.ofSeq
 
   test <@ (coveredLabels "Systolic").Count = readings.Length @>

--- a/code/BpMonitor.Core/ReadingStats.fs
+++ b/code/BpMonitor.Core/ReadingStats.fs
@@ -89,7 +89,7 @@ module ReadingStats =
         MaxDiastolic = maxDia })
 
   let private dailyAveragesWithCount =
-    buildAggregated (fun r -> r.Timestamp.ToLocalTime().Date) id
+    buildAggregated _.Timestamp.ToLocalTime().Date id
 
   /// Groups readings by local calendar date, sorted ascending.
   /// The returned reading's Timestamp is midnight of that local date. Comments are dropped.

--- a/code/BpMonitor.Data.Tests/EfFamilyMemberRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/EfFamilyMemberRepositoryTests.fs
@@ -191,7 +191,6 @@ let ``GetById translates Id filter to SQL WHERE clause`` () =
   log.Clear()
   repo.GetById(added.Id) |> ignore
 
-  let selectSql =
-    log |> Seq.filter (fun s -> s.Contains("SELECT")) |> String.concat " "
+  let selectSql = log |> Seq.filter _.Contains("SELECT") |> String.concat " "
 
   Assert.Contains("WHERE", selectSql)

--- a/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
+++ b/code/BpMonitor.Data.Tests/EfReadingRepositoryTests.fs
@@ -208,7 +208,6 @@ let ``GetAll translates MemberId filter to SQL WHERE clause`` () =
   log.Clear()
   repo.GetAll(defaultMemberId) |> ignore
 
-  let selectSql =
-    log |> Seq.filter (fun s -> s.Contains("SELECT")) |> String.concat " "
+  let selectSql = log |> Seq.filter _.Contains("SELECT") |> String.concat " "
 
   Assert.Contains("WHERE", selectSql)


### PR DESCRIPTION
## Summary
- Replace `fun x -> x.Property` lambdas with `_.Property` shorthand where the parameter is used exactly once as a plain member/method/indexer chain (`ReadingStats.fs`, `EfFamilyMemberRepositoryTests.fs`, `EfReadingRepositoryTests.fs`, `ChartsTests.fs`)
- Audited the rest of the `fun x -> x....` call sites in the codebase; left untouched where the parameter is used more than once (comparisons, tuples, `&&`) or mutated (`<-`), since the shorthand doesn't apply there
- Clarify the shorthand-lambda rule in `AGENTS.md` with the edge cases discovered during the audit: works for method/indexer chains, breaks if the parameter is used twice or the chain result is piped into another function