### PR TITLE
🐛 fix(e2e): freeze timestamp in flaky RecentChartHoverFormatTests

### DIFF
--- a/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
+++ b/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
@@ -2,6 +2,7 @@ module BpMonitor.Web.E2E.SmokeTests
 
 open System
 open System.Collections.Generic
+open System.Globalization
 open System.Net.Http
 open System.Threading.Tasks
 open BpMonitor.Web.E2E
@@ -192,7 +193,8 @@ type RecentChartHoverFormatTests(fixture: WebAppFixture) =
       do! TestAccount.claimAndLogin fixture.BaseUrl page
 
       let! _ = page.GotoAsync($"{fixture.BaseUrl}/add")
-      let ts = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm")
+      let now = System.DateTime.Now
+      let ts = now.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)
       do! page.FillAsync("#Timestamp", ts)
       do! page.FillAsync("#Systolic", "118")
       do! page.FillAsync("#Diastolic", "76")
@@ -215,6 +217,6 @@ type RecentChartHoverFormatTests(fixture: WebAppFixture) =
       do! page.WaitForTimeoutAsync(500.0f)
 
       let! headerText = page.Locator(".chart .hoverlayer .axistext text").TextContentAsync()
-      let expected = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm (ddd)")
+      let expected = now.ToString("yyyy-MM-dd HH:mm (ddd)", CultureInfo.InvariantCulture)
       Assert.Equal(expected, headerText)
     }


### PR DESCRIPTION
## Summary
- `RecentChartHoverFormatTests` called `DateTime.Now` twice — once to build the typed timestamp, once for the expected assertion — with a full page round-trip and 500ms wait in between, so a minute-boundary crossing made the test flake
- Capture the instant once and reuse it for both the input and the expectation
- Format with `CultureInfo.InvariantCulture` so day-name/time-separator differences on non-English locales can't cause a mismatch either
- Audited the rest of the codebase for other `DateTime.Now`/`UtcNow`/`Today` usages: the only other hits (`ProcessReadiness.fs` polling deadline, `SchemaMigrations.fs` backup filename stamp) are not assertion-based and carry no flake risk