### PR TITLE
🔧 chore(hooks): enforce branch-first, no-attribution, and PR-preflight rules via hooks

### DIFF
--- a/.claude/hooks/block-claude-attribution.sh
+++ b/.claude/hooks/block-claude-attribution.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash(git *) / Bash(gh *): hard-blocks Claude
+# attribution from reaching a commit or PR. Claude Code's own system
+# prompt pushes for Co-Authored-By trailers and a "Generated with Claude
+# Code" footer, so a reminder alone (git-workflow-reminder.sh) isn't
+# reliable enough — this is the backstop.
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+deny() {
+  jq -n --arg reason "$1" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+  exit 0
+}
+
+case "$cmd" in
+  *"git commit"*)
+    if printf '%s' "$cmd" | grep -qi "co-authored-by"; then
+      deny "git-workflow skill: NEVER add a Co-Authored-By trailer to commits — no Claude attribution, no exceptions."
+    fi
+    ;;
+  *"gh pr create"*)
+    body=""
+    if printf '%s' "$cmd" | grep -qi -- "--body-file"; then
+      body_file=$(printf '%s' "$cmd" | grep -oP -- '--body-file[= ]\K\S+' || true)
+      if [ -n "$body_file" ] && [ -f "$body_file" ]; then
+        body=$(cat "$body_file")
+      fi
+    fi
+    combined="$cmd
+$body"
+    if printf '%s' "$combined" | grep -qiE "generated with claude code|🤖|## Test plan"; then
+      deny "git-workflow skill: PR body is a Summary section only — no Test plan section, no Generated-with-Claude-Code footer/emoji."
+    fi
+    ;;
+esac

--- a/.claude/hooks/git-workflow-reminder.sh
+++ b/.claude/hooks/git-workflow-reminder.sh
@@ -20,6 +20,19 @@ case "$cmd" in
     ;;
   *"gh pr create"*)
     reminder="git-workflow skill: PR title must be gitmoji + conventional commits (it becomes the squash-merge commit). PR body is a Summary section only — no Test plan section, no Generated-with-Claude-Code footer."
+    preflight=""
+    if ! git diff --name-only main...HEAD 2>/dev/null | grep -q "^CHANGELOG.md$"; then
+      preflight="$preflight CHANGELOG.md has no changes on this branch — add an [Unreleased] bullet if this is user-facing."
+    fi
+    if git diff --name-only --diff-filter=A main...HEAD 2>/dev/null | grep -q "\.fsproj$"; then
+      touched=$(git diff --name-only main...HEAD 2>/dev/null)
+      if ! printf '%s' "$touched" | grep -q "^docs/architecture.md$" || ! printf '%s' "$touched" | grep -q "^AGENTS.md$"; then
+        preflight="$preflight A new project was added — update both docs/architecture.md and AGENTS.md in this branch."
+      fi
+    fi
+    if [ -n "$preflight" ]; then
+      reminder="$reminder$preflight"
+    fi
     ;;
   *"gh pr merge"*)
     reminder="git-workflow skill: do not merge until \`gh pr checks <number> --watch\` shows all checks green. Squash-merge only."

