### PR TITLE
✨ feat(charts): show day name in /recent chart's hover box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Recent chart's hover box now shows the day name alongside the date and time (e.g. `2026-08-03 12:45 (Mon)`)
+
 ## [1.9.0] - 2026-07-30
 
 ### Added

--- a/code/BpMonitor.Charts/Charts.fs
+++ b/code/BpMonitor.Charts/Charts.fs
@@ -120,7 +120,14 @@ module BpChart =
       SpikeThickness = 2,
       SpikeDash = StyleParam.DrawingStyle.Solid,
       SpikeMode = StyleParam.SpikeMode.Across,
-      SpikeSnap = StyleParam.SpikeSnap.Data
+      SpikeSnap = StyleParam.SpikeSnap.Data,
+      // Plotly auto-detects this axis as a date type and independently auto-formats
+      // both the tick labels and the unified-hover spike label; without this, the
+      // spike label defaults to Plotly's own locale format ("Aug 3, 2026, 12:45")
+      // rather than matching the rest of the app's yyyy-MM-dd HH:mm convention.
+      // %a (day name) is added here only, not in the tick labels, since the ticks
+      // already carry enough date context and adding it there would crowd them.
+      HoverFormat = "%Y-%m-%d %H:%M (%a)"
     )
 
   // FixedRange disables zoom on this axis — the y-axis is pinned to a clinical 0-200 mmHg

--- a/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
+++ b/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
@@ -176,3 +176,45 @@ type RememberMeCheckedCookieTests(fixture: WebAppFixture) =
 
       Assert.Contains("expires=", setCookieHeader)
     }
+
+/// Plotly auto-detects /recent's x-axis as a date type and would otherwise apply
+/// its own locale-formatted default ("Aug 3, 2026, 12:45") to the unified hover
+/// label, independently of the tick labels — guards the explicit HoverFormat
+/// (Charts.fs's recentXAxis) that keeps it on the app's yyyy-MM-dd HH:mm convention.
+type RecentChartHoverFormatTests(fixture: WebAppFixture) =
+  interface IClassFixture<WebAppFixture>
+
+  [<Fact>]
+  member _.``recent chart hover shows date, time, and day name``() : Task =
+    task {
+      let! page = fixture.Browser.NewPageAsync()
+
+      do! TestAccount.claimAndLogin fixture.BaseUrl page
+
+      let! _ = page.GotoAsync($"{fixture.BaseUrl}/add")
+      let ts = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm")
+      do! page.FillAsync("#Timestamp", ts)
+      do! page.FillAsync("#Systolic", "118")
+      do! page.FillAsync("#Diastolic", "76")
+      do! page.FillAsync("#HeartRate", "62")
+      do! page.ClickAsync("form[action='/readings'] button[type=submit]")
+      do! page.WaitForURLAsync($"{fixture.BaseUrl}/recent")
+
+      let! _ = page.WaitForSelectorAsync(".chart .plot-container")
+
+      let! rectJson =
+        page.EvalOnSelectorAsync<string>(
+          ".chart .scatterlayer path.point",
+          "el => { const r = el.getBoundingClientRect(); return JSON.stringify({x: r.x + r.width/2, y: r.y + r.height/2}); }"
+        )
+
+      let rect = System.Text.Json.JsonDocument.Parse(rectJson).RootElement
+      let px = rect.GetProperty("x").GetSingle()
+      let py = rect.GetProperty("y").GetSingle()
+      do! page.Mouse.MoveAsync(px, py)
+      do! page.WaitForTimeoutAsync(500.0f)
+
+      let! headerText = page.Locator(".chart .hoverlayer .axistext text").TextContentAsync()
+      let expected = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm (ddd)")
+      Assert.Equal(expected, headerText)
+    }


### PR DESCRIPTION
## Summary

- Recent chart's hover box now shows the day name alongside the date and time (e.g. `2026-08-03 12:45 (Mon)`)
- Plotly auto-formats the unified hover label independently of the tick labels once it detects a date-typed axis, defaulting to its own locale format instead of the app's `yyyy-MM-dd HH:mm` convention — this sets `HoverFormat` explicitly so it matches
- Added a permanent Playwright E2E regression test, since this behavior only exists in Plotly's client-side rendering and wouldn't show up in a static HTML snapshot