### PR TITLE
🐛 fix(medications): fix /history's medication window and chart alignment

### DIFF
--- a/code/BpMonitor.Data/EfMedicationRepository.fs
+++ b/code/BpMonitor.Data/EfMedicationRepository.fs
@@ -8,10 +8,10 @@ module private MedicationMapping =
     { Id = r.Id
       MemberId = r.MemberId
       Name = r.Name
-      FullName = if isNull r.FullName then None else Some r.FullName
-      Comment = if isNull r.Comment then None else Some r.Comment
+      FullName = Option.ofObj r.FullName
+      Comment = Option.ofObj r.Comment
       StartDate = r.StartDate
-      EndDate = if r.EndDate.HasValue then Some r.EndDate.Value else None
+      EndDate = Option.ofNullable r.EndDate
       CreatedAt = r.CreatedAt
       ModifiedAt = r.ModifiedAt }
 
@@ -26,13 +26,10 @@ module private MedicationMapping =
     { Id = m.Id
       MemberId = m.MemberId
       Name = m.Name
-      FullName = m.FullName |> Option.defaultValue null
-      Comment = m.Comment |> Option.defaultValue null
+      FullName = Option.toObj m.FullName
+      Comment = Option.toObj m.Comment
       StartDate = m.StartDate
-      EndDate =
-        m.EndDate
-        |> Option.map System.Nullable
-        |> Option.defaultValue (System.Nullable())
+      EndDate = Option.toNullable m.EndDate
       CreatedAt = m.CreatedAt
       ModifiedAt = m.ModifiedAt }
 

--- a/code/BpMonitor.Web.Tests/MedicationHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/MedicationHandlerTests.fs
@@ -253,3 +253,35 @@ let ``trends does not render the Medications Timeline panel`` () =
   TestHost.run ReadingHandlers.trends ctx
 
   test <@ (TestHost.readBody ctx).Contains "Medications Timeline" |> not @>
+
+[<Fact>]
+let ``history renders a medication whose entire date span falls after the last reading`` () =
+  // `sample`'s reading is 2026-05-01; a medication starting well after that would be
+  // dropped if the timeline's window were derived from the readings alone.
+  let laterMedication =
+    { sampleMedication with
+        StartDate = DateOnly(2026, 6, 1)
+        EndDate = Some(DateOnly(2026, 7, 1)) }
+
+  let repo = repoWith [ sample ]
+  let ctx = TestHost.contextWithMedications repo [ laterMedication ]
+
+  TestHost.run ReadingHandlers.history ctx
+
+  test <@ (TestHost.readBody ctx).Contains "Medications Timeline" @>
+
+[<Fact>]
+let ``history renders a medication when the member has no readings at all`` () =
+  // With no readings, a window derived solely from them collapses to "now" — a
+  // medication with a fixed past date span would then fall outside it.
+  let pastMedication =
+    { sampleMedication with
+        StartDate = DateOnly(2020, 1, 1)
+        EndDate = Some(DateOnly(2020, 2, 1)) }
+
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMedications repo [ pastMedication ]
+
+  TestHost.run ReadingHandlers.history ctx
+
+  test <@ (TestHost.readBody ctx).Contains "Medications Timeline" @>

--- a/code/BpMonitor.Web/Binding.fs
+++ b/code/BpMonitor.Web/Binding.fs
@@ -41,6 +41,12 @@ module Binding =
     | true, v -> Ok v
     | _ -> Error $"Timestamp: '{s}' is not a valid date/time"
 
+  /// Blank string → None; otherwise `Some` of the trimmed value.
+  let blankToOption (s: string) : string option =
+    match s.Trim() with
+    | "" -> None
+    | s -> Some s
+
   /// Parse-level conversion. Returns the unvalidated reading or the list of
   /// parse errors (range checks happen afterward via BloodPressureReading.parse).
   let toUnvalidated (m: FormModel) : Validation<BloodPressureReadingUnvalidated, string> =
@@ -50,10 +56,7 @@ module Binding =
       and! hr = tryInt "Heart Rate" m.HeartRate |> Validation.ofResult
       and! ts = tryTimestamp m.Timestamp |> Validation.ofResult
 
