### PR TITLE
✨ feat(settings): use European day-month-year format for medication dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Medications Timeline: a collapsible panel below the blood pressure chart on Recent and History showing each medication as a bar spanning its start and end dates, in the style of Wegier et al. 2021's Fig. 5. Manage medications from a new section on the Settings page. On Recent, the timeline's scrubber line stays in sync with the blood pressure chart's as you hover or pan.
+- Medications Timeline: a collapsible panel below the blood pressure chart on Recent and History showing each medication as a bar spanning its start and end dates, in the style of Wegier et al. 2021's Fig. 5. Manage medications from a new section on the Settings page, where dates are entered and shown as dd.mm.yyyy. On Recent, the timeline's scrubber line stays in sync with the blood pressure chart's as you hover or pan.
 
 ### Changed
 

--- a/code/BpMonitor.Core.Tests/BloodPressureReadingTests.fs
+++ b/code/BpMonitor.Core.Tests/BloodPressureReadingTests.fs
@@ -88,3 +88,7 @@ let ``parse sets MemberId to 0`` () =
   match BloodPressureReading.parse ranges validUnvalidated with
   | Ok reading -> test <@ reading.MemberId = 0 @>
   | Error _ -> failwith "Expected Ok"
+
+[<Fact>]
+let ``formatDateEuropean renders as dd.MM.yyyy`` () =
+  test <@ Formats.formatDateEuropean (DateOnly(2026, 4, 1)) = "01.04.2026" @>

--- a/code/BpMonitor.Core/BloodPressureReading.fs
+++ b/code/BpMonitor.Core/BloodPressureReading.fs
@@ -50,6 +50,11 @@ module Formats =
 
   let formatDate (d: System.DateOnly) = d.ToString(date)
 
