### PR TITLE
🐛 fix(web): assert health check version via JSON parsing instead of raw string match

### DIFF
--- a/code/BpMonitor.Core.Tests/LowessPropertyTests.fs
+++ b/code/BpMonitor.Core.Tests/LowessPropertyTests.fs
@@ -1,6 +1,5 @@
 module LowessPropertyTests
 
-open FsCheck
 open FsCheck.FSharp
 open FsCheck.Xunit
 open BpMonitor.Core

--- a/code/BpMonitor.Core.Tests/ReadingRepositoryContractTests.fs
+++ b/code/BpMonitor.Core.Tests/ReadingRepositoryContractTests.fs
@@ -1,6 +1,5 @@
 module ReadingRepositoryContractTests
 
-open System
 open Xunit
 open Swensen.Unquote
 open BpMonitor.Core

--- a/code/BpMonitor.Web.Tests/HealthHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/HealthHandlerTests.fs
@@ -2,6 +2,7 @@ module HealthHandlerTests
 
 open System
 open System.IO
+open System.Text.Json
 open Xunit
 open Swensen.Unquote
 open BpMonitor.Web
@@ -20,7 +21,11 @@ let ``health reports connected status and content type when the database is reac
   test <@ ctx.Response.ContentType = "application/json; charset=utf-8" @>
   test <@ body.Contains("\"status\":\"healthy\"") @>
   test <@ body.Contains("\"database\":\"connected\"") @>
-  test <@ body.Contains($"\"version\":\"{Version.current}\"") @>
+
+  let version =
+    JsonDocument.Parse(body).RootElement.GetProperty("version").GetString()
+
+  test <@ version = BpMonitor.Web.Version.current @>
 
 [<Fact>]
 let ``health returns 503 when the database is unreachable`` () =

--- a/code/BpMonitor.Web.Tests/PlotlyVendoringTests.fs
+++ b/code/BpMonitor.Web.Tests/PlotlyVendoringTests.fs
@@ -7,7 +7,6 @@ open System.Text.RegularExpressions
 open Xunit
 open Swensen.Unquote
 open Falco.Markup
-open BpMonitor.Core
 open BpMonitor.Web
 
 let private defaultMember = HandlerTestHelpers.sampleMember

--- a/code/BpMonitor.Web/AuthHandlers.fs
+++ b/code/BpMonitor.Web/AuthHandlers.fs
@@ -85,7 +85,7 @@ module AuthHandlers =
 
   /// Resolves both the authenticated member and the "id" route segment, passing both to
   /// `handler`. Redirects to /login if the member cannot be resolved; returns 400 for a
-  /// non-integer id.
+  /// noninteger id.
   let withMemberAndRouteId
     (handlerName: string)
     (handler: FamilyMember -> int -> HttpContext -> Task)

--- a/code/BpMonitor.Web/HealthHandlers.fs
+++ b/code/BpMonitor.Web/HealthHandlers.fs
@@ -2,7 +2,6 @@ namespace BpMonitor.Web
 
 open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
-open Microsoft.EntityFrameworkCore
 open Microsoft.Extensions.Logging
 
 /// Anonymous liveness + database-reachability probe for container orchestrators.

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -114,7 +114,7 @@ module ReadingHandlers =
         (ReadingViews.recent m chartHtml loadedReadings windowStart now recentZoomShortcutDays hasOlderHistory)
         ctx)
 
-  // The "Load full history" button's target (ReadingViews.recentChartContainer): an
+  // The "Load full history" button's target (ReadingViews.recentChartContainer): a
   // htmx fragment that re-renders the chart container with the member's *entire* history
   // loaded (still focused on the last 30 days), so panning works all the way back. Same
   // outerHTML-swap pattern as /trends' `trendsPanel`.

--- a/code/BpMonitor.sln.DotSettings
+++ b/code/BpMonitor.sln.DotSettings
@@ -1,11 +1,24 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=cliponaxis/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dragmode/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dtick/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=errorbar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=errorbars/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=fixedrange/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=granularities/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=htmx/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=linecolor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lowess/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=modebar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=redisplays/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=showlegend/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=showline/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=showspikes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=spikeline/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=tickcolor/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ticktext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Wegier/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=xanchor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=xaxis/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=yanchor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=yerror/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
## Summary
- Health check test asserted the JSON body via a raw `Contains()` on `Version.current`, which fails when the version string contains build metadata with a `+` — System.Text.Json's default encoder escapes it to `+`. Now parses the JSON and compares the decoded `version` field value instead.
- Removes unused opens (`FsCheck`, `System`, `BpMonitor.Core`) flagged by Rider inspections.
- Fixes two typos in doc comments (`noninteger`, "a htmx fragment").