### PR TITLE
🐛 fix(web): move chart-citation note below Medications Timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Reordered sidebar and landing-page navigation: top group is now Add, Recent, Trends, History; Members moved into the bottom group alongside Export JSON, Export CSV, and Settings. The landing page now mirrors the sidebar's order and two-group layout.
+- Recent page: the "Chart layout inspired by Wegier et al. 2021" citation now sits below the Medications Timeline panel instead of above it.
 
 ## [1.10.1] - 2026-08-15
 

--- a/code/BpMonitor.Web/ReadingViews.fs
+++ b/code/BpMonitor.Web/ReadingViews.fs
@@ -177,11 +177,11 @@ module ReadingViews =
        @ loadFullButton
        @ [ valueStrip
            Elem.div [ Attr.class' "chart" ] [ Text.raw chartHtml ]
+           medicationsPanel
            Elem.p
              [ Attr.class' "chart-citation" ]
              [ Text.raw "Chart layout inspired by "
-               Elem.a [ Attr.href "https://doi.org/10.1186/s12911-021-01598-4" ] [ Text.raw "Wegier et al. 2021" ] ]
-           medicationsPanel ])
+               Elem.a [ Attr.href "https://doi.org/10.1186/s12911-021-01598-4" ] [ Text.raw "Wegier et al. 2021" ] ] ])
 
   /// Recent: chart of all readings, focused on the last 30 days, with a sys/dias value strip.
   let recent


### PR DESCRIPTION
## Summary
- Reorder the Recent page's chart panel so the "Chart layout inspired by Wegier et al. 2021" citation renders after the Medications Timeline panel instead of between the chart and the panel.