### PR TITLE
♻️ refactor(nav): reorder sidebar and landing-page nav entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reordered sidebar and landing-page navigation: top group is now Add, Recent, Trends, History; Members moved into the bottom group alongside Export JSON, Export CSV, and Settings. The landing page now mirrors the sidebar's order and two-group layout.
+
 ## [1.10.1] - 2026-08-15
 
 ### Maintenance

--- a/code/BpMonitor.Web.Tests/LandingViewTests.fs
+++ b/code/BpMonitor.Web.Tests/LandingViewTests.fs
@@ -57,3 +57,34 @@ let ``non-admin does not see a Members action button on landing`` () =
   let nonAdmin = { defaultMember with IsAdmin = false }
   let html = renderHtml (ReadingViews.landing nonAdmin)
   test <@ occurrences $"href=\"{Routes.members}\"" html = 0 @>
+
+[<Fact>]
+let ``landing renders two home-actions groups`` () =
+  let html = renderHtml (ReadingViews.landing defaultMember)
+  test <@ occurrences "class=\"home-actions" html = 2 @>
+
+[<Fact>]
+let ``landing action buttons appear in order: Add, Recent, Trends, History, Export JSON, Export CSV, Settings, Members``
+  ()
+  =
+  let admin = { defaultMember with IsAdmin = true }
+  let html = renderHtml (ReadingViews.landing admin)
+  // the sidebar renders first with the same hrefs, so anchor to the landing
+  // action grid by slicing from its first container onward
+  let landingHtml = html.Substring(html.IndexOf "class=\"home-actions\"")
+
+  let indexOf (href: string) = landingHtml.IndexOf $"href=\"{href}\""
+
+  let indices =
+    [ Routes.add
+      Routes.recent
+      Routes.trends
+      Routes.history
+      Routes.exportJson
+      Routes.exportCsv
+      Routes.settings
+      Routes.members ]
+    |> List.map indexOf
+
+  test <@ indices |> List.forall (fun i -> i >= 0) @>
+  test <@ indices = List.sort indices @>

--- a/code/BpMonitor.Web.Tests/LayoutViewTests.fs
+++ b/code/BpMonitor.Web.Tests/LayoutViewTests.fs
@@ -30,6 +30,27 @@ let ``non-admin does not see Members nav link`` () =
   test <@ not (html.Contains $"href=\"{Routes.members}\"") @>
 
 [<Fact>]
+let ``sidebar nav links appear in order: Add, Recent, Trends, History, Export JSON, Export CSV, Settings, Members`` () =
+  let admin = { defaultMember with IsAdmin = true }
+  let html = renderHtml (ReadingViews.landing admin)
+
+  let indexOf (href: string) = html.IndexOf $"href=\"{href}\""
+
+  let indices =
+    [ Routes.add
+      Routes.recent
+      Routes.trends
+      Routes.history
+      Routes.exportJson
+      Routes.exportCsv
+      Routes.settings
+      Routes.members ]
+    |> List.map indexOf
+
+  test <@ indices |> List.forall (fun i -> i >= 0) @>
+  test <@ indices = List.sort indices @>
+
+[<Fact>]
 let ``every page has a BpMonitor footer`` () =
   let pages =
     [ renderHtml (ReadingViews.landing defaultMember)

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -30,12 +30,14 @@ module ReadingViews =
         Elem.div
           [ Attr.class' "home-actions" ]
           [ actionButton Routes.add "➕" "Add reading"
-            actionButton Routes.history "📜" "History"
-            actionButton Routes.trends "📈" "Trends"
             actionButton Routes.recent "🕒" "Recent"
-            actionButton Routes.settings "⚙️" "Settings"
-            downloadActionButton Routes.exportJson "⬇️" "Export JSON"
+            actionButton Routes.trends "📈" "Trends"
+            actionButton Routes.history "📜" "History" ]
+        Elem.div
+          [ Attr.class' "home-actions home-actions-secondary" ]
+          [ downloadActionButton Routes.exportJson "⬇️" "Export JSON"
             downloadActionButton Routes.exportCsv "⬇️" "Export CSV"
+            actionButton Routes.settings "⚙️" "Settings"
             if m.IsAdmin then
               actionButton Routes.members "👥" "Members" ] ]
 

--- a/code/BpMonitor.Web/ViewLayout.fs
+++ b/code/BpMonitor.Web/ViewLayout.fs
@@ -137,16 +137,16 @@ module ViewLayout =
               [ Elem.ul
                   []
                   [ navActionLink active Routes.add "➕" "Add"
-                    navLink active Routes.history "📜" "History"
                     navLink active Routes.recent "🕒" "Recent"
                     navLink active Routes.trends "📈" "Trends"
-                    if isAdmin then
-                      navLink active Routes.members "👥" "Members" ]
+                    navLink active Routes.history "📜" "History" ]
                 Elem.ul
                   [ Attr.class' "sidebar-bottom" ]
-                  [ navLink active Routes.settings "⚙️" "Settings"
-                    navDownloadLink Routes.exportJson "⬇️" "Export JSON"
-                    navDownloadLink Routes.exportCsv "⬇️" "Export CSV" ] ]
+                  [ navDownloadLink Routes.exportJson "⬇️" "Export JSON"
+                    navDownloadLink Routes.exportCsv "⬇️" "Export CSV"
+                    navLink active Routes.settings "⚙️" "Settings"
+                    if isAdmin then
+                      navLink active Routes.members "👥" "Members" ] ]
             Elem.div
               [ Attr.class' "content" ]
               [ Elem.main [ Attr.class' "container" ] content

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -479,6 +479,10 @@ td.col-center {
   margin-bottom: 0;
 }
 
+.home-actions-secondary {
+  margin-top: 1.5rem;
+}
+
 .icon {
   margin-right: 0.4rem;
 }


### PR DESCRIPTION
## Summary
- Sidebar top group reordered to Add, Recent, Trends, History
- Members moved from the sidebar's top group into the bottom group, alongside Export JSON, Export CSV, and Settings
- Landing page now mirrors the sidebar's order and two-group split (`home-actions` / `home-actions home-actions-secondary`)
- Added ordering tests to `LayoutViewTests.fs` and `LandingViewTests.fs`