### PR TITLE
🐛 fix(scripts): load screenshots' Playwright from the E2E project's build output

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -24,7 +24,14 @@ depends = ["lint:md", "lint:js", "lint:ts", "lint:shell"]
 
 [tasks.screenshots]
 description = "Regenerates docs/screenshots/*.png from a fresh self-seeded demo instance (run before cutting a release)"
-run = "dotnet fsi scripts/generate-screenshots.fsx"
+# Builds BpMonitor.Web.E2E.Tests first so its Microsoft.Playwright.dll is present and
+# current — the script loads Playwright from there instead of its own version pin.
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+dotnet build code/BpMonitor.Web.E2E.Tests --configuration Release
+dotnet fsi scripts/generate-screenshots.fsx
+'''
 
 [tasks."test:e2e-setup"]
 description = "One-time local setup: installs the Playwright Chromium browser used by BpMonitor.Web.E2E.Tests"

--- a/scripts/generate-screenshots.fsx
+++ b/scripts/generate-screenshots.fsx
@@ -2,7 +2,7 @@
 // instance seeded with the Simpson-family demo dataset.
 //
 // Run before cutting a release (see the cut-release skill):
-//   dotnet fsi scripts/generate-screenshots.fsx
+//   mise run screenshots
 //
 // Requires the Playwright Chromium browser (`mise run test:e2e-setup` once
 // locally). Uses Ned Flanders — his scripted "elevated readings improving
@@ -15,7 +15,12 @@
 // fsi` script with no project reference, so the two can't share a function
 // directly. Keep them in sync by hand if the self-hosting approach changes.
 
-#r "nuget: Microsoft.Playwright, 1.62.0"
+// Loads Playwright from BpMonitor.Web.E2E.Tests' own build output instead of a
+// separate `#r "nuget: ..."` pin, so the version can't drift from the one
+// Directory.Packages.props already pins solution-wide (see the `screenshots`
+// mise task, which builds that project first).
+#r "../code/BpMonitor.Web.E2E.Tests/bin/Release/net10.0/Microsoft.Bcl.AsyncInterfaces.dll"
+#r "../code/BpMonitor.Web.E2E.Tests/bin/Release/net10.0/Microsoft.Playwright.dll"
 
 open System
 open System.Diagnostics


### PR DESCRIPTION
## Summary

- `scripts/generate-screenshots.fsx` pinned its own `Microsoft.Playwright` version via `#r "nuget: ..."`, separate from `Directory.Packages.props`' solution-wide pin — the two drifted apart in PR #428, breaking `mise run screenshots`.
- Now loads Playwright from `BpMonitor.Web.E2E.Tests`' own build output instead (the same trick `test:e2e-setup` already uses to install Chromium), so there's no separate version to keep in sync by hand.
- The `screenshots` mise task now builds that project first to guarantee the DLL is present and current.