+  let dateEuropean = "dd.MM.yyyy"
+
+  let formatDateEuropean (d: System.DateOnly) =
+    d.ToString(dateEuropean, System.Globalization.CultureInfo.InvariantCulture)
+
 module ReadingRanges =
   let defaults =
     { SystolicMin = 1

--- a/code/BpMonitor.Web.Tests/MedicationHandlerTests.fs
+++ b/code/BpMonitor.Web.Tests/MedicationHandlerTests.fs
@@ -19,6 +19,7 @@ let ``settings renders the medications section with existing medications`` () =
   test <@ body.Contains "HCTZ" @>
   test <@ body.Contains "hydrochlorothiazide" @>
   test <@ body.Contains "Medications" @>
+  test <@ body.Contains "01.04.2026" @>
 
 [<Fact>]
 let ``create persists a valid medication and redirects to settings`` () =
@@ -44,6 +45,69 @@ let ``create persists a valid medication and redirects to settings`` () =
   test <@ saved[0].Name = "HCTZ" @>
   test <@ saved[0].FullName = Some "hydrochlorothiazide" @>
   test <@ saved[0].EndDate = None @>
+
+[<Fact>]
+let ``create parses the start date as dd.mm.yyyy, not mm.dd.yyyy`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMedications repo []
+
+  TestHost.setForm
+    ctx
+    [ FormFields.medicationName, "HCTZ"
+      FormFields.medicationFullName, ""
+      FormFields.medicationComment, ""
+      FormFields.medicationStartDate, "01.02.2026"
+      FormFields.medicationEndDate, "" ]
+
+  TestHost.run MedicationHandlers.create ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+
+  let medicationRepo = ctx.RequestServices.GetRequiredService<IMedicationRepository>()
+  let saved = medicationRepo.GetAll(defaultMemberId)
+  test <@ saved[0].StartDate = DateOnly(2026, 2, 1) @>
+
+[<Fact>]
+let ``create accepts single-digit day and month`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMedications repo []
+
+  TestHost.setForm
+    ctx
+    [ FormFields.medicationName, "HCTZ"
+      FormFields.medicationFullName, ""
+      FormFields.medicationComment, ""
+      FormFields.medicationStartDate, "1.8.2026"
+      FormFields.medicationEndDate, "" ]
+
+  TestHost.run MedicationHandlers.create ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+
+  let medicationRepo = ctx.RequestServices.GetRequiredService<IMedicationRepository>()
+  let saved = medicationRepo.GetAll(defaultMemberId)
+  test <@ saved[0].StartDate = DateOnly(2026, 8, 1) @>
+
+[<Fact>]
+let ``create still accepts an iso-format start date`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMedications repo []
+
+  TestHost.setForm
+    ctx
+    [ FormFields.medicationName, "HCTZ"
+      FormFields.medicationFullName, ""
+      FormFields.medicationComment, ""
+      FormFields.medicationStartDate, "2026-01-01"
+      FormFields.medicationEndDate, "" ]
+
+  TestHost.run MedicationHandlers.create ctx
+
+  test <@ ctx.Response.StatusCode = 302 @>
+
+  let medicationRepo = ctx.RequestServices.GetRequiredService<IMedicationRepository>()
+  let saved = medicationRepo.GetAll(defaultMemberId)
+  test <@ saved[0].StartDate = DateOnly(2026, 1, 1) @>
 
 [<Fact>]
 let ``create rejects an empty name with 422 and does not persist`` () =
@@ -116,7 +180,20 @@ let ``edit prefills the form from the existing medication`` () =
   let body = TestHost.readBody ctx
   test <@ body.Contains "value=\"HCTZ\"" @>
   test <@ body.Contains "value=\"hydrochlorothiazide\"" @>
-  test <@ body.Contains "value=\"2026-04-01\"" @>
+  test <@ body.Contains "value=\"01.04.2026\"" @>
+  test <@ body.Contains "dd.mm.yyyy" @>
+  test <@ not (body.Contains "type=\"date\"") @>
+
+[<Fact>]
+let ``settings renders the add-medication date fields with a dd.mm.yyyy hint`` () =
+  let repo = repoWith []
+  let ctx = TestHost.contextWithMedications repo []
+  TestHost.run ReadingHandlers.settings ctx
+
+  test <@ ctx.Response.StatusCode = 200 @>
+  let body = TestHost.readBody ctx
+  test <@ body.Contains "dd.mm.yyyy" @>
+  test <@ not (body.Contains "type=\"date\"") @>
 
 [<Fact>]
 let ``edit returns 404 for a medication belonging to a different member`` () =

--- a/code/BpMonitor.Web/MedicationHandlers.fs
+++ b/code/BpMonitor.Web/MedicationHandlers.fs
@@ -1,6 +1,7 @@
 namespace BpMonitor.Web
 
 open System
+open System.Globalization
 open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Logging
@@ -35,10 +36,13 @@ module MedicationHandlers =
           EndDate = get FormFields.medicationEndDate }
     }
 
+  /// "d.M.yyyy" accepts 1- or 2-digit day/month; yyyy-MM-dd is accepted too for pasted ISO dates.
+  let private dateFormats = [| "d.M.yyyy"; Formats.date |]
+
   let private tryDate (label: string) (s: string) : Result<DateOnly, string> =
-    match DateOnly.TryParse(s) with
+    match DateOnly.TryParseExact(s.Trim(), dateFormats, CultureInfo.InvariantCulture, DateTimeStyles.None) with
     | true, v -> Ok v
-    | _ -> Error $"{label}: '{s}' is not a valid date"
+    | _ -> Error $"{label}: '{s}' is not a valid date (expected dd.mm.yyyy)"
 
   let private tryOptionalDate (label: string) (s: string) : Result<DateOnly option, string> =
     if String.IsNullOrWhiteSpace s then
@@ -119,8 +123,8 @@ module MedicationHandlers =
             med.Name
             (med.FullName |> Option.defaultValue "")
             (med.Comment |> Option.defaultValue "")
-            (Formats.formatDate med.StartDate)
-            (med.EndDate |> Option.map Formats.formatDate |> Option.defaultValue ""))
+            (Formats.formatDateEuropean med.StartDate)
+            (med.EndDate |> Option.map Formats.formatDateEuropean |> Option.defaultValue ""))
           ctx)
 
   let private renderEditErrors

--- a/code/BpMonitor.Web/MedicationViews.fs
+++ b/code/BpMonitor.Web/MedicationViews.fs
@@ -19,8 +19,8 @@ module MedicationViews =
       []
       [ Elem.td [] [ Text.enc m.Name ]
         Elem.td [] [ Text.enc (m.FullName |> Option.defaultValue "") ]
-        Elem.td [] [ Text.enc (Formats.formatDate m.StartDate) ]
-        Elem.td [] [ Text.enc (m.EndDate |> Option.map Formats.formatDate |> Option.defaultValue "") ]
+        Elem.td [] [ Text.enc (Formats.formatDateEuropean m.StartDate) ]
+        Elem.td [] [ Text.enc (m.EndDate |> Option.map Formats.formatDateEuropean |> Option.defaultValue "") ]
         Elem.td [] [ Text.enc (m.Comment |> Option.defaultValue "") ]
         Elem.td
           [ Attr.class' "member-actions" ]
@@ -56,8 +56,8 @@ module MedicationViews =
             ""
             "text"
           ViewLayout.field "Comment" FormFields.medicationComment "" "text"
-          ViewLayout.field "Start date" FormFields.medicationStartDate "" "date"
-          ViewLayout.field "End date" FormFields.medicationEndDate "" "date"
+          fieldWithHint "Start date" "dd.mm.yyyy" FormFields.medicationStartDate "" "text"
+          fieldWithHint "End date" "dd.mm.yyyy" FormFields.medicationEndDate "" "text"
           Elem.button [ Attr.type' "submit" ] [ Text.raw "Add medication" ] ] ]
 
   /// Shared add/edit form for a single medication. `action` is the POST target;
@@ -91,8 +91,8 @@ module MedicationViews =
               fullName
               "text"
             ViewLayout.field "Comment" FormFields.medicationComment comment "text"
-            ViewLayout.field "Start date" FormFields.medicationStartDate startDate "date"
-            ViewLayout.field "End date" FormFields.medicationEndDate endDate "date"
+            fieldWithHint "Start date" "dd.mm.yyyy" FormFields.medicationStartDate startDate "text"
+            fieldWithHint "End date" "dd.mm.yyyy" FormFields.medicationEndDate endDate "text"
             ViewLayout.formActions Routes.settings ] ]
 
   /// The collapsible Medications Timeline panel embedded below the BP chart on /recent


### PR DESCRIPTION
## Summary

- Medication Start/End date fields on `/settings` were native `<input type="date">` pickers, which render `mm/dd/yyyy` on an English-locale browser. Switched to text inputs with a `dd.mm.yyyy` hint, matching the existing pattern on the reading form's timestamp field.
- Firefox ignores `lang`-based locale hints on native date pickers, so a `lang="de"` fix would only have worked in Chromium/Safari — this approach is deterministic in every browser.
- Parsing accepts single- or double-digit day/month (`1.8.2026` or `01.08.2026`) and falls back to ISO `yyyy-MM-dd` for pasted/seeded dates; output is always zero-padded `dd.mm.yyyy`.
- The medications table and edit-form prefill were switched to the same format for consistency on the page. Every other date surface in the app (readings, charts, exports) is unchanged.