### PR TITLE
🎨 chore(tests): remove redundant fully-qualified type names

### DIFF
--- a/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
+++ b/code/BpMonitor.Web.E2E.Tests/SmokeTests.fs
@@ -193,7 +193,7 @@ type RecentChartHoverFormatTests(fixture: WebAppFixture) =
       do! TestAccount.claimAndLogin fixture.BaseUrl page
 
       let! _ = page.GotoAsync($"{fixture.BaseUrl}/add")
-      let now = System.DateTime.Now
+      let now = DateTime.Now
       let ts = now.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)
       do! page.FillAsync("#Timestamp", ts)
       do! page.FillAsync("#Systolic", "118")

--- a/code/BpMonitor.Web.Tests/HandlerHelpersTests.fs
+++ b/code/BpMonitor.Web.Tests/HandlerHelpersTests.fs
@@ -8,12 +8,12 @@ open BpMonitor.Core
 open BpMonitor.Web
 open HandlerTestHelpers
 
-let private echoId: int -> Microsoft.AspNetCore.Http.HttpContext -> Task =
+let private echoId: int -> HttpContext -> Task =
   fun id ctx ->
     ctx.Response.StatusCode <- 200
     ctx.Response.WriteAsync(string id)
 
-let private echoMember: FamilyMember -> Microsoft.AspNetCore.Http.HttpContext -> Task =
+let private echoMember: FamilyMember -> HttpContext -> Task =
   fun m ctx ->
     ctx.Response.StatusCode <- 200
     ctx.Response.WriteAsync(m.Name)


### PR DESCRIPTION
## Summary
- Removes redundant `System.` prefix from `DateTime.Now` in `SmokeTests.fs` (namespace already opened)
- Removes redundant `Microsoft.AspNetCore.Http.` prefix from `HttpContext` type annotations in `HandlerHelpersTests.fs` (namespace already opened)