### PR TITLE
💄 style(settings): center date columns and harmonize Edit/Delete buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reordered sidebar and landing-page navigation: top group is now Add, Recent, Trends, History; Members moved into the bottom group alongside Export JSON, Export CSV, and Settings. The landing page now mirrors the sidebar's order and two-group layout.
 - Recent page: the "Chart layout inspired by Wegier et al. 2021" citation now sits below the Medications Timeline panel instead of above it.
 - Medications Timeline: each medication now gets its own color (consistent across visits), and its bar is thicker with rounded ends. Fixed a stray white line that could appear across the top row in dark mode.
+- Settings: the medications table's Start and End columns are now center-aligned, and its Edit action now renders as a button, matching Delete. Family Members table's Edit action likewise now matches Reset password's button style.
 
 ### Fixed
 

--- a/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
+++ b/code/BpMonitor.Web.Tests/BpMonitor.Web.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="LayoutViewTests.fs" />
     <Compile Include="HistoryViewTests.fs" />
     <Compile Include="MemberViewTests.fs" />
+    <Compile Include="MedicationViewTests.fs" />
     <Compile Include="LoginViewTests.fs" />
     <Compile Include="ConfigTests.fs" />
     <Compile Include="HandlerHelpersTests.fs" />

--- a/code/BpMonitor.Web.Tests/MedicationViewTests.fs
+++ b/code/BpMonitor.Web.Tests/MedicationViewTests.fs
@@ -1,0 +1,34 @@
+module MedicationViewTests
+
+open System
+open Xunit
+open Swensen.Unquote
+open Falco.Markup
+open BpMonitor.Core
+open BpMonitor.Web
+open ViewTestHelpers
+
+let private sampleMedication: Medication =
+  { Id = 5
+    MemberId = 1
+    Name = "HCTZ"
+    FullName = Some "Hydrochlorothiazide"
+    Comment = None
+    StartDate = DateOnly(2026, 1, 1)
+    EndDate = None
+    CreatedAt = DateTimeOffset.MinValue
+    ModifiedAt = DateTimeOffset.MinValue }
+
+[<Fact>]
+let ``medicationsSection center-aligns the Start and End columns`` () =
+  let html =
+    renderHtml (Elem.div [] (MedicationViews.medicationsSection [ sampleMedication ] []))
+
+  test <@ html.Contains "class=\"text-center\"" @>
+
+[<Fact>]
+let ``medicationsSection renders Edit as a button, matching Delete's style`` () =
+  let html =
+    renderHtml (Elem.div [] (MedicationViews.medicationsSection [ sampleMedication ] []))
+
+  test <@ html.Contains $"<a href=\"{Routes.medicationEdit 5}\" role=\"button\" class=\"outline secondary\">Edit</a>" @>

--- a/code/BpMonitor.Web.Tests/MemberViewTests.fs
+++ b/code/BpMonitor.Web.Tests/MemberViewTests.fs
@@ -29,6 +29,12 @@ let ``members page renders Admin and Active columns and Edit link`` () =
   test <@ html.Contains $"href=\"{Routes.memberEdit 2}\"" @>
 
 [<Fact>]
+let ``members page renders Edit as a button, matching Reset password's style`` () =
+  let html = renderHtml (MemberViews.members [ defaultMember ] defaultMember [])
+
+  test <@ html.Contains $"<a href=\"{Routes.memberEdit 1}\" role=\"button\" class=\"outline secondary\">Edit</a>" @>
+
+[<Fact>]
 let ``members page shows claimed/unclaimed badge`` () =
   let claimed =
     { defaultMember with

--- a/code/BpMonitor.Web/MedicationViews.fs
+++ b/code/BpMonitor.Web/MedicationViews.fs
@@ -19,12 +19,18 @@ module MedicationViews =
       []
       [ Elem.td [] [ Text.enc m.Name ]
         Elem.td [] [ Text.enc (m.FullName |> Option.defaultValue "") ]
-        Elem.td [] [ Text.enc (Formats.formatDateEuropean m.StartDate) ]
-        Elem.td [] [ Text.enc (m.EndDate |> Option.map Formats.formatDateEuropean |> Option.defaultValue "") ]
+        Elem.td [ Attr.class' "text-center" ] [ Text.enc (Formats.formatDateEuropean m.StartDate) ]
+        Elem.td
+          [ Attr.class' "text-center" ]
+          [ Text.enc (m.EndDate |> Option.map Formats.formatDateEuropean |> Option.defaultValue "") ]
         Elem.td [] [ Text.enc (m.Comment |> Option.defaultValue "") ]
         Elem.td
           [ Attr.class' "member-actions" ]
-          [ Elem.a [ Attr.href (Routes.medicationEdit m.Id); Attr.class' "outline" ] [ Text.raw "Edit" ]
+          [ Elem.a
+              [ Attr.href (Routes.medicationEdit m.Id)
+                Attr.role "button"
+                Attr.class' "outline secondary" ]
+              [ Text.raw "Edit" ]
             ViewLayout.inlinePostButton (Routes.medicationDelete m.Id) "Delete" ] ]
 
   /// The `/settings` Medications section: a table of the member's medications plus an
@@ -40,8 +46,8 @@ module MedicationViews =
                 []
                 [ Elem.th [] [ Text.raw "Name" ]
                   Elem.th [] [ Text.raw "Full name" ]
-                  Elem.th [] [ Text.raw "Start" ]
-                  Elem.th [] [ Text.raw "End" ]
+                  Elem.th [ Attr.class' "text-center" ] [ Text.raw "Start" ]
+                  Elem.th [ Attr.class' "text-center" ] [ Text.raw "End" ]
                   Elem.th [] [ Text.raw "Comment" ]
                   Elem.th [] [ Text.raw "" ] ] ]
           Elem.tbody [] (medications |> List.sortBy _.StartDate |> List.map medicationRow) ]

--- a/code/BpMonitor.Web/MemberViews.fs
+++ b/code/BpMonitor.Web/MemberViews.fs
@@ -27,7 +27,11 @@ module MemberViews =
             [ Attr.class' "member-actions" ]
             [ if isCurrent then
                 Elem.span [ Attr.class' "current-member" ] [ Text.raw "You" ]
-              Elem.a [ Attr.href (Routes.memberEdit m.Id); Attr.class' "outline" ] [ Text.raw "Edit" ]
+              Elem.a
+                [ Attr.href (Routes.memberEdit m.Id)
+                  Attr.role "button"
+                  Attr.class' "outline secondary" ]
+                [ Text.raw "Edit" ]
               ViewLayout.inlinePostButton (Routes.memberResetPassword m.Id) "Reset password" ] ]
 
     [ yield ViewLayout.errorBox errors

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -535,7 +535,8 @@ form.inline {
   display: inline;
 }
 
-form.inline button {
+form.inline button,
+.member-actions a[role="button"] {
   --pico-nav-link-spacing-vertical: 0.25rem;
   --pico-nav-link-spacing-horizontal: 0.75rem;
   --pico-form-element-spacing-vertical: 0.25rem;
@@ -577,6 +578,10 @@ form.inline button {
   gap: 0.5rem;
   align-items: center;
   flex-wrap: wrap;
+}
+
+.text-center {
+  text-align: center;
 }
 
 /* ── Recent page ────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Medications table's Start and End columns are now center-aligned.
- The Edit action on both the medications table and the family members table now renders as a same-sized button, matching Delete / Reset password instead of a plain link.