-      let comments =
-        match m.Comments.Trim() with
-        | "" -> None
-        | s -> Some s
+      let comments = blankToOption m.Comments
 
       return
         { Systolic = sys

--- a/code/BpMonitor.Web/MedicationHandlers.fs
+++ b/code/BpMonitor.Web/MedicationHandlers.fs
@@ -46,11 +46,6 @@ module MedicationHandlers =
     else
       tryDate label s |> Result.map Some
 
-  let private toOption (s: string) =
-    match s.Trim() with
-    | "" -> None
-    | s -> Some s
-
   /// Parse-level conversion (bad dates), mirroring Binding.toUnvalidated. Domain
   /// validation (empty name, end before start) happens afterward via Medication.parse.
   let private toUnvalidated (f: FormValues) : Validation<MedicationUnvalidated, string> =
@@ -60,8 +55,8 @@ module MedicationHandlers =
 
       return
         { Name = f.Name
-          FullName = toOption f.FullName
-          Comment = toOption f.Comment
+          FullName = Binding.blankToOption f.FullName
+          Comment = Binding.blankToOption f.Comment
           StartDate = startDate
           EndDate = endDate }
     }

--- a/code/BpMonitor.Web/ReadingHandlers.fs
+++ b/code/BpMonitor.Web/ReadingHandlers.fs
@@ -82,14 +82,13 @@ module ReadingHandlers =
   /// BpChart.medicationsXAxis). Empty medication list renders nothing (see
   /// MedicationViews.timelinePanel).
   let private medicationsPanel
-    (m: FamilyMember)
-    (ctx: HttpContext)
+    (medications: Medication list)
     (showScrubber: bool)
     (rangeLow: System.DateTimeOffset)
     (rangeHigh: System.DateTimeOffset)
     : Falco.Markup.XmlNode =
     let overlapping =
-      (medicationRepo ctx).GetAll(m.Id)
+      medications
       |> Medication.overlapping (toLocalDateOnly rangeLow) (toLocalDateOnly rangeHigh)
 
     let chartHtml =
@@ -97,20 +96,35 @@ module ReadingHandlers =
 
     MedicationViews.timelinePanel chartHtml
 
+  /// Readings-only would drop medications outside their span (or collapse to a point
+  /// with no readings); union in the medications' own span. Ongoing (EndDate = None)
+  /// counts as running to `today`.
+  let private medicationsSpan
+    (tp: System.TimeProvider)
+    (readings: BloodPressureReading list)
+    (medications: Medication list)
+    : System.DateTimeOffset * System.DateTimeOffset =
+    let today = toLocalDateOnly (tp.GetUtcNow())
+
+    let dates =
+      (readings |> List.map (_.Timestamp >> toLocalDateOnly))
+      @ (medications
+         |> List.collect (fun med -> [ med.StartDate; med.EndDate |> Option.defaultValue today ]))
+
+    let toOffset (d: System.DateOnly) =
+      System.DateTimeOffset(d.ToDateTime(System.TimeOnly.MinValue), tp.GetLocalNow().Offset)
+
+    match dates with
+    | [] -> let now = tp.GetUtcNow() in now, now
+    | ds -> toOffset (List.min ds), toOffset (List.max ds)
+
   let history: HttpContext -> Task =
     withMember (fun m ctx ->
       let readings = sortedReadings m.Id ctx
       let chartHtml = BpChart.toHtml m.Goal readings
-
-      // /history's BP chart autoranges to fit the readings (no explicit window, unlike
-      // /recent), so the timeline's own range is derived from the same readings here —
-      // the closest we can get to alignment without changing BpChart.toHtml's signature.
-      let rangeLow, rangeHigh =
-        match readings |> List.sortBy _.Timestamp with
-        | [] -> let now = (timeProvider ctx).GetUtcNow() in now, now
-        | sorted -> (List.head sorted).Timestamp, (List.last sorted).Timestamp
-
-      let panel = medicationsPanel m ctx false rangeLow rangeHigh
+      let medications = (medicationRepo ctx).GetAll(m.Id)
+      let rangeLow, rangeHigh = medicationsSpan (timeProvider ctx) readings medications
+      let panel = medicationsPanel medications false rangeLow rangeHigh
       htmlResponse (ReadingViews.history m chartHtml readings panel) ctx)
 
   let private recentChartWindowDays = 30
@@ -146,7 +160,9 @@ module ReadingHandlers =
         allReadings |> List.exists (fun r -> r.Timestamp < loadWindowStart)
 
       let windowStart, chartHtml = renderRecentChart m now loadedReadings
-      let panel = medicationsPanel m ctx true windowStart now
+
+      let panel =
+        medicationsPanel ((medicationRepo ctx).GetAll(m.Id)) true windowStart now
 
       htmlResponse
         (ReadingViews.recent m chartHtml loadedReadings windowStart now recentZoomShortcutDays hasOlderHistory panel)
@@ -168,7 +184,9 @@ module ReadingHandlers =
         |> List.sortByDescending _.Timestamp
 
       let windowStart, chartHtml = renderRecentChart m now allReadings