--- a/.claude/hooks/require-feature-branch.sh
+++ b/.claude/hooks/require-feature-branch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Edit/Write/NotebookEdit: blocks edits inside the repo
+# while HEAD is on main. git-workflow skill requires branching off main
+# before any code changes — husky's pre-commit hook only catches this at
+# commit time, after the edits already happened.
+set -euo pipefail
+
+input=$(cat)
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+case "$file_path" in
+  "$project_dir"/*) ;;
+  *) exit 0 ;;
+esac
+
+branch=$(git -C "$project_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+if [ "$branch" = "main" ]; then
+  jq -n '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",
+    permissionDecisionReason:"AGENTS.md: create a feature branch before any edits — git checkout -b <feature|fix|chore>/<desc>"}}'
+fi

--- a/.claude/hooks/verify-frontend-reminder.sh
+++ b/.claude/hooks/verify-frontend-reminder.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Stop hook: reminds to run /verify-frontend when frontend files changed
+# since the last nudge. AGENTS.md says any wwwroot/Views/page-handler
+# change should be verified via a real browser before reporting complete;
+# this catches the case where that step gets skipped.
+set -euo pipefail
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$project_dir"
+
+frontend_paths=("code/BpMonitor.Web/wwwroot" "code/BpMonitor.Web/Views")
+
+changed=""
+for p in "${frontend_paths[@]}"; do
+  if [ -d "$p" ]; then
+    while IFS= read -r f; do
+      changed="$changed$f:$(stat -c %Y "$f" 2>/dev/null || echo 0)|"
+    done < <(git status --porcelain -- "$p" 2>/dev/null | awk '{print $NF}')
+    branch_changed=$(git diff --name-only main...HEAD -- "$p" 2>/dev/null || true)
+    for f in $branch_changed; do
+      changed="$changed$f:$(stat -c %Y "$f" 2>/dev/null || echo 0)|"
+    done
+  fi
+done
+
+if [ -z "$changed" ]; then
+  exit 0
+fi
+
+hash=$(printf '%s' "$changed" | sha256sum | cut -d' ' -f1)
+stamp_file=".git/claude-verify-frontend"
+previous=""
+[ -f "$stamp_file" ] && previous=$(cat "$stamp_file")
+
+if [ "$hash" = "$previous" ]; then
+  exit 0
+fi
+
+printf '%s' "$hash" > "$stamp_file"
+jq -n '{decision:"block",reason:"AGENTS.md: frontend files changed — run /verify-frontend before reporting this complete."}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,39 @@
             "if": "Bash(gh *)",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/git-workflow-reminder.sh\"",
             "statusMessage": "Checking git-workflow rules..."
+          },
+          {
+            "type": "command",
+            "if": "Bash(git *)",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-claude-attribution.sh\"",
+            "statusMessage": "Checking for Claude attribution..."
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh *)",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-claude-attribution.sh\"",
+            "statusMessage": "Checking for Claude attribution..."
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/require-feature-branch.sh\"",
+            "statusMessage": "Checking branch..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/verify-frontend-reminder.sh\"",
+            "statusMessage": "Checking frontend verification..."
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,10 +78,11 @@ Keep `docs/architecture.md` and `AGENTS.md` in sync with every structural change
 
 Follow the `git-workflow` skill (`.claude/skills/git-workflow/SKILL.md`). Key rules:
 - Gitmoji commit messages
-- Feature branches only, never commit to `main`
+- Feature branches only, never commit to `main` *(enforced by hook)*
 - Squash merge via PR
 - Keep PRs small and focused
-- **NEVER add `Co-Authored-By:` trailers to commits** — no Claude attribution, no exceptions
+- **NEVER add `Co-Authored-By:` trailers to commits** — no Claude attribution, no exceptions *(enforced by hook)*
+- No "Generated with Claude Code" footer or "Test plan" section in PR bodies *(enforced by hook)*
 
 **Before making any code changes**, always create a feature branch first:
 
@@ -90,6 +91,11 @@ git checkout -b feat/<short-description>
 ```
 
 Never start work on `main`. Creating the branch is the first step, not an afterthought.
+
+`.claude/hooks/` mechanically enforces the branch-first, no-attribution, PR-preflight
+(CHANGELOG/docs sync reminders), and `/verify-frontend` rules described here and in
+`.claude/skills/verify-frontend/SKILL.md`; `.husky/` handles formatting checks and blocks
+commits on `main`.
 
 ## F# Style Conventions
 


### PR DESCRIPTION
## Summary
- Add `require-feature-branch.sh`: PreToolUse hook that blocks Edit/Write/NotebookEdit while `HEAD` is `main`, catching the rule earlier than Husky's commit-time check.
- Add `block-claude-attribution.sh`: PreToolUse hook that blocks attribution trailers in commit messages and attribution footers/Test-plan sections in PR bodies (including `--body-file`).
- Extend `git-workflow-reminder.sh`: `gh pr create` now also reminds about a missing `CHANGELOG.md` entry and missing `docs/architecture.md`/`AGENTS.md` sync when a new `.fsproj` was added on the branch.
- Add `verify-frontend-reminder.sh`: Stop hook that nudges `/verify-frontend` once per change-set when `wwwroot/`/`Views/` files changed.
- Wire all of the above into `.claude/settings.json` and annotate the now-enforced rules in `AGENTS.md`.
