### PR TITLE
🔥 chore: remove unused open in LoginHandlerTests

### DIFF
--- a/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/LoginHandlerTests.fs
@@ -1,6 +1,5 @@
 module LoginHandlerTests
 
-open System
 open Xunit
 open Swensen.Unquote
 open Microsoft.Extensions.DependencyInjection


### PR DESCRIPTION
## Summary
- Removes an unused `open System` in `BpMonitor.Web.Tests/LoginHandlerTests.fs`, found while spiking a custom unused-opens analyzer (see ADR-0007).