### PR TITLE
💄 style(settings): fix h2 heading hierarchy under h1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Medications Timeline: hovering anywhere along a medication's bar now shows its tooltip — previously only the two ends (start/end date) were hoverable, so long-running medications showed nothing but the scrubber line across most of the bar.
+- Settings: section headings (Goal Range, Medications, Add medication) now render smaller than page titles instead of larger, and no longer skip a heading level.
 
 ## [1.10.1] - 2026-08-15
 

--- a/code/BpMonitor.Web/MedicationViews.fs
+++ b/code/BpMonitor.Web/MedicationViews.fs
@@ -83,7 +83,7 @@ module MedicationViews =
                       Elem.th [] [ Text.raw "Comment" ]
                       Elem.th [] [ Text.raw "" ] ] ]
               Elem.tbody [] (medications |> List.sortBy _.StartDate |> List.map medicationRow) ]
-          Elem.h3 [] [ Text.raw "Add medication" ]
+          Elem.h2 [] [ Text.raw "Add medication" ]
           Elem.form
             [ Attr.method "post"; Attr.action Routes.medications; Attr.class' "stacked" ]
             [ fieldWithHint

--- a/code/BpMonitor.Web/wwwroot/app.css
+++ b/code/BpMonitor.Web/wwwroot/app.css
@@ -544,6 +544,10 @@ main h1 {
   margin: 1.25rem 0 1rem;
 }
 
+main h2 {
+  font-size: 1.1rem;
+}
+
 footer.container {
   max-width: 700px;
   margin-top: 2rem;


### PR DESCRIPTION
## Summary
- Add a `main h2` font-size rule (1.1rem) so section headings like "Goal Range" and "Medications" render smaller than page `h1`s (1.35rem), instead of inheriting Pico's larger default
- Promote the "Add medication" heading from `h3` to `h2` so the heading hierarchy on the Settings page doesn't skip a level