-      let panel = medicationsPanel m ctx true windowStart now
+
+      let panel =
+        medicationsPanel ((medicationRepo ctx).GetAll(m.Id)) true windowStart now
 
       htmlResponse
         (ReadingViews.recentChartContainer m chartHtml allReadings windowStart now recentZoomShortcutDays false panel)

--- a/code/BpMonitor.Web/wwwroot/medications-sync.js
+++ b/code/BpMonitor.Web/wwwroot/medications-sync.js
@@ -56,15 +56,34 @@ function setupMedicationsSync() {
       if (timelinePlot.dataset.medicationsSyncBound) return;
       timelinePlot.dataset.medicationsSyncBound = "1";
 
-      // Charts.fs configures both charts with the same Margin.Left/Right (48/16), but
-      // the BP chart's y-axis title ("blood pressure [mmHg]") makes Plotly auto-expand
-      // its *actual* rendered margin beyond that (measured, not the requested value —
-      // `_fullLayout.margin.l` still reports 48; `_fullLayout._size.l` has the real
-      // number). The timeline has no y-axis title, so it never gets that expansion and
-      // its plot area starts several pixels to the left of the BP chart's — copy the
-      // BP chart's real margin onto the timeline so their x-axes align pixel-for-pixel.
-      const bpSize = bpPlot._fullLayout._size;
-      Plotly.relayout(timelinePlot, { "margin.l": bpSize.l, "margin.r": bpSize.r });
+      // The BP chart's y-axis title makes Plotly auto-expand its margin beyond the
+      // configured value (`_fullLayout._size`, not `_fullLayout.margin`) — copy the
+      // real margin onto the timeline so the x-axes align pixel-for-pixel. Also copies
+      // the BP chart's actual x-axis range, since /history's BP chart autoranges.
+      function syncTimelineToBp() {
+        const bpSize = bpPlot._fullLayout._size;
+
+        Plotly.relayout(timelinePlot, {
+          "margin.l": bpSize.l,
+          "margin.r": bpSize.r,
+          "xaxis.range": bpPlot._fullLayout.xaxis.range,
+        });
+      }
+
+      syncTimelineToBp();
+
+      // /history wraps the BP chart in its own collapsed-by-default <details>; Plotly
+      // renders at zero width while hidden, so re-sync once it's opened.
+      const bpDetails = bpPlot.closest("details");
+
+      if (bpDetails) {
+        bpDetails.addEventListener("toggle", () => {
+          if (bpDetails.open) {
+            Plotly.Plots.resize(bpPlot);
+            syncTimelineToBp();
+          }
+        });
+      }
 
       // BP chart → timeline: mirror the spike position.
       bpPlot.on("plotly_hover", (e) => {
@@ -100,16 +119,22 @@ function setupMedicationsSync() {
         Plotly.relayout(timelinePlot, { "xaxis.range": [lo, hi] });
       });
 
-      // Plotly renders at zero width inside a closed <details>; resize the first time
-      // it's opened so the chart actually appears instead of collapsing to nothing.
+      // Resize on open (Plotly renders at zero width while hidden) and re-sync, in
+      // case the BP chart was still closed when this copy above ran.
       timelineDetails.addEventListener("toggle", () => {
-        if (timelineDetails.open) Plotly.Plots.resize(timelinePlot);
+        if (timelineDetails.open) {
+          Plotly.Plots.resize(timelinePlot);
+          syncTimelineToBp();
+        }
       });
 
       // details-memory.js may have already restored an open state (from localStorage)
       // before this async setup finished — that toggle fired before the listener above
       // existed to catch it, so resize once now to cover that case.
-      if (timelineDetails.open) Plotly.Plots.resize(timelinePlot);
+      if (timelineDetails.open) {
+        Plotly.Plots.resize(timelinePlot);
+        syncTimelineToBp();
+      }
     }, 1);
   }, 0);
 }


### PR DESCRIPTION
## Summary

- The Medications Timeline's date window on `/history` was derived solely from loaded readings, silently dropping medications outside that span (or collapsing to a single instant when there were no readings at all). It now also unions in the medications' own date span.
- The timeline's plot area could stay misaligned with the BP chart's until the user panned/zoomed, since `/history`'s BP chart autoranges rather than using an explicit window. The margin/range sync now also runs on initial setup and whenever either chart's own collapsible panel is opened.
- Cleans up hand-rolled Option/nullable conversions in `EfMedicationRepository` and a duplicated blank-to-None parsing helper in `MedicationHandlers` (now shared via `Binding.blankToOption`).

Found via a code review of #426.